### PR TITLE
improvement ZENKO-2158 Add storage type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,33 @@ Trigger CRR on all original source objects (not replicas) in a bucket.
 
 `TARGET_REPLICATION_STATUS=REPLICA`
 
-For disaster recovery notably, it may be useful to reprocess REPLICA 
+For disaster recovery notably, it may be useful to reprocess REPLICA
 objects to re-sync a backup bucket to the primary site.
+
+#### STORAGE_TYPE
+
+Comma-separated list of the destination storage location types. This is used
+only if a replication destination is a public cloud.
+
+The recognized statuses are:
+
+* **aws_s3**: The destination storage location type is Amazon S3.
+
+* **azure**: The destination storage location type is Microsoft Azure Blob
+   Storage.
+
+* **gcp**: The destination storage location type is Google Cloud Storage.
+
+Examples:
+
+`STORAGE_TYPE=aws_s3`
+
+The destination storage location type is AWS.
+
+`STORAGE_TYPE=aws_s3,azure,gcp`
+
+The destination storage type is a one-to-many configuration replicating to AWS,
+Azure, and GCP destination storage locations.
 
 #### WORKERS
 
@@ -86,7 +111,7 @@ passed on the command line).
  process them quickly enough, Kafka may drop the oldest entries**,
  and the associated objects will stay in the **PENDING** state
  permanently without being replicated. When the number of objects
- is large, it is a good idea to limit the batch size and wait 
+ is large, it is a good idea to limit the batch size and wait
  for CRR to complete between invocations.
 
 Example:
@@ -149,7 +174,7 @@ consumer log.
 #### Replicate entries that failed a previous replication
 
 If entries have permanently failed to replicate with a FAILED
-replication status and were lost in the failed CRR API, it's still 
+replication status and were lost in the failed CRR API, it's still
 possible to re-attempt replication later with the following
 extra environment variables:
 
@@ -161,7 +186,7 @@ export MAX_UPDATES=10000
 #### Re-sync a primary site completely to a new DR site
 
 To re-sync objects to a new DR site (for example, when the original
-DR site is lost) force a new replication of all original objects 
+DR site is lost) force a new replication of all original objects
 with the following environment variables (after setting the proper
 replication configuration to the DR site bucket):
 

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -13,6 +13,7 @@ const ACCESS_KEY = process.env.ACCESS_KEY;
 const SECRET_KEY = process.env.SECRET_KEY;
 const ENDPOINT = process.env.ENDPOINT;
 const SITE_NAME = process.env.SITE_NAME;
+let STORAGE_TYPE = process.env.STORAGE_TYPE;
 let TARGET_REPLICATION_STATUS = process.env.TARGET_REPLICATION_STATUS;
 const WORKERS = (process.env.WORKERS &&
                  Number.parseInt(process.env.WORKERS, 10)) || 10;
@@ -40,6 +41,9 @@ if (!ACCESS_KEY) {
 if (!SECRET_KEY) {
     log.fatal('SECRET_KEY not defined');
     process.exit(1);
+}
+if (!STORAGE_TYPE) {
+    STORAGE_TYPE = '';
 }
 if (!TARGET_REPLICATION_STATUS) {
     TARGET_REPLICATION_STATUS = 'NEW';
@@ -172,7 +176,7 @@ function _markObjectPending(bucket, key, versionId, storageClass,
                 destination,
                 storageClass,
                 role: Role,
-                storageType: '',
+                storageType: STORAGE_TYPE,
             };
             objMD.replicationInfo = replicationInfo;
             const mdBlob = JSON.stringify(objMD);


### PR DESCRIPTION
Currently the script crrExistingObjects.js does not support replicating to external clouds in a Zenko deployment. This will be needed particularly when a mirror-mode is enabled on a bucket and a replication configuration is set after objects have been ingested.