### PR TITLE
improvement: ZENKO-2412 use mongodb directly

### DIFF
--- a/CrrExistingObjects/listingParser.js
+++ b/CrrExistingObjects/listingParser.js
@@ -1,0 +1,24 @@
+function listingParser(entries) {
+    if (!entries) {
+        return entries;
+    }
+    return entries.map(entry => {
+        const tmp = JSON.parse(entry.value);
+        return {
+            Key: entry.key,
+            Size: tmp['content-length'],
+            ETag: tmp['content-md5'],
+            VersionId: tmp.versionId,
+            IsNull: tmp.isNull,
+            IsDeleteMarker: tmp.isDeleteMarker,
+            LastModified: tmp['last-modified'],
+            Owner: {
+                DisplayName: tmp['owner-display-name'],
+                ID: tmp['owner-id'],
+            },
+            StorageClass: tmp['x-amz-storage-class'],
+        };
+    });
+}
+
+module.exports = listingParser;

--- a/CrrExistingObjects/metadataClient.js
+++ b/CrrExistingObjects/metadataClient.js
@@ -1,0 +1,39 @@
+const { MetadataWrapper } = require('arsenal').storage.metadata;
+const werelogs = require('werelogs');
+const listingParser = require('./listingParser');
+
+const loggerConfig = {
+    level: 'info',
+    dump: 'error',
+};
+werelogs.configure(loggerConfig);
+
+const log = new werelogs.Logger('s3utils::crrExistingObjects');
+const replicaSetHosts = process.env.MONGODB_REPLICASET;
+const replicaSet = 'rs0';
+const writeConcern = 'majority';
+const readPreference = 'primary';
+const database = process.env.MONGODB_DATABASE || 'metadata';
+const implName = 'mongodb';
+const replicationGroupId = process.env.REPLICATION_GROUP_ID;
+const params = {
+    customListingParser: listingParser,
+    mongodb: {
+        replicaSetHosts,
+        writeConcern,
+        replicaSet,
+        readPreference,
+        database,
+    },
+    replicationGroupId,
+};
+if (process.env.MONGODB_AUTH_USERNAME &&
+    process.env.MONGODB_AUTH_PASSWORD) {
+    params.authCredentials = {
+        username: process.env.MONGODB_AUTH_USERNAME,
+        password: process.env.MONGODB_AUTH_PASSWORD,
+    };
+}
+const metadata = new MetadataWrapper(implName, params, null, log);
+
+module.exports = metadata;

--- a/CrrExistingObjects/metadataUtils.js
+++ b/CrrExistingObjects/metadataUtils.js
@@ -1,0 +1,149 @@
+const metadataClient = require('./metadataClient');
+const { errors, versioning } = require('arsenal');
+const versionIdUtils = versioning.VersionID;
+
+function _processVersions(list) {
+    /* eslint-disable no-param-reassign */
+    list.NextVersionIdMarker = list.NextVersionIdMarker ?
+        versionIdUtils.encode(list.NextVersionIdMarker)
+        : list.NextVersionIdMarker;
+
+    list.Versions.forEach(v => {
+        v.VersionId = v.VersionId ?
+            versionIdUtils.encode(v.VersionId) : v.VersionId;
+    });
+    /* eslint-enable no-param-reassign */
+    return list;
+}
+
+function listObjectVersions(params, log, cb) {
+    const bucketName = params.Bucket;
+    const listingParams = {
+        listingType: 'DelimiterVersions',
+        maxKeys: params.MaxKeys,
+        prefix: params.Prefix,
+        keyMarker: params.KeyMarker,
+        versionIdMarker: params.VersionIdMarker,
+    };
+
+    return metadataClient.listObject(bucketName, listingParams, log,
+        (err, list) => {
+            if (err) {
+                return cb(err);
+            }
+            return cb(null, _processVersions(list));
+        });
+}
+
+function _formatConfig(config) {
+    const { role, destination, rules } = config;
+    const Rules = rules.map(rule => {
+        const { prefix, enabled, storageClass, id } = rule;
+        return {
+            ID: id,
+            Prefix: prefix,
+            Status: enabled ? 'Enabled' : 'Disabled',
+            Destination: {
+                Bucket: destination,
+                StorageClass: (storageClass || ''),
+            },
+        };
+    });
+
+    return {
+        ReplicationConfiguration: {
+            Role: role,
+            Rules,
+        },
+    };
+}
+
+function getBucketReplication(options, log, cb) {
+    const bucketName = options.Bucket;
+    return metadataClient.getBucket(bucketName, log, (err, data) => {
+        if (err) {
+            return cb(err);
+        }
+        const replConf = _formatConfig(data._replicationConfiguration);
+        return cb(null, replConf);
+    });
+}
+
+function _getNullVersion(objMD, bucketName, objectKey, log, cb) {
+    const options = {};
+    if (objMD.isNull || !objMD.versionId) {
+        log.debug('found null version');
+        return process.nextTick(() => cb(null, objMD));
+    }
+    if (objMD.nullVersionId) {
+        log.debug('null version exists, get the null version');
+        options.versionId = objMD.nullVersionId;
+        return metadataClient.getObjectMD(bucketName, objectKey,
+            options, log, cb);
+    }
+    return process.nextTick(() => cb());
+}
+
+function getMetadata(params, log, cb) {
+    let versionId = params.VersionId;
+    if (versionId && versionId !== 'null') {
+        versionId = versionIdUtils.decode(versionId);
+    }
+
+    if (versionId instanceof Error) {
+        const errMsg = 'Invalid version id specified';
+        return cb(errors.InvalidArgument.customizeDescription(errMsg));
+    }
+
+    const mdParams = {
+        versionId,
+    };
+    const { Bucket, Key } = params;
+    return metadataClient.getBucketAndObjectMD(Bucket, Key, mdParams, log,
+        (err, data) => {
+            if (err) {
+                return cb(err);
+            }
+            const objMD = data.obj ? JSON.parse(data.obj) : undefined;
+            if (objMD && versionId === 'null') {
+                return _getNullVersion(objMD, Bucket, Key, log,
+                    (err, nullVer) => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        return cb(null, nullVer);
+                    });
+            }
+            return cb(null, objMD);
+        });
+}
+
+function putMetadata(params, log, cb) {
+    const { Bucket, Key, Body } = params;
+    const objMD = JSON.parse(Body);
+
+    // specify both 'versioning' and 'versionId' to create a "new"
+    // version (updating master as well) but with specified versionId
+    const options = {
+        versioning: true,
+        versionId: objMD.versionId,
+    };
+
+    // If the object is from a source bucket without versioning (i.e. NFS),
+    // then we want to create a version for the replica object even though
+    // none was provided in the object metadata value.
+    if (objMD.replicationInfo.isNFS) {
+        const isReplica = objMD.replicationInfo.status === 'REPLICA';
+        options.versioning = isReplica;
+        objMD.replicationInfo.isNFS = !isReplica;
+    }
+    return metadataClient.putObjectMD(Bucket, Key, objMD, options, log, cb);
+}
+
+module.exports = {
+    metadataClient,
+    listObjectVersions,
+    getBucketReplication,
+    getMetadata,
+    putMetadata,
+};

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ S3 Connector and Zenko Utilities
 
 Run the Docker container as
 ```
-docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretKey' -e 'ENDPOINT=http://127.0.0.1:8000' zenko/s3utils node scriptName bucket1[,bucket2...]
+docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretKey' -e 'ENDPOINT=http://127.0.0.1:8000' -e 'REPLICATION_GROUP_ID=RG001'
+zenko/s3utils node scriptName bucket1[,bucket2...]
 ```
 
 ## Trigger CRR on existing objects
@@ -13,6 +14,10 @@ docker run --net=host -e 'ACCESS_KEY=accessKey' -e 'SECRET_KEY=secretKey' -e 'EN
 ```
 node crrExistingObjects.js testbucket1,testbucket2
 ```
+
+### Mandatory environment variables,
+
+1. **REPLICATION_GROUP_ID**
 
 ### Extra environment variables
 


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
Replication script adds more load to cloudserver/backbeat, to reduce this calls are made to mongodb directly. 