### PR TITLE
ZENKO-1363 fix readme and progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ S3 Connector and Zenko Utilities
 
 Run the docker container as
 ```
-docker run -d -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils
+docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils node scriptName bucket1[,bucket2...]
 ```
 
 ## Trigger CRR on objects that were put before replication was enabled on the bucket


### PR DESCRIPTION
* bf: ZENKO-1363 fix README.md "docker run" command

Replace option -d by --net=host in the example command

* ft: ZENKO-1363 log progress update every 10s

Add a log every 10 seconds to show how many objects have been
processed, and how many errors occurred.
