### PR TITLE
S3C-1850 fixes for CRR on existing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ S3 Connector and Zenko Utilities
 
 Run the docker container as
 ```
-docker run -d -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' zenko/s3utils
+docker run -d -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils
 ```
 
 ## Trigger CRR on objects that were put before replication was enabled on the bucket


### PR DESCRIPTION
* S3C-1850 require SITE_NAME environment variable

When StorageClass is not defined in the replication configuration,
which is the case on S3C, require it to be passed via the SITE_NAME
environment variable, so that it can be set correctly in object
metadata.

* S3C-1850 trigger CRR on nonversioned keys

Add an extra metadata update for keys that were originally put on a
non-versioned bucket (see code comments for technical details on why
this is needed).

Note: in w/8.0 and w/8.1, I updated the merge to remove the update on README.md that shows how to pass the SITE_NAME environment variable: for zenko, it should not be needed because we always should have a storage class.

Tested with:

- objects put originally on nonversioned bucket: script adds an internal version and triggers replication
- objects put originally on versioning-suspended bucket: script triggers replication
- objects put originally on versioned bucket: script triggers replication on all versions
- objects already replicated: script skips those entries