### PR TITLE
improvement: ZENKO-2661 option to pass keys to check in stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,21 @@ node verifyBucketSproxydKeys.js
 
 * **SPROXYD_HOSTPORT**: ip:port of sproxyd endpoint
 
-* Either:
+* One of:
 
-** **BUCKETS**: comma-separated list of buckets to scan
+  * **BUCKETS**: comma-separated list of buckets to scan
 
 * or:
 
-** **RAFT_SESSIONS**: comma-separated list of raft sessions to scan
+  * **RAFT_SESSIONS**: comma-separated list of raft sessions to scan
+
+* or:
+
+  * **KEYS_FROM_STDIN**: reads objects to scan from stdin if this
+    environment variable is set, where the input is a stream of JSON
+    objects, each of the form:
+    `{"bucket":"bucketname","key":"objectkey\u0000objectversion"}` -
+    **note**: if `\u0000objectversion` is not present, it checks the master key
 
 ## Optional environment variables:
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "arsenal": "github:scality/arsenal#81d05b6",
     "async": "^2.6.1",
     "aws-sdk": "^2.333.0",
+    "JSONStream": "^1.3.5",
     "node-uuid": "^1.4.8",
     "werelogs": "scality/werelogs",
     "zenkoclient": "scality/zenkoclient#5c7f655"


### PR DESCRIPTION
Add the KEYS_FROM_STDIN environment variable to allow to check only the specified list of keys read from stdin

The input is then a stream of JSON objects, each containing a "bucket"
and "key" attribute (key can optionally have a versionId appended to
it, separated from the key by a null character).