### PR TITLE
ZENKO-2263 updating package.json versionning according to GitWaterflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.0.0",
+  "version": "7.4.0",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
# Problem
Currently there's multiple development branches for the GitWaterflow,
but the repository tags and the package.json file do not seem to be
respecting it. Therefore making the update on the package.json file.

## Why?
I need a place where the version of the repository is set so that I can use this version number as a tag for the docker image that will be hosted on registry.scality.com (done by #100)

## Suggestions
For me there's two options here, we either:
* create a development/1.x branch so that the tags fits and remove all development/7.* and development/8.* branches. (In that case we close this PR)
* Update the package.json file and start tagging this repo accordingly the existing development/7.x or development/8.x branches. (Accept the suggested changes on PR)

PS: I'm fine with both.