### PR TITLE
ZENKO-2263 upload docker image to registry

### DIFF
--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+script_full_path=$(readlink -f "$0")
+file_dir=$(dirname "$script_full_path")/..
+
+PACKAGE_VERSION=$(cat $file_dir/package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
+
+echo $PACKAGE_VERSION

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,18 +2,28 @@
 version: 0.2
 
 branches:
+  development/*:
+    stage: release
   default:
     stage: pre-merge
 
 stages:
   pre-merge:
+    worker:
+      type: local
+    steps:
+    - TriggerStages:
+        stage_names:
+        - tests
+        - build
+  tests:
     worker: &master-worker
       type: docker
       path: eve/workers/master
       volumes:
         - '/home/eve/workspace'
     steps:
-      - Git:
+      - Git: &git_clone
           name: fetch source
           repourl: '%(prop:git_reference)s'
           shallow: True
@@ -29,3 +39,48 @@ stages:
           name: run test
           command: yarn --silent test
 
+  build:
+    worker: &builder_worker
+      type: kube_pod
+      path: eve/workers/builder/pod.yaml
+      images:
+        builder: eve/workers/builder
+    steps:
+      - Git: *git_clone
+      - ShellCommand: &wait_docker_daemon
+          name: Wait for Docker daemon to be ready
+          command: |
+            bash -c '
+            for i in {1..150}
+            do
+              docker info &> /dev/null && exit
+              sleep 2
+            done
+            echo "Could not reach Docker daemon from buildbot worker" >&2
+            exit 1'
+          haltOnFailure: true
+      - ShellCommand: &docker_login
+          name: Login to docker registry
+          command: docker login -u "${HARBOR_LOGIN}" -p "${HARBOR_PASSWORD}" registry.scality.com
+          usePTY: true
+          env:
+            HARBOR_LOGIN: '%(secret:harbor_login)s'
+            HARBOR_PASSWORD: '%(secret:harbor_password)s'
+      - ShellCommand: &build_s3utils
+          name: Build s3utils image
+          command: sh eve/scripts/pull-or-build.sh .
+          env: &build_s3utils_env
+            DOCKER_IMAGE: s3utils
+            DOCKER_TAG: '%(prop:commit_short_revision)s'
+          haltOnFailure: true
+  release:
+    worker: *builder_worker
+    steps:
+      - Git: *git_clone
+      - ShellCommand: *wait_docker_daemon
+      - ShellCommand: *docker_login
+      - ShellCommand:
+          <<: *build_s3utils
+          env:
+            <<: *build_s3utils_env
+            DOCKER_TAG: "%(prop:product_version)s"

--- a/eve/scripts/pull-or-build.sh
+++ b/eve/scripts/pull-or-build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Tries to pull the specified tag of a specified image
+# If it can not it builds, tags, and pushes one.
+
+DOCKER_REPO='registry.scality.com/zenko'
+CONTEXT="$1"
+
+if [ -z "$DOCKER_IMAGE" ]; then
+    echo 'DOCKER_IMAGE environment variable has not been set. quitting'
+    exit 1
+fi
+
+if [ -z "$DOCKER_TAG" ]; then
+    echo "DOCKER_TAG not found, defaulting to 'latest'"
+    DOCKER_TAG='latest'
+fi
+
+echo "Trying to pull $DOCKER_REPO/$DOCKER_IMAGE:$DOCKER_TAG"
+
+docker pull $DOCKER_REPO/$DOCKER_IMAGE:$DOCKER_TAG
+
+if [ "$?" -ne 0 ]; then
+    echo "Image not found, building..."
+    set -e
+    docker build -t $DOCKER_REPO/$DOCKER_IMAGE:$DOCKER_TAG $CONTEXT
+    docker push $DOCKER_REPO/$DOCKER_IMAGE:$DOCKER_TAG
+else
+    echo "Pulled image."
+fi

--- a/eve/workers/builder/Dockerfile
+++ b/eve/workers/builder/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+# Install package needed for bootstraping the image as well as runtime
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    git \
+    gnupg2 \
+    locales \
+    lsb-release \
+    python3-buildbot-worker \
+ && rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_GB.UTF-8
+
+ENV LANG en_GB.UTF-8
+ENV LC_ALL en_GB.UTF-8
+
+# Install docker
+ARG DOCKER_VERSION=18.06.1~ce~3-0~ubuntu
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+ && echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    | tee -a /etc/apt/sources.list.d/docker-ce.list \
+ && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    docker-ce=${DOCKER_VERSION} \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workdir
+
+CMD buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} \
+      && buildbot-worker start --nodaemon

--- a/eve/workers/builder/pod.yaml
+++ b/eve/workers/builder/pod.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: worker
+spec:
+  containers:
+    - name: build-worker
+      image: "{{ images.builder }}"
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      env:
+        - name: DOCKER_HOST
+          value: localhost:2375
+      volumeMounts:
+        - name: worker-workspace
+          mountPath: /workdir
+    - name: dind-daemon
+      image: docker:18.09.6-dind
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: docker-storage
+          mountPath: /var/lib/docker
+        - name: worker-workspace
+          mountPath: /workdir
+  volumes:
+    - name: docker-storage
+      emptyDir: {}
+    - name: worker-workspace
+      emptyDir: {}


### PR DESCRIPTION
# Description

This PR will give us a little pipeline to help us host s3utils image in our docker registry.

## Pipeline

The way it works today is, the following. We have two stage `pre-merge` and `release`.

`pre-merge` will be triggered by default on every push to the repository, we will then execute the `yarn test` commands, and build s3utils image and host it with the following tag `registry.scality.com/zenko/s3utils:$commit_revision` 

And after every merge the stage `release` will be called. we will retrieve the version defined in the `package.json` build s3utils image and push it with the following tag `registry.scality.com/zenko/s3utils:$package_version`. Ideally I would like this stage to be triggered with a tag event, but today Eve is unable to trigger an event on tag (but this could be added in a future release ;) )
