### PR TITLE
feature: ZENKO-1379 update crrExistingObjects with more use-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # s3utils
 S3 Connector and Zenko Utilities
 
-Run the docker container as
+Run the Docker container as
 ```
 docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretKey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils node scriptName bucket1[,bucket2...]
 ```
 
 ## Trigger CRR on existing objects
 
-1. Enable versioning and setup replication on the bucket
+1. Enable versioning and set up replication on the bucket.
 2. Run script as
 ```
 node crrExistingObjects.js testbucket1,testbucket2
@@ -21,21 +21,21 @@ to the script to modify its behavior:
 
 #### TARGET_REPLICATION_STATUS
 
-Comma-separated list of replication status to target for CRR
+Comma-separated list of replication statuses to target for CRR
 requeueing. The recognized statuses are:
 
-* **NEW**: no replication status is attached to the object, this is
-   the state of objects that have been written without any CRR policy
-   attached to the bucket that would have triggered CRR on them
+* **NEW**: No replication status is attached to the object. This is
+   the state of objects written without any CRR policy attached to
+   the bucket that would have triggered CRR on them.
 
-* **PENDING**: the object replication status is PENDING
+* **PENDING**: The object replication status is PENDING.
 
-* **COMPLETED**: the object replication status is COMPLETED
+* **COMPLETED**: The object replication status is COMPLETED.
 
-* **FAILED**: the object replication status is FAILED
+* **FAILED**: The object replication status is FAILED.
 
-* **REPLICA**: the object replication status is REPLICA (objects that
-   were put to a target site via CRR have this status)
+* **REPLICA**: The object replication status is REPLICA (objects that
+   were put to a target site via CRR have this status).
 
 The default script behavior is to affect objects that have no
 replication status attached (so equivalent to
@@ -46,7 +46,7 @@ Examples:
 `TARGET_REPLICATION_STATUS=PENDING,COMPLETED`
 
 Requeue objects that either have a replication status of PENDING or
-COMPLETED for CRR, do not requeue the others
+COMPLETED for CRR, do not requeue the others.
 
 `TARGET_REPLICATION_STATUS=NEW,PENDING,COMPLETED,FAILED`
 
@@ -54,8 +54,8 @@ Trigger CRR on all original source objects (not replicas) in a bucket.
 
 `TARGET_REPLICATION_STATUS=REPLICA`
 
-For disaster recovery notably, to re-sync a backup bucket to the
-primary site, it may be useful to reprocess REPLICA objects.
+For disaster recovery notably, it may be useful to reprocess REPLICA 
+objects to re-sync a backup bucket to the primary site.
 
 #### WORKERS
 
@@ -71,35 +71,35 @@ Example:
 Specify a maximum number of metadata updates to execute before
 stopping the script.
 
-If the script reaches this limit, it will output a log line containing
-the KeyMarker and VersionIdMarker to pass to the next invocation, as
-environment variables `KEY_MARKER` and `VERSION_ID_MARKER`, and the
+If the script reaches this limit, it outputs a log line containing
+the KeyMarker and VersionIdMarker to pass to the next invocation (as
+environment variables `KEY_MARKER` and `VERSION_ID_MARKER`) and the
 updated bucket list without the already completed buckets. At the next
-invocation of the script, those two environment variables should be
-set and the updated bucket list passed on the command-line to resume
-from where the script stopped.
+invocation of the script, those two environment variables must be
+set and the updated bucket list passed on the command line to resume
+where the script stopped.
 
 The default is unlimited (will process the complete listing of buckets
-passed on the command-line).
+passed on the command line).
 
-**Beware that if too many objects are queued by the script and cannot
- be processed by backbeat quickly enough, it might lead to Kafka
- dropping the oldest entries**, and the associated objects will stay
- in **PENDING** state permanently without being replicated. When the
- number of objects is large, it can be a good idea to limit the batch
- size, and wait for CRR to complete between invocations.
+**If the script queues too many objects and Backbeat cannot
+ process them quickly enough, Kafka may drop the oldest entries**,
+ and the associated objects will stay in the **PENDING** state
+ permanently without being replicated. When the number of objects
+ is large, it is a good idea to limit the batch size and wait 
+ for CRR to complete between invocations.
 
 Example:
 
 `MAX_UPDATES=10000`
 
-Limit the number of updates to 10000 objects, which will requeue a
-maximum of 10000 objects to replicate before the script stops.
+This limits the number of updates to 10,000 objects, which requeues
+a maximum of 10,000 objects to replicate before the script stops.
 
 #### KEY_MARKER
 
 Set to resume from where an earlier invocation stopped (see
-[MAX_UPDATES](#MAX_UPDATES))
+[MAX_UPDATES](#MAX_UPDATES)).
 
 Example:
 
@@ -108,7 +108,7 @@ Example:
 #### VERSION_ID_MARKER
 
 Set to resume from where an earlier invocation stopped (see
-[MAX_UPDATES](#MAX_UPDATES))
+[MAX_UPDATES](#MAX_UPDATES)).
 
 Example:
 
@@ -119,11 +119,11 @@ Example:
 
 #### CRR existing objects after setting a replication policy for the first time
 
-For this use-case, it's not necessary to pass any extra environment
-variable as the default behavior is to process objects without a
+For this use case, it's not necessary to pass any extra environment
+variable, because the default behavior is to process objects without a
 replication status attached.
 
-Though to avoid requeuing too many entries at once you could pass:
+To avoid requeuing too many entries at once, pass this value:
 
 ```
 export MAX_UPDATES=10000
@@ -131,10 +131,9 @@ export MAX_UPDATES=10000
 
 #### Re-queue objects stuck in PENDING state
 
-In case where replication entries would have been dropped by kafka,
-and objects are stuck in PENDING state without being replicated, you
-could pass the following extra environment variables to reprocess
-them:
+If Kafka has dropped replication entries, leaving objects stuck in a
+PENDING state without being replicated, pass the following extra
+environment variables to reprocess them:
 
 ```
 export TARGET_REPLICATION_STATUS=PENDING
@@ -147,11 +146,11 @@ offsets of "backbeat-replication" Kafka topic to the latest topic
 offsets before launching the script, to skip over the existing
 consumer log.
 
-#### Replicate again entries that have failed a previous replication
+#### Replicate entries that failed a previous replication
 
-If entries have failed permanently to replicate and got a FAILED
-replication status, and we lost track of them in the failed CRR API,
-it's still possible to re-attempt replication later with the following
+If entries have permanently failed to replicate with a FAILED
+replication status and were lost in the failed CRR API, it's still 
+possible to re-attempt replication later with the following
 extra environment variables:
 
 ```
@@ -161,11 +160,10 @@ export MAX_UPDATES=10000
 
 #### Re-sync a primary site completely to a new DR site
 
-In order to re-sync the objects again to a new DR site, for example
-when the original DR site was lost, it could be done by forcing a new
-replication of all original objects, with the following environment
-variables, after having set the proper replication configuration to
-the DR site bucket:
+To re-sync objects to a new DR site (for example, when the original
+DR site is lost) force a new replication of all original objects 
+with the following environment variables (after setting the proper
+replication configuration to the DR site bucket):
 
 ```
 export TARGET_REPLICATION_STATUS=NEW,PENDING,COMPLETED,FAILED
@@ -174,11 +172,11 @@ export MAX_UPDATES=10000
 
 #### Re-sync a DR site back to the primary site
 
-In order to re-sync the objects from the DR site back to the primary
-site, when objects have been lost from the primary site, it would be
-possible by re-syncing the objects that have a REPLICA status with the
-following environment variables, after having set the proper
-replication configuration from the DR bucket to the primary bucket:
+When objects have been lost from the primary site you can re-sync
+objects from the DR site to the primary site by re-syncing the
+objects that have a REPLICA status with the following environment
+variables (after setting the proper replication configuration
+from the DR bucket to the primary bucket):
 
 ```
 export TARGET_REPLICATION_STATUS=REPLICA
@@ -187,18 +185,18 @@ export MAX_UPDATES=10000
 
 # Empty a versioned bucket
 
-This script deletes all versions of objects in the bucket including delete markers,
+This script deletes all versions of objects in the bucket, including delete markers,
 and aborts any ongoing multipart uploads to prepare the bucket for deletion.
 
-**Note: This will delete data associated with the objects and it's not recoverable**
+**Note: This deletes the data associated with objects and is not recoverable**
 ```
 node cleanupBuckets.js testbucket1,testbucket2
 ```
 
 # List objects that failed replication
 
-This script can print the list of objects that failed replication to stdout by
-taking a comma-separated list of buckets. Run the command as
+This script prints the list of objects that failed replication to stdout,
+following a comma-separated list of buckets. Run the command as
 
 ````
 node listFailedObjects testbucket1,testbucket2

--- a/README.md
+++ b/README.md
@@ -3,14 +3,10 @@ S3 Connector and Zenko Utilities
 
 Run the docker container as
 ```
-docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretkey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils node scriptName bucket1[,bucket2...]
+docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretKey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'SITE_NAME=crrSiteName' zenko/s3utils node scriptName bucket1[,bucket2...]
 ```
 
-Optionally, the environment variable "WORKERS" may be set to specify
-how many parallel workers should run, otherwise a default of 10
-workers will be used.
-
-## Trigger CRR on objects that were put before replication was enabled on the bucket
+## Trigger CRR on existing objects
 
 1. Enable versioning and setup replication on the bucket
 2. Run script as
@@ -18,19 +14,176 @@ workers will be used.
 node crrExistingObjects.js testbucket1,testbucket2
 ```
 
-## Trigger CRR on *all* objects of a bucket
+### Extra environment variables
 
-This mode includes the objects that have already been replicated or
-that have a replication status attached.
+Additionally, the following extra environment variables can be passed
+to the script to modify its behavior:
+
+#### TARGET_REPLICATION_STATUS
+
+Comma-separated list of replication status to target for CRR
+requeueing. The recognized statuses are:
+
+* **NEW**: no replication status is attached to the object, this is
+   the state of objects that have been written without any CRR policy
+   attached to the bucket that would have triggered CRR on them
+
+* **PENDING**: the object replication status is PENDING
+
+* **COMPLETED**: the object replication status is COMPLETED
+
+* **FAILED**: the object replication status is FAILED
+
+* **REPLICA**: the object replication status is REPLICA (objects that
+   were put to a target site via CRR have this status)
+
+The default script behavior is to affect objects that have no
+replication status attached (so equivalent to
+`TARGET_REPLICATION_STATUS=NEW`).
+
+Examples:
+
+`TARGET_REPLICATION_STATUS=PENDING,COMPLETED`
+
+Requeue objects that either have a replication status of PENDING or
+COMPLETED for CRR, do not requeue the others
+
+`TARGET_REPLICATION_STATUS=NEW,PENDING,COMPLETED,FAILED`
+
+Trigger CRR on all original source objects (not replicas) in a bucket.
+
+`TARGET_REPLICATION_STATUS=REPLICA`
 
 For disaster recovery notably, to re-sync a backup bucket to the
-primary site, it may be useful to reprocess all objects regardless of
-the existence of a current replication status (e.g. "REPLICA").
+primary site, it may be useful to reprocess REPLICA objects.
 
-Follow the above steps for using "crrExistingObjects" script, and
-specify an extra environment variable `-e "PROCESS_ALL=true"` to force
-the script to reset the replication status of all objects in the
-bucket to "pending", which will force a replication for all objects.
+#### WORKERS
+
+Specify how many parallel workers should run to update object
+metadata. The default is 10 parallel workers.
+
+Example:
+
+`WORKERS=50`
+
+#### MAX_UPDATES
+
+Specify a maximum number of metadata updates to execute before
+stopping the script.
+
+If the script reaches this limit, it will output a log line containing
+the KeyMarker and VersionIdMarker to pass to the next invocation, as
+environment variables `KEY_MARKER` and `VERSION_ID_MARKER`, and the
+updated bucket list without the already completed buckets. At the next
+invocation of the script, those two environment variables should be
+set and the updated bucket list passed on the command-line to resume
+from where the script stopped.
+
+The default is unlimited (will process the complete listing of buckets
+passed on the command-line).
+
+**Beware that if too many objects are queued by the script and cannot
+ be processed by backbeat quickly enough, it might lead to Kafka
+ dropping the oldest entries**, and the associated objects will stay
+ in **PENDING** state permanently without being replicated. When the
+ number of objects is large, it can be a good idea to limit the batch
+ size, and wait for CRR to complete between invocations.
+
+Example:
+
+`MAX_UPDATES=10000`
+
+Limit the number of updates to 10000 objects, which will requeue a
+maximum of 10000 objects to replicate before the script stops.
+
+#### KEY_MARKER
+
+Set to resume from where an earlier invocation stopped (see
+[MAX_UPDATES](#MAX_UPDATES))
+
+Example:
+
+`KEY_MARKER="some/key"`
+
+#### VERSION_ID_MARKER
+
+Set to resume from where an earlier invocation stopped (see
+[MAX_UPDATES](#MAX_UPDATES))
+
+Example:
+
+`VERSION_ID_MARKER="123456789"`
+
+
+### Example use cases
+
+#### CRR existing objects after setting a replication policy for the first time
+
+For this use-case, it's not necessary to pass any extra environment
+variable as the default behavior is to process objects without a
+replication status attached.
+
+Though to avoid requeuing too many entries at once you could pass:
+
+```
+export MAX_UPDATES=10000
+```
+
+#### Re-queue objects stuck in PENDING state
+
+In case where replication entries would have been dropped by kafka,
+and objects are stuck in PENDING state without being replicated, you
+could pass the following extra environment variables to reprocess
+them:
+
+```
+export TARGET_REPLICATION_STATUS=PENDING
+export MAX_UPDATES=10000
+```
+
+**Warning**: This may cause replication of objects already in the
+Kafka queue to repeat. To avoid this, set the backbeat consumer
+offsets of "backbeat-replication" Kafka topic to the latest topic
+offsets before launching the script, to skip over the existing
+consumer log.
+
+#### Replicate again entries that have failed a previous replication
+
+If entries have failed permanently to replicate and got a FAILED
+replication status, and we lost track of them in the failed CRR API,
+it's still possible to re-attempt replication later with the following
+extra environment variables:
+
+```
+export TARGET_REPLICATION_STATUS=FAILED
+export MAX_UPDATES=10000
+```
+
+#### Re-sync a primary site completely to a new DR site
+
+In order to re-sync the objects again to a new DR site, for example
+when the original DR site was lost, it could be done by forcing a new
+replication of all original objects, with the following environment
+variables, after having set the proper replication configuration to
+the DR site bucket:
+
+```
+export TARGET_REPLICATION_STATUS=NEW,PENDING,COMPLETED,FAILED
+export MAX_UPDATES=10000
+```
+
+#### Re-sync a DR site back to the primary site
+
+In order to re-sync the objects from the DR site back to the primary
+site, when objects have been lost from the primary site, it would be
+possible by re-syncing the objects that have a REPLICA status with the
+following environment variables, after having set the proper
+replication configuration from the DR bucket to the primary bucket:
+
+```
+export TARGET_REPLICATION_STATUS=REPLICA
+export MAX_UPDATES=10000
+```
 
 # Empty a versioned bucket
 


### PR DESCRIPTION
- support specifying a list of replication statuses to target for
  re-queuing

- support a limit in the number of updates to do, and the ability to
  resume from where it stopped

Linked to the need to requeue PENDING entries for ZENKO-2101.