### PR TITLE
bf: secondary read preference for count items

### DIFF
--- a/countItems.js
+++ b/countItems.js
@@ -9,7 +9,7 @@ const config = {
     replicaSetHosts,
     writeConcern: 'majority',
     replicaSet: 'rs0',
-    readPreference: 'primary',
+    readPreference: 'secondaryPreferred',
     database: 'metadata',
     replicationGroupId: 'RG001',
     logger: log,


### PR DESCRIPTION
This updates the read preference for the count items script to the secondaries. Since the aggregations done in by the script are fairly cost, offloading it to the secondaries would greatly minimize the impact of the script on live workloads.