### PR TITLE
ft: ZENKO-1379 update for disaster recovery use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Run the docker container as
 docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils node scriptName bucket1[,bucket2...]
 ```
 
+Optionally, the environment variable "WORKERS" may be set to specify
+how many parallel workers should run, otherwise a default of 10
+workers will be used.
+
 ## Trigger CRR on objects that were put before replication was enabled on the bucket
 
 1. Enable versioning and setup replication on the bucket
@@ -13,6 +17,20 @@ docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'EN
 ```
 node crrExistingObjects.js testbucket1,testbucket2
 ```
+
+## Trigger CRR on *all* objects of a bucket
+
+This mode includes the objects that have already been replicated or
+that have a replication status attached.
+
+For disaster recovery notably, to re-sync a backup bucket to the
+primary site, it may be useful to reprocess all objects regardless of
+the existence of a current replication status (e.g. "REPLICA").
+
+Follow the above steps for using "crrExistingObjects" script, and
+specify an extra environment variable `-e "PROCESS_ALL=true"` to force
+the script to reset the replication status of all objects in the
+bucket to "pending", which will force a replication for all objects.
 
 # Empty a versioned bucket
 


### PR DESCRIPTION
* allow processing all objects for CRR on the set of provided buckets
  (not just the ones without a replication configuration), by setting
  the PROCESS_ALL environment variable to a truish value

* provide ability to specify the number of workers with the WORKERS
  environment variable (default is 10, may not be enough for very
  large number of objects)

* add "skipped" count to periodic progress log messages

* handle SIGINT/SIGHUP/SIGTERM/SIGQUIT to terminate the script