### PR TITLE
bugfix: S3C-3855 add "content-length" header to sproxyd requests

### DIFF
--- a/repairDuplicateVersions.js
+++ b/repairDuplicateVersions.js
@@ -249,6 +249,9 @@ function copySproxydKey(objectUrl, sproxydKey, cb) {
             path: sproxydDestUrl.pathname,
             method: 'PUT',
             agent: httpAgent,
+            headers: {
+                'Content-Length': Number.parseInt(sourceRes.headers['content-length'], 10),
+            },
         }, targetRes => {
             if (targetRes.statusCode !== 200) {
                 log.error('sproxyd returned HTTP error code', {


### PR DESCRIPTION
In repairDuplicateVersions.js, add the "content-length" header for
sproxyd PUT requests, instead of using chunked transfer-encoding.

The patch was made by @rahulreddy then applied and tested at customer
platform.