### PR TITLE
Improvement: ZENKO-2303 crr existing objects robustness and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Example:
 
 `WORKERS=50`
 
-#### MAX_UPDATES
+#### MAX_UPDATES, MAX_SCANNED
 
-Specify a maximum number of metadata updates to execute before
-stopping the script.
+Specify a maximum number of metadata updates (MAX_UPDATES) or scanned
+entries (MAX_SCANNED) to execute before stopping the script.
 
 If the script reaches this limit, it outputs a log line containing
 the KeyMarker and VersionIdMarker to pass to the next invocation (as
@@ -114,17 +114,22 @@ passed on the command line).
  is large, it is a good idea to limit the batch size and wait
  for CRR to complete between invocations.
 
-Example:
+Examples:
 
 `MAX_UPDATES=10000`
 
 This limits the number of updates to 10,000 objects, which requeues
 a maximum of 10,000 objects to replicate before the script stops.
 
+`MAX_SCANNED=10000`
+
+This limits the number of scanned objects to 10,000 objects before
+the script stops.
+
 #### KEY_MARKER
 
 Set to resume from where an earlier invocation stopped (see
-[MAX_UPDATES](#MAX_UPDATES)).
+[MAX_UPDATES, MAX_SCANNED](#MAX_UPDATES)).
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ Trigger CRR on all original source objects (not replicas) in a bucket.
 For disaster recovery notably, it may be useful to reprocess REPLICA
 objects to re-sync a backup bucket to the primary site.
 
+#### TARGET_PREFIX
+
+Optional prefix of keys to scan
+
+Example:
+
+`TARGET_PREFIX=foo/`
+
+Only scan keys beginning with "foo/"
+
+
 #### STORAGE_TYPE
 
 Comma-separated list of the destination storage location types. This is used

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -73,7 +73,6 @@ const options = {
     signatureVersion: 'v4',
     signatureCache: false,
     httpOptions: {
-        maxRetries: 0,
         timeout: 0,
         agent: new http.Agent({ keepAlive: true }),
     },

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -19,6 +19,8 @@ const WORKERS = (process.env.WORKERS &&
                  Number.parseInt(process.env.WORKERS, 10)) || 10;
 const MAX_UPDATES = (process.env.MAX_UPDATES &&
                      Number.parseInt(process.env.MAX_UPDATES, 10));
+const MAX_SCANNED = (process.env.MAX_SCANNED &&
+                     Number.parseInt(process.env.MAX_SCANNED, 10));
 let KEY_MARKER = process.env.KEY_MARKER;
 let VERSION_ID_MARKER = process.env.VERSION_ID_MARKER;
 
@@ -282,7 +284,7 @@ function triggerCRROnBucket(bucketName, cb) {
                     });
             }),
         () => {
-            if (nUpdated >= MAX_UPDATES) {
+            if (nUpdated >= MAX_UPDATES || nProcessed >= MAX_SCANNED) {
                 _logProgress();
                 let remainingBuckets;
                 if (VersionIdMarker || KeyMarker) {
@@ -295,7 +297,9 @@ function triggerCRROnBucket(bucketName, cb) {
                         BUCKETS.findIndex(bucket => bucket === bucketName) + 1);
                 }
                 let message =
-                    'reached update count limit, resuming from this ' +
+                    'reached ' +
+                    `${nUpdated >= MAX_UPDATES ? 'update' : 'scanned'} ` +
+                    'count limit, resuming from this ' +
                     'point can be achieved by re-running the script with ' +
                     `the bucket list "${remainingBuckets.join(',')}"`;
                 if (VersionIdMarker || KeyMarker) {

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -15,6 +15,7 @@ const ENDPOINT = process.env.ENDPOINT;
 const SITE_NAME = process.env.SITE_NAME;
 let STORAGE_TYPE = process.env.STORAGE_TYPE;
 let TARGET_REPLICATION_STATUS = process.env.TARGET_REPLICATION_STATUS;
+const TARGET_PREFIX = process.env.TARGET_PREFIX;
 const WORKERS = (process.env.WORKERS &&
                  Number.parseInt(process.env.WORKERS, 10)) || 10;
 const MAX_UPDATES = (process.env.MAX_UPDATES &&
@@ -219,6 +220,7 @@ function _listObjectVersions(bucket, VersionIdMarker, KeyMarker, cb) {
     return s3.listObjectVersions({
         Bucket: bucket,
         MaxKeys: LISTING_LIMIT,
+        Prefix: TARGET_PREFIX,
         VersionIdMarker,
         KeyMarker,
     }, cb);

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -191,7 +191,7 @@ function _markObjectPending(bucket, key, versionId, storageClass,
         ++nProcessed;
         if (err) {
             ++nErrors;
-            return cb(err);
+            return cb();
         }
         if (skip) {
             ++nSkipped;

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -83,11 +83,12 @@ const bb = new BackbeatClient(options);
 
 let nProcessed = 0;
 let nSkipped = 0;
+let nUpdated = 0;
 let nErrors = 0;
 let bucketInProgress = null;
 
 function _logProgress() {
-    log.info(`progress update: ${nProcessed - nSkipped} updated, ` +
+    log.info(`progress update: ${nUpdated} updated, ` +
              `${nSkipped} skipped, ${nErrors} errors, ` +
              `bucket in progress: ${bucketInProgress || '(none)'}`);
 }
@@ -198,6 +199,8 @@ function _markObjectPending(bucket, key, versionId, storageClass,
         }
         if (skip) {
             ++nSkipped;
+        } else {
+            ++nUpdated;
         }
         return cb();
     });
@@ -270,7 +273,7 @@ function triggerCRROnBucket(bucketName, cb) {
                     bucket, data.Versions.concat(data.DeleteMarkers), done);
             }),
         () => {
-            if (nProcessed - nSkipped >= MAX_UPDATES) {
+            if (nUpdated >= MAX_UPDATES) {
                 _logProgress();
                 let remainingBuckets;
                 if (VersionIdMarker || KeyMarker) {

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -191,6 +191,9 @@ function _markObjectPending(bucket, key, versionId, storageClass,
         ++nProcessed;
         if (err) {
             ++nErrors;
+            log.error('error updating object', {
+                bucket, key, versionId, error: err.message,
+            });
             return cb();
         }
         if (skip) {


### PR DESCRIPTION
Improvements and fixes:

- keep processing objects after errors
- log on error to update object
- do not count errors in 'updated' counter
- use default maxRetries of the AWS SDK
- log last processed KeyMarker/VersionIdMarker
- add MAX_SCANNED env var support
- add TARGET_PREFIX support

With lack of automation support for s3utils, I tested manually with a few scenarios:
- with MAX_UPDATES and MAX_SCANNED env vars
- with KEY_MARKER and VERSION_ID_MARKER env vars
- with TARGET_REPLICATION_STATUS=NEW,FAILED
- with TARGET_PREFIX
- error ingestion on some objects during script execution (killed cloudserver pod)