### PR TITLE
bugfix: ZENKO-2909 stalled retry

### DIFF
--- a/CountItems/utils/createWorkers.js
+++ b/CountItems/utils/createWorkers.js
@@ -5,7 +5,7 @@ function createWorkers(numWorkers) {
     if (!cluster.isMaster) return {};
     const workers = {};
     for (let i = 0; i < numWorkers; ++i) {
-        const worker = cluster.fork();
+        const worker = cluster.fork(process.env);
         workers[worker.process.pid] =
             new CountWorkerObj(worker.process.pid, worker);
     }

--- a/StalledRetry/CursorWrapper.js
+++ b/StalledRetry/CursorWrapper.js
@@ -1,0 +1,231 @@
+const MongoError = require('mongodb').MongoError;
+const { encode } = require('arsenal').versioning.VersionID;
+const { once } = require('arsenal').jsutil;
+
+class StalledEntry {
+    constructor(bucketName, key, versionId, storageClass, forceRetry) {
+        this.bucketName = bucketName;
+        this.key = key;
+        this.versionId = versionId;
+        this.storageClass = storageClass;
+        this.forceRetry = forceRetry;
+    }
+
+    toObject() {
+        return {
+            Bucket: this.bucketName,
+            Key: this.key,
+            VersionId: this.versionId,
+            StorageClass: this.storageClass,
+            ForceRetry: this.forceRetry,
+        };
+    }
+}
+
+function objectToEntries(bucketName, cmpDate, data) {
+    if (!data || typeof data !== 'object' ||
+        !data.value || typeof data.value !== 'object') {
+        return [];
+    }
+
+    const time = data.value['last-modified'] || null;
+    if (isNaN(Date.parse(time))) {
+        return [];
+    }
+
+    const testDate = new Date(time);
+    const withinRange = testDate <= cmpDate;
+    if (!withinRange) {
+        return [];
+    }
+
+    const storageClasses = data._id.storageClasses.split(',');
+    return storageClasses.map(i => {
+        const storageClass = i.split(':')[0];
+        return new StalledEntry(
+            bucketName,
+            data._id.key,
+            encode(data._id.versionId),
+            storageClass,
+            true
+        );
+    });
+}
+
+class RateLimitingCursor {
+    constructor(cursor, params) {
+        this.info = {
+            stalled: 0,
+        };
+
+        this.bucketName = params.bucketName;
+        this.cmpDate = params.cmpDate;
+        this.log = params.log;
+
+        this.queueLimit = params.queueLimit || 1000;
+
+        this.buffer = [];
+        this.getBatchCallbacks = [];
+        this.cursor = cursor;
+        this.cursorErr = null;
+        this.cursorEnd = false;
+
+        this.completed = false;
+
+        this._init();
+    }
+
+    _init() {
+        this.cursor.on('data', data => {
+            const entries = objectToEntries(
+                this.bucketName,
+                this.cmpDate,
+                data) || [];
+
+            if (entries.length === 0) {
+                return;
+            }
+
+            this.info.stalled += entries.length;
+            this.buffer.push(...entries);
+
+            this._fulfillGetBatch();
+
+            if (this.buffer.length >= this.queueLimit) {
+                this.cursor.pause();
+            }
+        });
+
+        this.cursor.on('end', () => {
+            this.log.debug('reached end of cursor', {
+                inQueue: this.buffer.length,
+            });
+            this.cursorEnd = true;
+            this._cleanUp();
+        });
+
+        this.cursor.on('error', err => {
+            this.log.error('encountered error while reading cursor', {
+                error: err,
+            });
+
+            if (
+                err instanceof MongoError &&
+                err.errorLabels.includes('TransientTransactionError')
+            ) {
+                this.log.info('transient error, continue reading from cursor');
+                return;
+            }
+
+            this.cursorEnd = true;
+            this.cursorErr = err;
+
+            this.buffer = [];
+            this._cleanUp();
+        });
+    }
+
+    _fulfillGetBatch() {
+        if (this.getBatchCallbacks.length === 0) {
+            return;
+        }
+
+        while (this.buffer.length > 0 && this.getBatchCallbacks.length > 0) {
+            const i = this.getBatchCallbacks.length - 1;
+            // TODO: implement a min-heap for callback on size
+            // atm, size is the same for all getBatch requests, so only the
+            // last items is checked
+            if (this.getBatchCallbacks[i].size <= this.buffer.length) {
+                const { size, cb } = this.getBatchCallbacks.pop();
+                const batch = this.buffer.splice(0, size);
+                if (batch.length === 0) {
+                    cb(null, null);
+                } else {
+                    cb(null, batch);
+                }
+            } else {
+                break;
+            }
+        }
+
+        if (this.cursor.isPaused() && this.buffer.length < this.queueLimit) {
+            this.cursor.resume();
+        }
+
+        if (this.cursorEnd && this.buffer.length === 0) {
+            this._cleanUp();
+        }
+    }
+
+    getInfo() {
+        return this.info;
+    }
+
+    _cleanUp() {
+        if (this.cursor && typeof this.cursor.destroy === 'function') {
+            this.cursor.destroy();
+            this.cursor = null;
+        }
+
+        this.getBatchCallbacks.forEach(({ size, cb }) => {
+            if (this.cursorErr !== null) {
+                return cb(this.cursorErr, null);
+            }
+
+            if (this.completed) {
+                return cb(null, null);
+            }
+
+            const batch = this.buffer.splice(0, size);
+            if (this.buffer.length === 0) {
+                this.completed = true;
+            }
+
+            if (batch.length === 0) {
+                return cb(null, null);
+            }
+
+            return cb(null, batch);
+        });
+
+        this.getBatchCallbacks = [];
+        if (this.buffer.length === 0) {
+            this.completed = true;
+        }
+    }
+
+    getBatch(size, cb) {
+        if (this.cursorErr !== null) {
+            cb(this.cursorErr, null);
+            return;
+        }
+
+        if (this.completed) {
+            cb(null, null);
+            return;
+        }
+
+        if (size === 0) {
+            cb(null, []);
+            return;
+        }
+
+        this.getBatchCallbacks.push({ size, cb: once(cb) });
+
+        if (this.cursor && this.cursor.isPaused()) {
+            this._fulfillGetBatch();
+        }
+
+        if (this.cursorEnd) {
+            this._cleanUp();
+        }
+
+        return;
+    }
+}
+
+module.exports = {
+    objectToEntries,
+    RateLimitingCursor,
+    StalledEntry,
+};

--- a/StalledRetry/MongoClientInterfaceStalled.js
+++ b/StalledRetry/MongoClientInterfaceStalled.js
@@ -1,0 +1,84 @@
+const async = require('async');
+
+const {
+    MongoClientInterface,
+} = require('arsenal').storage.metadata.mongoclient;
+
+class MongoClientInterfaceStalled extends MongoClientInterface {
+    constructor(params) {
+        super(params);
+        this.cursorWrapperFactory = params.cursorWrapperFactory;
+        this.requestHandlerFactory = params.requestHandlerFactory;
+    }
+
+    _getStalledObjectsByBucket(bucketName) {
+        const c = this.getCollection(bucketName);
+        const reducedFields = {
+            '_id': {
+                id: '$_id',
+                storageClasses: '$value.replicationInfo.storageClass',
+                status: '$value.replicationInfo.status',
+                key: '$value.key',
+                versionId: '$value.versionId',
+            },
+            'value.last-modified': 1,
+        };
+        return c.aggregate([
+            { $project: reducedFields },
+            { $match: {
+                '_id.id': { $regex: /\0/ },
+                '_id.status': { $eq: 'PENDING' },
+            } },
+        ]);
+    }
+
+    queueStalledObjects(expiredBy, cb) {
+        const cmpDate = new Date();
+        cmpDate.setHours(cmpDate.getHours() - expiredBy);
+        const reqHandler = this.requestHandlerFactory(this.logger);
+
+        let stalledCount = 0;
+        this.db.listCollections().toArray((err, collections) => {
+            if (err) {
+                return cb(err);
+            }
+            return async.eachSeries(collections, (value, next) => {
+                if (this._isSpecialCollection(value.name)) {
+                    // skip
+                    return next();
+                }
+                const bucketName = value.name;
+                const wrapper = this.cursorWrapperFactory(
+                    bucketName,
+                    cmpDate,
+                    this._getStalledObjectsByBucket(bucketName),
+                    this.logger
+                );
+
+                return reqHandler.handleRequests(wrapper, (err, results) => {
+                    if (err) {
+                        this.logger.error(
+                            'encountered error while processing requests',
+                            { method: 'queueStalledObjects', error: err }
+                        );
+                        return next(err);
+                    }
+
+                    this.logger.debug('completed handling requests', {
+                        method: 'queueStalledObjects',
+                        bucket: value.name,
+                        info: results,
+                    });
+
+                    stalledCount += results.stalled;
+                    return next();
+                });
+            }, err => cb(err, stalledCount));
+        });
+    }
+}
+
+module.exports = {
+    MongoClientInterfaceStalled,
+};
+

--- a/StalledRetry/StalledRequestHandler.js
+++ b/StalledRetry/StalledRequestHandler.js
@@ -1,0 +1,142 @@
+const async = require('async');
+const { jsutil } = require('arsenal');
+
+class StalledRequestHandler {
+    constructor(client, params) {
+        this.client = client;
+        this.dryRun = params.dryRun;
+        this.batchSize = params.batchSize;
+        this.concurrentRequests = params.concurrentRequests;
+        this.log = params.log;
+
+        this._queue = null;
+        this.killed = false;
+        this.queueError = null;
+
+        this.queueSetup();
+    }
+
+    queueSetup() {
+        this._queue = async.queue(({ bucket, batch, getNext }, done) => {
+            if (this.queueError !== null) {
+                return done();
+            }
+
+            this.log.info(`retrying stalled objects, count# ${batch.length}`);
+            if (this.dryRun) {
+                this.log.info('dry run, skipping retry request');
+                return getNext(done);
+            }
+
+            if (typeof this.client.retryFailedObjects !== 'function') {
+                return done(new Error('invalid stalled handler client'));
+            }
+
+            return this.client.retryFailedObjects({
+                Body: JSON.stringify(batch.map(entry => entry.toObject())),
+            }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return getNext(done);
+            });
+        }, this.concurrentRequests);
+
+        this._queue.error = (err, { bucket, batch }) => {
+            this.log.error('error occurred while processing request', {
+                error: err,
+                lastBatch: batch,
+                bucket,
+            });
+            this.queueError = err;
+            this.kill();
+        };
+    }
+
+    isInProgress() {
+        this.log.debug('queue progress', {
+            running: this._queue.running(),
+            inQueue: this._queue.length(),
+        });
+        return (this._queue.running() > 0 || this._queue.length() > 0);
+    }
+
+    kill() {
+        this._queue.kill();
+        this.killed = true;
+    }
+
+    _waitForCompletion(cb) {
+        async.whilst(() =>
+            (!this.killed && this.isInProgress()),
+        done => setTimeout(done, 1000), cb);
+    }
+
+    handleRequests(source, cb) {
+        // todo: check using instanceof?
+        if (!source || typeof source.getBatch !== 'function') {
+            return cb(new Error('Invalid cursor source'));
+        }
+
+        if (this.killed) {
+            return cb(new Error('terminated handler'));
+        }
+
+        const onceCB = jsutil.once(cb);
+        const nextBatch = cb => source.getBatch(
+            this.batchSize,
+            (err, batch) => {
+                if (err) {
+                    this.log.error('failed to retrieve batch', {
+                        method: 'nextBatch',
+                        error: err,
+                    });
+                    return cb(err);
+                }
+
+                if (batch !== null) {
+                    this._queue.push({
+                        bucket: source.bucketName,
+                        batch,
+                        getNext: nextBatch,
+                    });
+                }
+
+                return cb(null);
+            });
+
+        return async.times(
+            this.concurrentRequests,
+            (_, cb) => nextBatch(cb),
+            err => {
+                if (err) {
+                    this.log.error('failed to populate queue', {
+                        method: '::handleRequests',
+                        error: err,
+                    });
+                    return onceCB(err);
+                }
+
+                // wait for queue to be done and source to be consumed
+                return this._waitForCompletion(() => {
+                    if (this.queueError) {
+                        this.killed = true;
+                        return onceCB(this.queueError);
+                    }
+
+                    const result = {
+                        bucket: source.bucketName,
+                        stalled: source.getInfo().stalled,
+                    };
+
+                    return onceCB(null, result);
+                });
+            }
+        );
+    }
+}
+
+module.exports = {
+    StalledRequestHandler,
+};
+

--- a/countItems.js
+++ b/countItems.js
@@ -1,8 +1,22 @@
 const cluster = require('cluster');
 
+const { parseEnvInt } = require('./utils');
+
+const HEAP_PROFILER_INTERVAL_MS =
+    parseEnvInt(process.env.HEAP_PROFILER_INTERVAL_MS, 10 * 60 * 1000);
+const HEAP_PROFILER_PATH = process.env.HEAP_PROFILER_PATH;
+
 if (cluster.isMaster) {
+    require('./utils/heapProfiler')(
+        `${HEAP_PROFILER_PATH}/master`,
+        HEAP_PROFILER_INTERVAL_MS
+    );
     require('./CountItems/masterProcess');
 } else if (cluster.isWorker) {
+    require('./utils/heapProfiler')(
+        `${HEAP_PROFILER_PATH}/worker/${cluster.worker.id}`,
+        HEAP_PROFILER_INTERVAL_MS
+    );
     require('./CountItems/workerProcess');
 }
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -46,10 +46,10 @@ stages:
         - docker-build
   tests:
     worker: &master-worker
-      type: docker
-      path: eve/workers/master
-      volumes:
-        - '/home/eve/workspace'
+      type: kube_pod
+      path: eve/workers/master/pod.yaml
+      images:
+        master: eve/workers/master
     steps:
       - Git: &git_clone
           name: fetch source
@@ -69,6 +69,8 @@ stages:
       - ShellCommand:
           name: run test
           command: yarn --silent test:functional 
+          env:
+            MONGODB_REPLICASET: "localhost:27018"
 
   # The docker-build stage ensures that your images are built on every commit
   # and also hosted on the registry to help you pull it up and

--- a/eve/workers/master/pod.yaml
+++ b/eve/workers/master/pod.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: worker
+spec:
+  containers:
+    - name: master
+      image: "{{ images.master }}"
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      volumeMounts:
+        - name: worker-workspace
+          mountPath: /home/eve/workspace
+    - name: mongo
+      image: scality/ci-mongo:3.6.8
+      imagePullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 1Gi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+  volumes:
+    - name: worker-workspace
+      emptyDir: {}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "arsenal": "github:scality/arsenal#81d05b6",
     "async": "^2.6.1",
     "aws-sdk": "^2.333.0",
+    "heapdump": "^0.3.15",
     "node-uuid": "^1.4.8",
     "werelogs": "scality/werelogs",
     "zenkoclient": "scality/zenkoclient#5c7f655"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint $(git ls-files '*.js')",
     "test:unit": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js --coverage --testPathPattern='tests/unit/[\\w/-]+\\.[tj]s'",
-    "test:functional": "MONGODB_REPLICASET=localhost:27017 LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose  --logHeapUsage --projects jest.config.js  --coverage --testPathPattern='tests/functional/[\\w/-]+\\.[tj]s'"
+    "test:functional": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js  --coverage --testPathPattern='tests/functional/[\\w/-]+\\.[tj]s'"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,6 @@
     "eslint-config-scality": "github:scality/Guidelines",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-react": "^4.3.0",
-    "jest": "^23.6.0",
-    "mongodb-memory-server": "^6.2.4"
+    "jest": "^23.6.0"
   }
 }

--- a/stalled.js
+++ b/stalled.js
@@ -21,7 +21,7 @@ const ACCESS_KEY = process.env.ACCESS_KEY;
 const SECRET_KEY = process.env.SECRET_KEY;
 const MONGODB_REPLICASET = process.env.MONGODB_REPLICASET;
 const MONGODB_DATABASE = process.env.MONGODB_DATABASE || 'metadata';
-const DRY_RUN = process.env.DRY_RUN && process.env.DRY_RUN !== '0';
+const DRY_RUN = process.env.DRY_RUN && process.env.DRY_RUN !== 'false';
 
 const BATCH_SIZE = parseEnvInt(process.env.REQUEST_BATCH_SIZE, 10);
 const QUEUE_LIMIT = parseEnvInt(process.env.QUEUE_LIMIT, 1000);

--- a/stalled.js
+++ b/stalled.js
@@ -1,15 +1,46 @@
-const async = require('async');
-const { storage, versioning } = require('arsenal');
+const assert = require('assert');
 const { Logger } = require('werelogs');
 const ZenkoClient = require('zenkoclient');
 
-const { MongoClientInterface } = storage.metadata.mongoclient;
-const { encode } = versioning.VersionID;
+const {
+    MongoClientInterfaceStalled,
+} = require('./StalledRetry/MongoClientInterfaceStalled');
+
+const {
+    RateLimitingCursor,
+} = require('./StalledRetry/CursorWrapper');
+
+const {
+    StalledRequestHandler,
+} = require('./StalledRetry/StalledRequestHandler');
+
 const ENDPOINT = process.env.ENDPOINT;
 const ACCESS_KEY = process.env.ACCESS_KEY;
 const SECRET_KEY = process.env.SECRET_KEY;
 const MONGODB_REPLICASET = process.env.MONGODB_REPLICASET;
-const DRY_RUN = !!process.env.DRY_RUN;
+const MONGODB_DATABASE = process.env.MONGODB_DATABASE || 'metadata';
+const DRY_RUN = process.env.DRY_RUN && process.env.DRY_RUN !== '0';
+
+/**
+ * parse environment variable as a integer number
+ * @param {string} env - environment variable value
+ * @param {int} defValue - default value if environment cannot be found or is
+ *      not int parseable
+ * @returns {int} - return integer value
+ */
+function parseEnvInt(env, defValue) {
+    return (env && !Number.isNaN(env))
+        ? Number.parseInt(env, 10)
+        : defValue;
+}
+
+const BATCH_SIZE = parseEnvInt(process.env.REQUEST_BATCH_SIZE, 10);
+const QUEUE_LIMIT = parseEnvInt(process.env.QUEUE_LIMIT, 1000);
+const CONCURRENT_REQUESTS = parseEnvInt(process.env.CONCURRENT_REQUESTS, 5);
+const EXPIRED_BY_HOUR =
+    Math.max(parseEnvInt(process.env.EXPIRED_BY_HOUR, 1), 1);
+
+assert(BATCH_SIZE <= QUEUE_LIMIT);
 
 if (!ENDPOINT) {
     throw new Error('ENDPOINT not defined!');
@@ -23,144 +54,42 @@ if (!SECRET_KEY) {
 if (!MONGODB_REPLICASET) {
     throw new Error('MONGODB_REPLICASET not defined');
 }
-const USERSBUCKET = '__usersbucket';
-const METASTORE = '__metastore';
-const INFOSTORE = '__infostore';
-const PENSIEVE = 'PENSIEVE';
-const MPU_BUCKET_PREFIX = 'mpuShadowBucket';
-const zenkoClient = new ZenkoClient({
-    apiVersion: '2018-07-08-json',
-    accessKeyId: ACCESS_KEY,
-    secretAccessKey: SECRET_KEY,
-    endpoint: ENDPOINT,
-    s3ForcePathStyle: true,
-    signatureVersion: 'v4',
-    maxRetries: 0,
-    sslEnabled: false,
-    httpOptions: { timeout: 0 },
-});
 const log = new Logger('S3Utils::Stalled');
 
-class MongoClientInterfaceStalled extends MongoClientInterface {
-    constructor(params) {
-        super(params);
-        this.zenkoClient = zenkoClient;
-    }
+function wrapperFactory(bucketName, cmpDate, cursor, log) {
+    return new RateLimitingCursor(
+        cursor,
+        {
+            log,
+            queueLimit: QUEUE_LIMIT,
+            cmpDate,
+            bucketName,
+        }
+    );
+}
 
-    _getStalledObjectsByBucket(bucketName, cb) {
-        const c = this.getCollection(bucketName);
-        const cmpDate = new Date();
-        cmpDate.setHours(cmpDate.getHours() - 1);
-        const reducedFields = {
-            '_id': {
-                id: '$_id',
-                storageClasses: '$value.replicationInfo.storageClass',
-                status: '$value.replicationInfo.status',
-                key: '$value.key',
-                versionId: '$value.versionId',
-            },
-            'value.last-modified': 1,
-        };
-        return c.aggregate([
-            { $project: reducedFields },
-            { $match: {
-                '_id.id': { $regex: /\0/ },
-                '_id.status': { $eq: 'PENDING' },
-            } },
-        ]).toArray((err, res) => {
-            if (err) {
-                log.debug('unable to retrieve stalled entries', {
-                    error: err,
-                });
-                return cb(err);
-            }
-            const stalledObjects = res.map(data => {
-                if (!data || typeof data !== 'object' ||
-                    !data.value || typeof data.value !== 'object') {
-                    return false;
-                }
-                const time = data.value['last-modified'] || null;
-                if (isNaN(Date.parse(time))) {
-                    return false;
-                }
-                const testDate = new Date(time);
-                const withinRange = testDate <= cmpDate;
-                if (withinRange) {
-                    const storageClasses = data._id.storageClasses.split(',');
-                    return storageClasses.map(i => {
-                        const storageClass = i.split(':')[0];
-                        return {
-                            Bucket: bucketName,
-                            Key: data._id.key,
-                            VersionId: encode(data._id.versionId),
-                            StorageClass: storageClass,
-                            ForceRetry: true,
-                        };
-                    });
-                }
-                return false;
-            })
-            // filter nulls
-            .filter(i => !!i);
-            // flatten array of arrays
-            if (stalledObjects.length > 0) {
-                return cb(null, stalledObjects.reduce(
-                    (accumulator, currVal) => accumulator.concat(currVal)));
-            }
-            return cb(null, stalledObjects);
-        });
-    }
+function handlerFactory(log) {
+    const zenkoClient = new ZenkoClient({
+        apiVersion: '2018-07-08-json',
+        accessKeyId: ACCESS_KEY,
+        secretAccessKey: SECRET_KEY,
+        endpoint: ENDPOINT,
+        s3ForcePathStyle: true,
+        signatureVersion: 'v4',
+        maxRetries: 0,
+        sslEnabled: false,
+        httpOptions: { timeout: 0 },
+    });
 
-    queueStalledObjects(cb) {
-        this.db.listCollections().toArray((err, collections) => {
-            if (err) {
-                return cb(err);
-            }
-            return async.eachLimit(collections, 1, (value, next) => {
-                const skipBucket = value.name === METASTORE ||
-                    value.name === INFOSTORE ||
-                    value.name === USERSBUCKET ||
-                    value.name === PENSIEVE ||
-                    value.name.startsWith(MPU_BUCKET_PREFIX);
-                if (skipBucket) {
-                    // skip
-                    return next();
-                }
-                const bucketName = value.name;
-                return this._getStalledObjectsByBucket(bucketName, (err, r) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    if (!r) {
-                        log.info('no stalled objects for bucket: ', bucketName);
-                        return next();
-                    }
-                    const count = r.length;
-                    const stalledObjects = [];
-                    while (r.length > 0) {
-                        // build arrays of 10 objects each
-                        stalledObjects.push(r.splice(0, 10));
-                    }
-                    // upto 50 objects are retried in parallel
-                    return async.mapLimit(stalledObjects, 5, (i, done) => {
-                        log.info('retrying stalled objects, count# ', i.length);
-                        if (DRY_RUN) {
-                            log.info('dry run, skipping retry request');
-                            return done();
-                        }
-                        return zenkoClient.retryFailedObjects({
-                            Body: JSON.stringify(i),
-                        }, done);
-                    }, err => {
-                        if (err) {
-                            return next(err);
-                        }
-                        return next(null, { bucket: bucketName, count });
-                    });
-                });
-            }, cb);
-        });
-    }
+    return new StalledRequestHandler(
+        zenkoClient,
+        {
+            dryRun: DRY_RUN,
+            batchSize: BATCH_SIZE,
+            concurrentRequests: CONCURRENT_REQUESTS,
+            log,
+        }
+    );
 }
 
 const config = {
@@ -171,19 +100,23 @@ const config = {
     database: 'metadata',
     replicationGroupId: 'RG001',
     logger: log,
+    cursorWrapperFactory: wrapperFactory,
+    requestHandlerFactory: handlerFactory,
 };
 
 const mongoclient = new MongoClientInterfaceStalled(config);
 mongoclient.setup(err => {
     if (err) {
-        return log.error('error connecting to mongodb', err);
+        log.error('error connecting to mongodb', err);
+        return process.exit(1);
     }
-    return mongoclient.queueStalledObjects((err, res) => {
+    return mongoclient.queueStalledObjects(EXPIRED_BY_HOUR, (err, res) => {
         if (err) {
-            return log.error('error occurred', err);
+            log.error('error occurred', err);
+            return process.exit(1);
         }
-        if (res && res.length > 0) {
-            return log.info('stalled objects are queued for retries');
+        if (res > 0) {
+            log.info('stalled objects are queued for retries');
         }
         log.info('stalled objects retry job completed');
         return process.exit(0);

--- a/stalledRetry.yaml
+++ b/stalledRetry.yaml
@@ -31,5 +31,25 @@ spec:
               value: ""
             - name: MONGODB_REPLICASET
               value: ""
+            - name: MONGODB_DATABASE
+              value: "metadata"
             - name: DRY_RUN
               value: "false"
+            - name: EXPIRED_BY_HOUR
+              value: "1"
+              # limits the number of retry resources per retry request
+            - name: BATCH_SIZE
+              value: "10"
+              # limits the number of retry resource entries in queue
+            - name: QUEUE_LIMIT
+              value: "1000"
+              # limits the number of parallel retry requests
+            - name: CONCURRENT_REQUESTS
+              value: "5"
+            - name: ENABLE_HEAP_PROFILER
+              value: "1"
+            - name: HEAP_PROFILER_INTERVAL_MS
+              value: "600000"
+              # path to write heap snapshots
+            - name: HEAP_PROFILER_PATH
+              value: "/path/to/write"

--- a/tests/functional/stalled.js
+++ b/tests/functional/stalled.js
@@ -1,0 +1,260 @@
+const async = require('async');
+const werelogs = require('werelogs');
+const { BucketInfo, ObjectMD } = require('arsenal').models;
+
+const {
+    MongoClientInterfaceStalled,
+} = require('../../StalledRetry/MongoClientInterfaceStalled');
+const {
+    RateLimitingCursor,
+} = require('../../StalledRetry/CursorWrapper');
+
+const {
+    StalledRequestHandler,
+} = require('../../StalledRetry/StalledRequestHandler');
+
+
+const loggerConfig = {
+    level: 'debug',
+    dump: 'error',
+};
+
+werelogs.configure(loggerConfig);
+
+const logger = new werelogs.Logger('StalledRetry::Test::Functional');
+const MONGODB_REPLICASET = process.env.MONGODB_REPLICASET;
+const dbName = 'stalledRetryTest';
+
+function wrapperFactory(bucketName, cmpDate, cursor, log) {
+    return new RateLimitingCursor(
+        cursor,
+        {
+            queueLimit: 10,
+            log,
+            cmpDate,
+            bucketName,
+        }
+    );
+}
+
+class TrackingClient {
+    constructor() {
+        this.requestedBatch = [];
+    }
+
+    retryFailedObjects(params, done) {
+        this.requestedBatch.push(params.Body);
+        return done();
+    }
+}
+
+function handlerFactory(client, log) {
+    return new StalledRequestHandler(
+        client,
+        {
+            dryRun: false,
+            batchSize: 10,
+            concurrentRequests: 5,
+            log,
+        }
+    );
+}
+
+function createStalledObject(objName, lastModified) {
+    return new ObjectMD()
+        .setKey(objName)
+        .setDataStoreName('us-east-1')
+        .setLastModified(lastModified)
+        .setReplicationInfo({
+            status: 'PENDING',
+            backends: [],
+            content: [],
+            destination: '',
+            storageClass: '',
+            role: '',
+            storageType: '',
+            dataStoreVersionId: '',
+            isNFS: null,
+        })
+        .setReplicationStorageClass('location-1,location-2')
+        .getValue();
+}
+
+function createCompletedObject(objName) {
+    return new ObjectMD()
+        .setKey(objName)
+        .setDataStoreName('us-east-1')
+        .setLastModified('2020-01-01T00:00:00.000Z')
+        .setReplicationInfo({
+            status: 'COMPLETED',
+            backends: [
+                {
+                    status: 'COMPLETED',
+                    site: 'location-1',
+                },
+                {
+                    status: 'COMPLETED',
+                    site: 'location-2',
+                },
+            ],
+            content: [],
+            destination: '',
+            storageClass: '',
+            role: '',
+            storageType: '',
+            dataStoreVersionId: '',
+            isNFS: null,
+        }).getValue();
+}
+
+function populateMongo(client, callback) {
+    async.series([
+        next => async.timesSeries(10, (n, done) => {
+            const bucketName = `test-bucket-${n}`;
+            const bucketMD = BucketInfo.fromObj({
+                _name: bucketName,
+                _owner: 'testowner',
+                _ownerDisplayName: 'testdisplayname',
+                _creationDate: new Date().toJSON(),
+                _acl: {
+                    Canned: 'private',
+                    FULL_CONTROL: [],
+                    WRITE: [],
+                    WRITE_ACP: [],
+                    READ: [],
+                    READ_ACP: [],
+                },
+                _mdBucketModelVersion: 10,
+                _transient: false,
+                _deleted: false,
+                _serverSideEncryption: null,
+                _versioningConfiguration: { Status: 'Enabled' },
+                _locationConstraint: 'primary-location',
+                _readLocationConstraint: null,
+                _cors: null,
+                _replicationConfiguration: null,
+                _lifecycleConfiguration: null,
+                _uid: '',
+                _isNFS: null,
+                ingestion: null,
+            });
+            async.series([
+                next => client.createBucket(bucketName, bucketMD, logger, next),
+                next => async.timesSeries(100, (m, done) => {
+                    async.parallel([
+                        done => {
+                            const objName = `stalled-1hr-${m}`;
+                            const cmpDate = new Date();
+                            cmpDate.setHours(cmpDate.getHours() - 1);
+                            const lastModified = cmpDate.toUTCString();
+                            return client.putObject(
+                                bucketName,
+                                objName,
+                                createStalledObject(objName, lastModified),
+                                { versionId: null, versioning: true },
+                                logger,
+                                done
+                            );
+                        },
+                        done => {
+                            const objName = `stalled-10hr-${m}`;
+                            const cmpDate = new Date();
+                            cmpDate.setHours(cmpDate.getHours() - 10);
+                            const lastModified = cmpDate.toUTCString();
+                            return client.putObject(
+                                bucketName,
+                                objName,
+                                createStalledObject(objName, lastModified),
+                                { versionId: null, versioning: true },
+                                logger,
+                                done
+                            );
+                        },
+                        done => {
+                            const objName = `pending-${m}`;
+                            const cmpDate = new Date();
+                            const lastModified = cmpDate.toUTCString();
+                            return client.putObject(
+                                bucketName,
+                                objName,
+                                createStalledObject(objName, lastModified),
+                                { versionId: null, versioning: true },
+                                logger,
+                                done
+                            );
+                        },
+                        done => {
+                            const objName = `completed-${m}`;
+                            return client.putObject(
+                                bucketName,
+                                objName,
+                                createCompletedObject(objName),
+                                { versionId: null, versioning: true },
+                                logger,
+                                done
+                            );
+                        },
+                    ], done);
+                }, next),
+            ], done);
+        }, next),
+    ], callback);
+}
+
+
+jest.setTimeout(3600000);
+describe('StalledRetry', () => {
+    let mgoClient;
+    let reqClient;
+
+    beforeAll(done => {
+        reqClient = new TrackingClient();
+        const opts = {
+            replicaSetHosts: MONGODB_REPLICASET,
+            writeConcern: 'majority',
+            replicaSet: 'rs0',
+            readPreference: 'primary',
+            database: dbName,
+            replicationGroupId: 'RG001',
+            logger,
+            cursorWrapperFactory: wrapperFactory,
+            requestHandlerFactory: handlerFactory.bind(null, reqClient),
+        };
+        mgoClient = new MongoClientInterfaceStalled(opts);
+        async.series([
+            next => mgoClient.setup(next),
+            next => populateMongo(mgoClient, next),
+        ], done);
+    });
+
+    afterAll(done => {
+        async.series([
+            next => mgoClient.db.dropDatabase(next),
+            next => mgoClient.close(next),
+        ], done);
+    });
+
+    test('should correctly process stalled entries (all stalled)', done => {
+        mgoClient.queueStalledObjects(1, (err, res) => {
+            expect(err).toBeNull();
+            expect(res).toEqual(4000);
+            done();
+        });
+    });
+
+    test('should correctly process stalled entries (skip 1hr exp)', done => {
+        mgoClient.queueStalledObjects(5, (err, res) => {
+            expect(err).toBeNull();
+            expect(res).toEqual(2000);
+            done();
+        });
+    });
+
+    test('should correctly process stalled entries (skip 1+10hr exp)', done => {
+        mgoClient.queueStalledObjects(11, (err, res) => {
+            expect(err).toBeNull();
+            expect(res).toEqual(0);
+            done();
+        });
+    });
+});

--- a/tests/unit/StalledRetry/CursorWrapper.js
+++ b/tests/unit/StalledRetry/CursorWrapper.js
@@ -1,0 +1,401 @@
+const { PassThrough } = require('stream');
+const werelogs = require('werelogs');
+const {
+    RateLimitingCursor,
+} = require('../../../StalledRetry/CursorWrapper');
+
+const {
+    generateObjectMD,
+    generateModifiedDateString,
+} = require('../../utils');
+
+const loggerConfig = {
+    level: 'debug',
+    dump: 'error',
+};
+
+werelogs.configure(loggerConfig);
+
+const log = new werelogs.Logger('S3Utils::StalledRetry::RateLimitingCursor');
+
+const cmpDate = new Date('2020-01-01T00:00:00.000Z');
+
+function writeItemsTo(writable, items) {
+    items.forEach(item => {
+        writable.write(item);
+    });
+}
+
+describe('RateLimitingCursor', () => {
+    let mockCursor;
+
+    beforeEach(() => {
+        mockCursor = new PassThrough({
+            objectMode: true,
+            highWaterMark: 1000, // 1000 objects read/write
+        });
+    });
+
+    afterEach(() => {
+        mockCursor.destroy();
+    });
+
+    test('should pause source stream if queue limit has been reached', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        writeItemsTo(mockCursor, [
+            generateObjectMD(
+                'testobject-0',
+                generateModifiedDateString(cmpDate, -24),
+                'us-east-1,us-east-2'
+            ),
+            generateObjectMD(
+                'testobject-1',
+                generateModifiedDateString(cmpDate, -24),
+                'us-east-1,us-east-2'
+            ),
+        ]);
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toBeNull();
+            expect(wrapper.cursorEnd).toEqual(false);
+            expect(wrapper.cursor.isPaused()).toEqual(true);
+            expect(wrapper.completed).toEqual(false);
+            // expect 2 entries to be queued from the first item
+            expect(wrapper.buffer.length).toEqual(2);
+            done();
+        }, 100);
+    });
+
+    test('should ignore non-stalled items', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1000,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        writeItemsTo(mockCursor, [
+            generateObjectMD(
+                'testobject-0',
+                generateModifiedDateString(cmpDate, +24),
+                'us-east-1,us-east-2'
+            ),
+        ]);
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toBeNull();
+            expect(wrapper.cursorEnd).toEqual(false);
+            expect(wrapper.cursor.isPaused()).toEqual(false);
+            expect(wrapper.completed).toEqual(false);
+            // expect 2 entries to be queued from the first item
+            expect(wrapper.buffer.length).toEqual(0);
+            done();
+        }, 100);
+    });
+
+    test('should queue stalled items', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1000,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        writeItemsTo(mockCursor, [
+            generateObjectMD(
+                'testobject-0',
+                generateModifiedDateString(cmpDate, -24),
+                'us-east-1,us-east-2'
+            ),
+        ]);
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toBeNull();
+            expect(wrapper.cursorEnd).toEqual(false);
+            expect(wrapper.cursor.isPaused()).toEqual(false);
+            expect(wrapper.completed).toEqual(false);
+            // expect 2 entries to be queued from the first item
+            expect(wrapper.buffer.length).toEqual(2);
+            done();
+        }, 100);
+    });
+
+    test('should handle cursor error', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        mockCursor.emit('error', new Error('test error'));
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toEqual(new Error('test error'));
+            expect(wrapper.cursorEnd).toEqual(true);
+            expect(wrapper.completed).toEqual(true);
+            done();
+        }, 100);
+    });
+
+    test('should handle cursor end with items in queue', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1000,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        writeItemsTo(mockCursor, [
+            generateObjectMD(
+                'testobject-0',
+                generateModifiedDateString(cmpDate, -24),
+                'us-east-1,us-east-2'
+            ),
+        ]);
+        mockCursor.end();
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toBeNull();
+            expect(wrapper.cursorEnd).toEqual(true);
+            expect(wrapper.completed).toEqual(false);
+            // expect 2 entries to be queued from the first item
+            expect(wrapper.buffer.length).toEqual(2);
+            done();
+        }, 100);
+    });
+
+    test('should handle cursor end with 0 items in queue', done => {
+        const wrapper = new RateLimitingCursor(
+            mockCursor,
+            {
+                queueLimit: 1000,
+                bucketName: 'test-bucket',
+                cmpDate,
+                log,
+            }
+        );
+
+        mockCursor.end();
+
+        setTimeout(() => {
+            expect(wrapper.cursorErr).toBeNull();
+            expect(wrapper.cursorEnd).toEqual(true);
+            expect(wrapper.completed).toEqual(true);
+            done();
+        }, 100);
+    });
+
+    describe('::getBatch', () => {
+        test('should add getBatch request to queue', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            wrapper.getBatch(1, () => {});
+
+            setTimeout(() => {
+                expect(wrapper.getBatchCallbacks).toHaveLength(1);
+                done();
+            }, 100);
+        });
+
+        test('should call queued callback when size is met', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            wrapper.getBatch(5, (err, batch) => {
+                expect(err).toBeNull();
+                expect(batch.length).toEqual(5);
+                expect(wrapper.buffer.length).toEqual(1);
+                done();
+            });
+
+            setTimeout(() => {
+                writeItemsTo(mockCursor, [
+                    generateObjectMD(
+                        'testobject-0',
+                        generateModifiedDateString(cmpDate, -24),
+                        'us-east-1,us-east-2,us-east-3'
+                    ),
+                    generateObjectMD(
+                        'testobject-1',
+                        generateModifiedDateString(cmpDate, -24),
+                        'us-east-1,us-east-2,us-east-3'
+                    ),
+                ]);
+            }, 100);
+        });
+
+        test('should destroy source on completion', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            writeItemsTo(mockCursor, [
+                generateObjectMD(
+                    'testobject-0',
+                    generateModifiedDateString(cmpDate, -24),
+                    'us-east-1'
+                ),
+            ]);
+            mockCursor.end();
+
+            setTimeout(() => {
+                wrapper.getBatch(1, err => {
+                    expect(err).toBeNull();
+                    expect(wrapper.cursorEnd).toEqual(true);
+                    expect(wrapper.completed).toEqual(true);
+                    expect(wrapper.cursor).toEqual(null);
+                    done();
+                });
+            }, 1000);
+        });
+
+        test('should return error', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            wrapper.getBatch(1, (err, batch) => {
+                expect(err).toEqual(new Error('test error'));
+                expect(batch).toBeNull();
+                done();
+            });
+
+            setTimeout(() => {
+                mockCursor.emit('error', new Error('test error'));
+            }, 100);
+        });
+
+        test('should call queued getBatch requests on source end', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            writeItemsTo(mockCursor, [
+                generateObjectMD(
+                    'testobject-0',
+                    generateModifiedDateString(cmpDate, -24),
+                    'us-east-1,us-east-2,us-east-3'
+                ),
+                generateObjectMD(
+                    'testobject-1',
+                    generateModifiedDateString(cmpDate, -24),
+                    'us-east-1,us-east-2,us-east-3'
+                ),
+            ]);
+
+            wrapper.getBatch(3, (err, batch) => {
+                expect(err).toBeNull();
+                expect(batch.length).toEqual(3);
+                expect(wrapper.completed).toEqual(false);
+            });
+
+            wrapper.getBatch(2, (err, batch) => {
+                expect(err).toBeNull();
+                expect(batch.length).toEqual(2);
+                expect(wrapper.completed).toEqual(false);
+            });
+
+            wrapper.getBatch(1, (err, batch) => {
+                expect(err).toBeNull();
+                expect(batch.length).toEqual(1);
+                expect(wrapper.completed).toEqual(true);
+                done();
+            });
+
+            mockCursor.end();
+        });
+
+        test('should resume paused source', done => {
+            const wrapper = new RateLimitingCursor(
+                mockCursor,
+                {
+                    queueLimit: 1000,
+                    bucketName: 'test-bucket',
+                    cmpDate,
+                    log,
+                }
+            );
+
+            mockCursor.pause();
+            writeItemsTo(mockCursor, [
+                generateObjectMD(
+                    'testobject-0',
+                    generateModifiedDateString(cmpDate, -24),
+                    'us-east-1,us-east-2,us-east-3'
+                ),
+                generateObjectMD(
+                    'testobject-1',
+                    generateModifiedDateString(cmpDate, -24),
+                    'us-east-1,us-east-2,us-east-3'
+                ),
+            ]);
+
+            setTimeout(() => {
+                expect(wrapper.cursor.isPaused()).toEqual(true);
+                wrapper.getBatch(1, (err, batch) => {
+                    expect(err).toBeNull();
+                    expect(batch.length).toEqual(1);
+                    expect(wrapper.completed).toEqual(false);
+                    expect(wrapper.cursorEnd).toEqual(false);
+                    expect(wrapper.cursor.isPaused()).toEqual(false);
+                    done();
+                });
+            }, 1000);
+        });
+    });
+});

--- a/tests/unit/StalledRetry/StalledRequestHandler.js
+++ b/tests/unit/StalledRetry/StalledRequestHandler.js
@@ -1,0 +1,137 @@
+const werelogs = require('werelogs');
+
+const {
+    StalledRequestHandler,
+} = require('../../../StalledRetry/StalledRequestHandler');
+
+const {
+    generateRequestArray,
+} = require('../../utils');
+
+const loggerConfig = {
+    level: 'debug',
+    dump: 'error',
+};
+
+werelogs.configure(loggerConfig);
+
+const log = new werelogs.Logger('S3Utils::StalledRetry::StalledRequestHandler');
+
+const mockClient = {
+    retryFailedObjects: jest.fn(),
+};
+
+const mockSource = {
+    getBatch: jest.fn(),
+    getInfo: jest.fn(),
+};
+
+
+const mockSourceGetBatchResponses = respList => {
+    respList.forEach(resp => {
+        mockSource.getBatch.mockImplementationOnce((_, cb) => cb(...resp));
+    });
+};
+
+describe('StalledRequestHandler', () => {
+    let handler;
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockClient.retryFailedObjects.mockReset();
+        mockSource.getBatch.mockReset();
+        mockSource.getInfo.mockReset();
+
+        handler = new StalledRequestHandler(mockClient, {
+            dryRun: false,
+            batchSize: 10,
+            concurrentRequests: 5,
+            log,
+        });
+    });
+
+    afterEach(() => {
+        handler.kill();
+    });
+
+    describe('::handleRequests', () => {
+        test('error if called using a terminated handler', done => {
+            mockSource.getBatch.mockImplementation((_, cb) => cb(null, null));
+
+            handler.kill();
+            handler.handleRequests(mockSource, err => {
+                expect(err).toEqual(new Error('terminated handler'));
+                done();
+            });
+        });
+
+        test('error if source is missing the getBatch method', done => {
+            handler = new StalledRequestHandler({}, {
+                dryRun: false,
+                batchSize: 10,
+                concurrentRequests: 5,
+                log,
+            });
+
+            handler.handleRequests({}, err => {
+                expect(err).toEqual(new Error('Invalid cursor source'));
+                done();
+            });
+        });
+
+        test('should return error from queue', done => {
+            mockClient.retryFailedObjects.mockImplementation((param, cb) =>
+                cb(new Error('test client error')));
+            mockSourceGetBatchResponses([
+                [null, generateRequestArray('bucket', 'key', 'loc-1')],
+                [null, generateRequestArray('bucket', 'key', 'loc-2')],
+            ]);
+            mockSource.getBatch.mockImplementation((_, cb) => cb(null, null));
+
+            handler.handleRequests(mockSource, err => {
+                expect(err).toEqual(new Error('test client error'));
+                expect(handler.killed).toEqual(true);
+                expect(handler.queueError)
+                    .toEqual(new Error('test client error'));
+                done();
+            });
+        });
+
+        test('should wait until queue is completed', done => {
+            mockClient.retryFailedObjects.mockImplementation((_, cb) =>
+                setTimeout(() => cb(), 500));
+            mockSource.getInfo.mockImplementation(() => ({ stalled: 1 }));
+            mockSourceGetBatchResponses([
+                [null, generateRequestArray('bucket', 'key', 'loc-1')],
+            ]);
+            mockSource.getBatch.mockImplementation((_, cb) => cb(null, null));
+
+            handler.handleRequests(mockSource, err => {
+                expect(err).toBeNull();
+                expect(handler.isInProgress()).toEqual(false);
+                done();
+            });
+
+            // early check
+            setTimeout(() => {
+                expect(handler.isInProgress()).toEqual(true);
+            }, 100);
+        });
+
+        test('should complete successfully', done => {
+            mockClient.retryFailedObjects.mockImplementation((_, cb) =>
+                setTimeout(() => cb(), 500));
+            mockSource.getInfo.mockImplementation(() => ({ stalled: 1 }));
+            mockSourceGetBatchResponses([
+                [null, generateRequestArray('bucket', 'key', 'loc-1')],
+            ]);
+            mockSource.getBatch.mockImplementation((_, cb) => cb(null, null));
+
+            handler.handleRequests(mockSource, err => {
+                expect(err).toBeNull();
+                expect(handler.queueError).toEqual(null);
+                done();
+            });
+        });
+    });
+});

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,0 +1,51 @@
+const { ObjectMD } = require('arsenal').models;
+const { encode } = require('arsenal').versioning.VersionID;
+
+const { StalledEntry } = require('../../StalledRetry/CursorWrapper');
+
+const testVersion = '98502347359531999999RG001  5.2375.2122';
+
+function generateObjectMD(objectKey, lastModified, storageClasses) {
+    return {
+        _id: {
+            key: objectKey,
+            storageClasses,
+            versionId: testVersion,
+        },
+        value: new ObjectMD()
+            .setKey(objectKey)
+            .setLastModified(lastModified)
+            .setVersionId(testVersion)
+            .setReplicationStorageClass(storageClasses)
+            .getValue(),
+    };
+}
+
+function generateRequestObject(bucket, objectKey, storageClass) {
+    const storageClassName = storageClass.split(':')[0];
+    return new StalledEntry(
+        bucket,
+        objectKey,
+        encode(testVersion),
+        storageClassName,
+        true
+    );
+}
+
+function generateRequestArray(bucket, objectKey, storageClasses) {
+    return storageClasses.split(',')
+        .map(i => generateRequestObject(bucket, objectKey, i));
+}
+
+function generateModifiedDateString(date, delta) {
+    const mDate = new Date(date);
+    mDate.setHours(mDate.getHours() + delta);
+    return mDate.toUTCString();
+}
+
+module.exports = {
+    generateRequestObject,
+    generateRequestArray,
+    generateObjectMD,
+    generateModifiedDateString,
+};

--- a/utils/heapProfiler.js
+++ b/utils/heapProfiler.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const werelogs = require('werelogs');
+const heapdump = require('heapdump');
+
+const logger = new werelogs.Logger('Utils::HeapProfiler');
+
+function generateFilename(dir) {
+    return path.join(dir, `${Date.now()}.heapsnapshot`);
+}
+
+function writeSnapshot(filename) {
+    heapdump.writeSnapshot(filename, (err, filename) => {
+        if (err) {
+            logger.error(`unable to write heapdump to ${filename}:`, {
+                error: err,
+            });
+        } else {
+            logger.debug(`heapdump written to ${filename}:`);
+        }
+    });
+}
+
+module.exports = (dir, interval) => {
+    if (process.env.ENABLE_HEAP_PROFILER &&
+        process.env.ENABLE_HEAP_PROFILER !== '0') {
+        if (!fs.existsSync(dir)) {
+            try {
+                fs.mkdirSync(dir, { recursive: true });
+            } catch (err) {
+                logger.error('unable to create directory for heap profiler', {
+                    error: err,
+                });
+                logger.error('skipping heap profiling');
+                return;
+            }
+        }
+
+        writeSnapshot(generateFilename(dir));
+        setInterval(() => writeSnapshot(generateFilename(dir)), interval);
+        process.on('exit', () => writeSnapshot(generateFilename(dir)));
+    }
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,17 @@
+
+/**
+ * parse environment variable as a integer number
+ * @param {string} env - environment variable value
+ * @param {int} defValue - default value if environment cannot be found or is
+ *      not int parseable
+ * @returns {int} - return integer value
+ */
+function parseEnvInt(env, defValue) {
+    return (env && !Number.isNaN(env))
+        ? Number.parseInt(env, 10)
+        : defValue;
+}
+
+module.exports = {
+    parseEnvInt,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,82 +50,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@types/cross-spawn@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.1.tgz#60fa0c87046347c17d9735e5289e72b804ca9b63"
-  integrity sha512-MtN1pDYdI6D6QFDzy39Q+6c9rl2o/xN7aWGe6oZuzqq5N6+YuwFsWiEAv3dNzvzN9YzU+itpN8lBzFpphQKLAw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/decompress@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
-  integrity sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/dedent@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
-  integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
-
-"@types/find-cache-dir@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/find-cache-dir/-/find-cache-dir-2.0.0.tgz#6ee79b947b8e51ce8c565fc8278822b2605609db"
-  integrity sha512-LHAReDNv7IVTE2Q+nPcRBgUZAUKPJIvR7efMrWgx69442KMoMK+QYjtTtK9WGUdaqUYVLkd/0cvCfb55LFWsVw==
-
-"@types/find-package-json@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/find-package-json/-/find-package-json-1.1.1.tgz#c0d296ac74fe3309ed0fe75a9c3edb42a776d30c"
-  integrity sha512-XMCocYkg6VUpkbOQMKa3M5cgc3MvU/LJKQwd3VUJrWZbLr2ARUggupsCAF8DxjEEIuSO6HlnH+vl+XV4bgVeEQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/get-port@^4.0.1":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-4.2.0.tgz#4fc44616c737d37d3ee7926d86fa975d0afba5e4"
-  integrity sha512-Iv2FAb5RnIk/eFO2CTu8k+0VMmIR15pKbcqRWi+s3ydW+aKXlN2yemP92SrO++ERyJx+p6Ie1ggbLBMbU1SjiQ==
-  dependencies:
-    get-port "*"
-
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
-
-"@types/lockfile@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/lockfile/-/lockfile-1.0.1.tgz#434a3455e89843312f01976e010c60f1bcbd56f7"
-  integrity sha512-65WZedEm4AnOsBDdsapJJG42MhROu3n4aSSiu87JXF/pSdlubxZxp3S1yz3kTfkJ2KBPud4CpjoHVAptOm9Zmw==
-
-"@types/md5-file@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/md5-file/-/md5-file-4.0.1.tgz#5e6cfb7949dc375049b8f6fd8f91adacfc176c63"
-  integrity sha512-uK6vlo/LJp6iNWinpSzZwMe8Auzs0UYxesm7OGfQS3oz6PJciHtrKcqVOGk4wjYKawrl234vwNWvHyXH1ZzRyQ==
-
-"@types/mkdirp@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
-  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*":
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
-  integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
-
-"@types/tmp@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
-  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
-
-"@types/uuid@3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
-  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
-  dependencies:
-    "@types/node" "*"
 
 "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.19.0"
@@ -246,11 +174,6 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
-
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@^4.3.0:
   version "4.3.0"
@@ -792,22 +715,6 @@ bintrees@1.0.1:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
   integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
-  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
-bl@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.0.tgz#e1a574cdf528e4053019bb800b041c0ac88da493"
-  integrity sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
 bl@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
@@ -897,34 +804,6 @@ bson@^1.1.0:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
   integrity sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==
 
-bson@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.3.tgz#aa82cb91f9a453aaa060d6209d0675114a8154d3"
-  integrity sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==
-
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -939,7 +818,7 @@ buffer@4.9.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.1.0, buffer@^5.2.1:
+buffer@^5.1.0:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
   integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
@@ -1008,11 +887,6 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -1151,18 +1025,6 @@ commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@~2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
-  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
-
-commondir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1234,15 +1096,6 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
-  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
 crypto-browserify@1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
@@ -1283,13 +1136,6 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
-debug@4, debug@^4.1.1, debug@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
 debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1301,6 +1147,13 @@ debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.1, debug@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -1320,64 +1173,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
-  integrity sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==
-  dependencies:
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-    tar-stream "^1.5.2"
-
-decompress-tarbz2@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
-  integrity sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==
-  dependencies:
-    decompress-tar "^4.1.0"
-    file-type "^6.1.0"
-    is-stream "^1.1.0"
-    seek-bzip "^1.0.5"
-    unbzip2-stream "^1.0.9"
-
-decompress-targz@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
-  integrity sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==
-  dependencies:
-    decompress-tar "^4.1.1"
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-
-decompress-unzip@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
-  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
-  dependencies:
-    file-type "^3.8.0"
-    get-stream "^2.2.0"
-    pify "^2.3.0"
-    yauzl "^2.4.2"
-
-decompress@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
-  integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=
-  dependencies:
-    decompress-tar "^4.0.0"
-    decompress-tarbz2 "^4.0.0"
-    decompress-targz "^4.0.0"
-    decompress-unzip "^4.0.1"
-    graceful-fs "^4.1.10"
-    make-dir "^1.0.0"
-    pify "^2.3.0"
-    strip-dirs "^2.0.0"
-
-dedent@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1463,7 +1258,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-denque@^1.1.0, denque@^1.4.1:
+denque@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
   integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
@@ -1530,13 +1325,6 @@ encoding-down@^6.3.0:
     inherits "^2.0.3"
     level-codec "^9.0.0"
     level-errors "^2.0.0"
-
-end-of-stream@^1.0.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
 
 engine.io-client@~3.3.1:
   version "3.3.2"
@@ -1989,13 +1777,6 @@ fb-watchman@^2.0.0:
     bindings "^1.1.1"
     nan "^2.3.2"
 
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
-
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2011,21 +1792,6 @@ file-entry-cache@^1.1.1:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
-
-file-type@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
-
-file-type@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
-  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
-
-file-type@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
-  integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2068,20 +1834,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-cache-dir@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.2.0.tgz#e7fe44c1abc1299f516146e563108fd1006c1874"
-  integrity sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^3.0.0"
-    pkg-dir "^4.1.0"
-
-find-package-json@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
-  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
-
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2096,14 +1848,6 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -2147,11 +1891,6 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
-
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -2211,26 +1950,6 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-port@*:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
-  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
-
-get-port@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6"
-  integrity sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==
-  dependencies:
-    type-fest "^0.3.0"
-
-get-stream@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
-  dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
-
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -2275,7 +1994,7 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2304,20 +2023,10 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.10:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2467,14 +2176,6 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-https-proxy-agent@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
-  dependencies:
-    agent-base "5"
-    debug "4"
 
 https-proxy-agent@^2.2.0:
   version "2.2.4"
@@ -2785,11 +2486,6 @@ is-my-json-valid@^2.10.0:
     is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
-
-is-natural-number@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
-  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -3644,20 +3340,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
-
-lockfile@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
-  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
-  dependencies:
-    signal-exit "^3.0.2"
-
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -3733,20 +3415,6 @@ ltgt@~2.1.1:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
 
-make-dir@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
-  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
-  dependencies:
-    pify "^3.0.0"
-
-make-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
-  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
-  dependencies:
-    semver "^6.0.0"
-
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3788,11 +3456,6 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
-
-md5-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-4.0.0.tgz#f3f7ba1e2dd1144d5bf1de698d0e5f44a4409584"
-  integrity sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==
 
 md5.js@1.3.4:
   version "1.3.4"
@@ -3969,46 +3632,6 @@ mongodb-core@3.1.7:
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongodb-memory-server-core@6.2.4:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.2.4.tgz#36390295e41b4aa3b2b65bec30c2a49551b1e54e"
-  integrity sha512-W64vmFmfChl/0WVi5Kwg5AhWcWqIaEHZnhU+WZ1Outs12uraUeagdoRucDug65GEL1grUpuSHuz1tBRds+o2IQ==
-  dependencies:
-    "@types/cross-spawn" "^6.0.1"
-    "@types/decompress" "^4.2.3"
-    "@types/dedent" "^0.7.0"
-    "@types/find-cache-dir" "^2.0.0"
-    "@types/find-package-json" "^1.1.0"
-    "@types/get-port" "^4.0.1"
-    "@types/lockfile" "^1.0.1"
-    "@types/md5-file" "^4.0.0"
-    "@types/mkdirp" "^0.5.2"
-    "@types/tmp" "0.1.0"
-    "@types/uuid" "3.4.6"
-    camelcase "^5.3.1"
-    cross-spawn "^7.0.1"
-    debug "^4.1.1"
-    decompress "^4.2.0"
-    dedent "^0.7.0"
-    find-cache-dir "3.2.0"
-    find-package-json "^1.2.0"
-    get-port "5.0.0"
-    https-proxy-agent "4.0.0"
-    lockfile "^1.0.4"
-    md5-file "^4.0.0"
-    mkdirp "^0.5.1"
-    tmp "^0.1.0"
-    uuid "^3.3.3"
-  optionalDependencies:
-    mongodb "^3.2.7"
-
-mongodb-memory-server@^6.2.4:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-6.2.4.tgz#d67db84b9a4a407a4485ddefddd13cb4336df2a8"
-  integrity sha512-QWm1oFsc6DBJFE8JZt/bubOnrpbyODC4sAD+MHSAaU51wZwL7J17tr7gtX3ChkdwI9jmTFGASySM0XsKSY3qSA==
-  dependencies:
-    mongodb-memory-server-core "6.2.4"
-
 mongodb@^3.0.1:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.8.tgz#df8084fda2efdbaddd05dfd6a269891fc4cc72df"
@@ -4016,19 +3639,6 @@ mongodb@^3.0.1:
   dependencies:
     mongodb-core "3.1.7"
     safe-buffer "^5.1.2"
-
-mongodb@^3.2.7:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.2.tgz#83b8bcb3d96b666a10eeca2f9c7ad1db056ae291"
-  integrity sha512-Lxt4th2tK2MxmkDBR5cMik+xEnkvhwg0BC5kGcHm9RBwaNEsrIryvV5istGXOHbnif5KslMpY1FbX6YbGJ/Trg==
-  dependencies:
-    bl "^2.2.0"
-    bson "^1.1.1"
-    denque "^1.4.1"
-    require_optional "^1.0.1"
-    safe-buffer "^5.1.2"
-  optionalDependencies:
-    saslprep "^1.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4347,13 +3957,6 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
-  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -4361,22 +3964,10 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
-
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
-
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -4431,11 +4022,6 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -4451,11 +4037,6 @@ path-key@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -4470,11 +4051,6 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4485,15 +4061,10 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
-
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -4513,13 +4084,6 @@ pkg-dir@^2.0.0:
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
-
-pkg-dir@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -4722,19 +4286,6 @@ readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.3.0, readable-stream@^2.3.5:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -4970,13 +4521,6 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -4999,7 +4543,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.1.1, safe-buffer@~5.2.0:
+safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -5064,19 +4608,12 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-seek-bzip@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
-  integrity sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=
-  dependencies:
-    commander "~2.8.1"
-
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -5118,22 +4655,10 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shelljs@^0.6.0:
   version "0.6.1"
@@ -5460,13 +4985,6 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-dirs@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
-  integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
-  dependencies:
-    is-natural-number "^4.0.1"
-
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -5518,19 +5036,6 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-tar-stream@^1.5.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
-  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
-  dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.2.0"
-    end-of-stream "^1.0.0"
-    fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.1"
-    xtend "^4.0.0"
-
 tar@^4:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -5572,17 +5077,10 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-"through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
+"through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -5593,11 +5091,6 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
   integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
-
-to-buffer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
-  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -5687,11 +5180,6 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-fest@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
-  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
-
 typedarray-to-buffer@~3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -5738,14 +5226,6 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
-
-unbzip2-stream@^1.0.9:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
-  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
-  dependencies:
-    buffer "^5.2.1"
-    through "^2.3.8"
 
 underscore@~1.8.3:
   version "1.8.3"
@@ -5823,7 +5303,7 @@ uuid@3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
-uuid@^3.0.0, uuid@^3.3.3:
+uuid@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -5945,13 +5425,6 @@ which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -6114,14 +5587,6 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
-
-yauzl@^2.4.2:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yeast@0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,7 +273,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.2:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -1015,10 +1015,12 @@ combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+commander@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-1.3.2.tgz#8a8f30ec670a6fdd64af52f1914b907d79ead5b5"
+  integrity sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=
+  dependencies:
+    keypress "0.1.x"
 
 commander@~2.17.1:
   version "2.17.1"
@@ -1512,8 +1514,8 @@ eslint-config-airbnb@^6.2.0:
   version "8.1.0"
   resolved "https://codeload.github.com/scality/Guidelines/tar.gz/e49d1a2abfbbfb2c766c92d04a695b9171d511ff"
   dependencies:
-    commander "2.19.0"
-    markdownlint "0.11.0"
+    commander "1.3.2"
+    markdownlint "0.0.8"
 
 eslint-plugin-jest@^23.6.0:
   version "23.6.0"
@@ -2147,6 +2149,13 @@ hdclient@scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b:
   resolved "https://codeload.github.com/scality/hdclient/tar.gz/5145e04e5ed33e85106765b1caa90cd245ef482b"
   dependencies:
     werelogs scality/werelogs#GA7.2.0.5
+
+heapdump@^0.3.15:
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/heapdump/-/heapdump-0.3.15.tgz#631a8a2585588ea64778d8ec80a64c6c025f6a08"
+  integrity sha512-n8aSFscI9r3gfhOcAECAtXFaQ1uy4QSke6bnaL+iymYZ/dWs9cqDqHM+rALfsHUwukUbxsdlECZ0pKmJdQ/4OA==
+  dependencies:
+    nan "^2.13.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3144,6 +3153,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keypress@0.1.x:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.1.0.tgz#4a3188d4291b66b4f65edb99f806aa9ae293592a"
+  integrity sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3314,10 +3328,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-linkify-it@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+linkify-it@~1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-1.2.4.tgz#0773526c317c8fd13bd534ee1d180ff88abf881a"
+  integrity sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=
   dependencies:
     uc.micro "^1.0.1"
 
@@ -3434,23 +3448,23 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
-  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+markdown-it@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-4.4.0.tgz#3df373dbea587a9a7fef3e56311b68908f75c414"
+  integrity sha1-PfNz2+pYepp/7z5WMRtokI91xBQ=
   dependencies:
-    argparse "^1.0.7"
+    argparse "~1.0.2"
     entities "~1.1.1"
-    linkify-it "^2.0.0"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
+    linkify-it "~1.2.0"
+    mdurl "~1.0.0"
+    uc.micro "^1.0.0"
 
-markdownlint@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.11.0.tgz#3858bbdbc1ab78abf0c098d841c72b63dd3206a0"
-  integrity sha512-wE5WdKD6zW2DQaPQ5TFBTXh5j76DnWd/IFffnDQgHmi6Y61DJXBDfLftZ/suJHuv6cwPjM6gKw2GaRLJMOR+Mg==
+markdownlint@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.0.8.tgz#ed2a0fc6cba3aae6af09ae08bdbfa4de178a4677"
+  integrity sha1-7SoPxsujquavCa4Ivb+k3heKRnc=
   dependencies:
-    markdown-it "8.4.2"
+    markdown-it "^4.4.0"
 
 math-random@^1.0.1:
   version "1.0.1"
@@ -3465,7 +3479,7 @@ md5.js@1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-mdurl@^1.0.1:
+mdurl@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
@@ -3654,6 +3668,11 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
+
+nan@^2.13.2:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nan@^2.14.0:
   version "2.14.0"
@@ -5209,15 +5228,15 @@ typewiselite@~1.0.0:
   resolved "https://registry.yarnpkg.com/typewiselite/-/typewiselite-1.0.0.tgz#c8882fa1bb1092c06005a97f34ef5c8508e3664e"
   integrity sha1-yIgvobsQksBgBal/NO9chQjjZk4=
 
+uc.micro@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
 uc.micro@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
   integrity sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==
-
-uc.micro@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Refactors existing stalledRetry script to to fix possible OOM issue when the mongo cursor's `.toArray` method is called; `toArray` will attempt to load all the entries into memory, and, if the cursor result becomes too large, the script will fail due to memory issues. 

On a collection with 5.1M Entries (average entry size 1.1KB):

stalled retry (incomplete run):
![stalledRetry_mem_timeline](https://user-images.githubusercontent.com/9201089/113306377-dfb8cc80-92b8-11eb-82a4-1c410e8fb69a.png)

refactor (complete run):
![stalled_retry_rewrite_mem_timeline](https://user-images.githubusercontent.com/9201089/113306390-e1829000-92b8-11eb-9720-e81f35cb5784.png)

with the limits to match values set in stalled retry:
* batch: 10
* queue: 1000
* concurrent_requests: 5 

(blue: mem in use, gray: mem gc'd)