### PR TITLE
surpress error

### DIFF
--- a/autoRetryFailedCRR-S3C.js
+++ b/autoRetryFailedCRR-S3C.js
@@ -161,7 +161,13 @@ function _requeueObject(bucket, key, versionId, counters, cb) {
                 next(err);
             });
         },
-    ], cb);
+    ], err => {
+        if (err) {
+            log.error('error in _requeueObject waterfall',
+                      { error: err.message });
+        }
+        return cb();
+    });
     /* eslint-enable no-param-reassign */
 }
 


### PR DESCRIPTION
eachLimit will exit prematurely if an error is bubbled up from _requeueObject. However, suppressing the error in the async.waterfall callback allows the retry logic to continue. 