### PR TITLE
bugfix: ZENKO-2016 trigger CRR on delete markers

### DIFF
--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -259,7 +259,8 @@ function triggerCRROnBucket(bucketName, cb) {
                 }
                 VersionIdMarker = data.NextVersionIdMarker;
                 KeyMarker = data.NextKeyMarker;
-                return _markPending(bucket, data.Versions, done);
+                return _markPending(
+                    bucket, data.Versions.concat(data.DeleteMarkers), done);
             }),
         () => {
             if (nProcessed - nSkipped >= MAX_UPDATES) {


### PR DESCRIPTION
Add delete markers to the list of objects to process for retro-CRR, in
addition to regular object versions.