### PR TITLE
bf: S3C-3019 s3utils fails to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:10
 
 WORKDIR /usr/src/app
 ENV MONGO_VER 3.6.8


### PR DESCRIPTION
Node v8 is not sufficient to build the package mongodb-memory-server, bumping it to v10.