### PR TITLE
improvement: ZENKO-2576 optimize crrExistingObject

### DIFF
--- a/CrrExistingObjects/metadataUtils.js
+++ b/CrrExistingObjects/metadataUtils.js
@@ -109,17 +109,13 @@ function getMetadata(params, log, cb) {
     const mdParams = {
         versionId,
     };
-    return metadataClient.getBucketAndObjectMD(Bucket, Key, mdParams, log,
+    return metadataClient.getObjectMD(Bucket, Key, mdParams, log,
         (err, data) => {
             if (err) {
                 return cb(err);
             }
-            const objMD = data.obj ? JSON.parse(data.obj) : undefined;
-            if (objMD === undefined) {
-                return cb(new Error('could not get metadata'));
-            }
-            if (objMD && versionId === 'null') {
-                return _getNullVersion(objMD, Bucket, Key, log,
+            if (data && versionId === 'null') {
+                return _getNullVersion(data, Bucket, Key, log,
                     (err, nullVer) => {
                         if (err) {
                             return cb(err);
@@ -127,13 +123,12 @@ function getMetadata(params, log, cb) {
                         return cb(null, nullVer);
                     });
             }
-            return cb(null, objMD);
+            return cb(null, data);
         });
 }
 
 function putMetadata(params, log, cb) {
-    const { Bucket, Key, Body } = params;
-    const objMD = JSON.parse(Body);
+    const { Bucket, Key, Body: objMD } = params;
     // specify both 'versioning' and 'versionId' to create a "new"
     // version (updating master as well) but with specified versionId
     const options = {

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -104,7 +104,7 @@ function _markObjectPending(bucket, key, versionId, storageClass,
         }, log, next),
         (mdRes, next) => {
             objMD = new ObjectMD(mdRes);
-            const mdBlob = objMD.getSerialized();
+            const md = objMD.getValue();
             if (!_objectShouldBeUpdated(objMD)) {
                 skip = true;
                 return next();
@@ -128,8 +128,7 @@ function _markObjectPending(bucket, key, versionId, storageClass,
             return metadataUtil.putMetadata({
                 Bucket: bucket,
                 Key: key,
-                ContentLength: Buffer.byteLength(mdBlob),
-                Body: mdBlob,
+                Body: md,
             }, log, (err, putRes) => {
                 if (err) {
                     return next(err);
@@ -166,12 +165,11 @@ function _markObjectPending(bucket, key, versionId, storageClass,
             };
             objMD.setReplicationInfo(replicationInfo);
             objMD.updateMicroVersionId();
-            const mdBlob = objMD.getSerialized();
+            const md = objMD.getValue();
             return metadataUtil.putMetadata({
                 Bucket: bucket,
                 Key: key,
-                ContentLength: Buffer.byteLength(mdBlob),
-                Body: mdBlob,
+                Body: md,
             }, log, next);
         },
     ], err => {


### PR DESCRIPTION
Improvements to `crrExistingObjects` script.

- Removed unnecessary serialization and deserialization.
- Removed extra mongo query in `metadaUtil.getMetadata`