### PR TITLE
INTEGRATION [PR#78 > development/8.1] bugfix: ZENKO-2016 trigger CRR on delete markers

### DIFF
--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -259,7 +259,8 @@ function triggerCRROnBucket(bucketName, cb) {
                 }
                 VersionIdMarker = data.NextVersionIdMarker;
                 KeyMarker = data.NextKeyMarker;
-                return _markPending(bucket, data.Versions, done);
+                return _markPending(
+                    bucket, data.Versions.concat(data.DeleteMarkers), done);
             }),
         () => {
             if (nProcessed - nSkipped >= MAX_UPDATES) {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #78.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-2016-crrExistingObjectsDeleteMarkers`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-2016-crrExistingObjectsDeleteMarkers
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-2016-crrExistingObjectsDeleteMarkers
```

Please always comment pull request #78 instead of this one.