### PR TITLE
improvement: S3UTILS-7 requeue failed CRR to kafka topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "async": "^2.6.1",
     "aws-sdk": "^2.333.0",
     "heapdump": "^0.3.15",
+    "node-rdkafka": "2.2.0",
+    "node-schedule": "^1.3.2",
     "node-uuid": "^1.4.8",
     "werelogs": "scality/werelogs",
     "zenkoclient": "scality/zenkoclient#5c7f655"

--- a/requeueFailedCRRCronJob.js
+++ b/requeueFailedCRRCronJob.js
@@ -1,0 +1,284 @@
+const { waterfall, doWhilst, eachLimit, retry } = require('async');
+const http = require('http');
+const { Producer } = require('node-rdkafka');
+const { scheduleJob } = require('node-schedule');
+
+const { errors } = require('arsenal');
+const VID_SEP = require('arsenal').versioning.VersioningConstants
+      .VersionId.Separator;
+const { Logger } = require('werelogs');
+
+const BackbeatClient = require('./BackbeatClient');
+
+const log = new Logger('s3utils::requeueFailedCRRCronJob');
+const {
+    CLOUDSERVER_ENDPOINT,
+    BACKBEAT_API_ENDPOINT,
+    ACCESS_KEY,
+    SECRET_KEY,
+    SITE_NAME,
+    KAFKA_HOSTS,
+    KAFKA_TOPIC,
+} = process.env;
+const CRON_RULE = process.env.CRON_RULE || '0 */6 * * *';
+
+
+if (!CLOUDSERVER_ENDPOINT) {
+    throw new Error('CLOUDSERVER_ENDPOINT not defined');
+}
+if (!BACKBEAT_API_ENDPOINT) {
+    throw new Error('BACKBEAT_API_ENDPOINT not defined');
+}
+if (!ACCESS_KEY) {
+    throw new Error('ACCESS_KEY not defined');
+}
+if (!SECRET_KEY) {
+    throw new Error('SECRET_KEY not defined');
+}
+if (!SITE_NAME) {
+    throw new Error('missing SITE_NAME environment variable, must be set to' +
+                    ' the value of "site" property in the CRR configuration');
+}
+if (!KAFKA_HOSTS) {
+    throw new Error('KAFKA_HOSTS not defined');
+}
+if (!KAFKA_TOPIC) {
+    throw new Error('KAFKA_TOPIC not defined');
+}
+
+const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+const PRODUCER_RETRY_DELAY_MS = 5000;
+const PRODUCER_MAX_RETRIES = 60;
+const PRODUCER_POLL_INTERVAL_MS = 2000;
+
+const bbOptions = {
+    accessKeyId: ACCESS_KEY,
+    secretAccessKey: SECRET_KEY,
+    endpoint: CLOUDSERVER_ENDPOINT,
+    region: 'us-east-1',
+    sslEnabled: false,
+    s3ForcePathStyle: true,
+    apiVersions: { s3: '2006-03-01' },
+    signatureVersion: 'v4',
+    signatureCache: false,
+    httpOptions: {
+        timeout: 0,
+        agent: new http.Agent({ keepAlive: true }),
+    },
+};
+
+const bb = new BackbeatClient(bbOptions);
+
+const producer = new Producer({
+    'metadata.broker.list': KAFKA_HOSTS,
+    'message.max.bytes': PRODUCER_MESSAGE_MAX_BYTES,
+}, {
+});
+
+let requeueInProgress = false;
+let stopRequest = false;
+
+function _requeueObject(bucket, key, versionId, counters, cb) {
+    /* eslint-disable no-param-reassign */
+    if (stopRequest) {
+        return process.nextTick(cb);
+    }
+    return waterfall([
+        // get object blob
+        next => bb.getMetadata({
+            Bucket: bucket,
+            Key: key,
+            VersionId: versionId,
+        }, (err, mdRes) => {
+            if (err) {
+                log.error('error getting metadata of object', {
+                    bucket,
+                    key,
+                    error: err.message,
+                });
+                ++counters.errors;
+            }
+            next(err, mdRes);
+        }),
+        (mdRes, next) => {
+            const objMD = JSON.parse(mdRes.Body);
+            if (!objMD.replicationInfo ||
+                objMD.replicationInfo.status !== 'FAILED') {
+                log.info('skipping object: not FAILED', {
+                    bucket,
+                    key,
+                    versionId,
+                    status: objMD.replicationInfo ?
+                        objMD.replicationInfo.status : 'NEW',
+                });
+                ++counters.skipped;
+                return next();
+            }
+            const objSize = objMD['content-length'];
+            // reset to PENDING
+            objMD.replicationInfo.status = 'PENDING';
+            objMD.replicationInfo.backends[0].status = 'PENDING';
+            const mdBlob = JSON.stringify(objMD);
+            // create an entry as if coming from the raft log
+            const entry = JSON.stringify({
+                type: 'put',
+                bucket,
+                key: `${key}${VID_SEP}${objMD.versionId}`,
+                value: mdBlob,
+            });
+            return retry({
+                times: PRODUCER_MAX_RETRIES,
+                interval: PRODUCER_RETRY_DELAY_MS,
+            }, attemptDone => {
+                try {
+                    producer.produce(
+                        KAFKA_TOPIC,
+                        null, // partition
+                        new Buffer(entry), // value
+                        `${bucket}/${key}`, // key (for keyed partitioning)
+                        Date.now(), // timestamp
+                        null);
+                    log.info('requeued object version for replication', {
+                        bucket,
+                        key,
+                        versionId,
+                    });
+                    ++counters.requeued;
+                    counters.requeuedBytes += objSize;
+                    return attemptDone();
+                } catch (err) {
+                    log.error('error producing entry to kafka, retrying', {
+                        bucket,
+                        key,
+                        error: err.message,
+                    });
+                    return attemptDone(err);
+                }
+            }, err => {
+                if (err) {
+                    log.error('give up producing entry to kafka after retries',
+                              { bucket, key, error: err.message });
+                    ++counters.errors;
+                }
+                next(err);
+            });
+        },
+    ], err => {
+        if (err) {
+            log.error('error in _requeueObject waterfall',
+                      { error: err.message });
+        }
+        return cb();
+    });
+    /* eslint-enable no-param-reassign */
+}
+
+function _requeueAll() {
+    log.info('starting requeuing task');
+    const counters = {
+        requeued: 0,
+        requeuedBytes: 0,
+        skipped: 0,
+        errors: 0,
+    };
+    let marker = undefined;
+    requeueInProgress = true;
+    doWhilst(
+        batchDone => {
+            log.info('requeuing task progress', counters);
+            let url = `${BACKBEAT_API_ENDPOINT}/_/crr/failed?sitename=${SITE_NAME}`;
+            if (marker !== undefined) {
+                url += `&marker=${marker}`;
+            }
+            const failedReq = http.request(url, res => {
+                const bodyChunks = [];
+                res.on('data', chunk => bodyChunks.push(chunk));
+                res.on('error', err => {
+                    log.error('error receiving response body for the list of failed CRR', {
+                        error: err.message,
+                    });
+                    return batchDone(err);
+                });
+                res.on('end', () => {
+                    const body = Buffer.concat(bodyChunks).toString();
+                    if (res.statusCode !== 200) {
+                        log.error('request to retrieve list of failed CRR returned HTTP error status', {
+                            errorCode: res.statusCode,
+                            error: body,
+                        });
+                        return batchDone(errors.InternalError);
+                    }
+                    let result;
+                    try {
+                        result = JSON.parse(body);
+                    } catch (err) {
+                        log.error('invalid response: not JSON');
+                        return batchDone(errors.InternalError);
+                    }
+                    marker = result.NextMarker;
+                    return eachLimit(
+                        result.Versions, 10,
+                        (version, objDone) => _requeueObject(
+                            version.Bucket, version.Key, version.VersionId, counters, objDone),
+                        () => batchDone(null, result.IsTruncated));
+                });
+            });
+            failedReq.on('error', err => {
+                log.error('error sending request to retrieve list of failed CRR', {
+                    error: err.message,
+                });
+                return batchDone(err);
+            });
+            failedReq.end();
+        },
+        isTruncated => isTruncated && !stopRequest,
+        () => {
+            requeueInProgress = false;
+            if (stopRequest) {
+                log.info('aborted requeuing task', counters);
+                producer.disconnect();
+            } else {
+                log.info('completed requeuing task', counters);
+            }
+        });
+}
+
+let cronJob = null;
+
+producer.connect();
+producer.on('ready', () => {
+    producer.setPollInterval(PRODUCER_POLL_INTERVAL_MS);
+    log.info('process is ready', { cronRule: CRON_RULE });
+    cronJob = scheduleJob(CRON_RULE, _requeueAll);
+});
+producer.on('event.error', error => {
+    // This is a bit hacky: the "broker transport failure"
+    // error occurs when the kafka broker reaps the idle
+    // connections every few minutes, and librdkafka handles
+    // reconnection automatically anyway, so we ignore those
+    // harmless errors (moreover with the current
+    // implementation there's no way to access the original
+    // error code, so we match the message instead).
+    if (!['broker transport failure',
+          'all broker connections are down']
+        .includes(error.message)) {
+        log.error('error with producer', {
+            error: error.message,
+        });
+    }
+});
+
+function stop(signal) {
+    log.info('received signal, exiting', { signal });
+    if (cronJob) {
+        cronJob.cancel();
+    }
+    if (requeueInProgress) {
+        stopRequest = true;
+    } else {
+        producer.disconnect();
+    }
+}
+
+process.on('SIGTERM', () => stop('SIGTERM'));
+process.on('SIGINT', () => stop('SIGINT'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,6 +705,13 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+bindings@1.x:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bindings@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
@@ -860,6 +867,14 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1089,6 +1104,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cron-parser@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
+  integrity sha512-s4odpheTyydAbTBQepsqd2rNWGa2iV3cyo8g7zbI2QQYGLVsfbhmwukayS1XHppe02Oy1fg7mg6xoaraVJeEcg==
+  dependencies:
+    is-nan "^1.3.0"
+    moment-timezone "^0.5.31"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1208,7 +1231,7 @@ deferred-leveldown@~5.3.0:
     abstract-leveldown "~6.2.1"
     inherits "^2.0.3"
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1795,6 +1818,11 @@ file-entry-cache@^1.1.1:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -1952,6 +1980,15 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -2093,6 +2130,11 @@ has-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
+has-symbols@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2129,7 +2171,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -2495,6 +2537,14 @@ is-my-json-valid@^2.10.0:
     is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-nan@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -3389,6 +3439,11 @@ lodash@^4.17.14, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+long-timeout@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
+  integrity sha1-lyHXiLR+C8taJMLivuGg2lXatRQ=
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -3635,6 +3690,18 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.31:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 mongodb-core@3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.7.tgz#fe61853a6a6acbd2046c91794e5325ecad85428a"
@@ -3668,6 +3735,11 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
+
+nan@2.x:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nan@^2.13.2:
   version "2.14.2"
@@ -3770,6 +3842,23 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-rdkafka@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.2.0.tgz#a9d1928c7785897639898ed81a0aa4c5336736a2"
+  integrity sha1-qdGSjHeFiXY5iY7YGgqkxTNnNqI=
+  dependencies:
+    bindings "1.x"
+    nan "2.x"
+
+node-schedule@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-1.3.3.tgz#f8e01c5fb9597f09ecf9c4c25d6938e5e7a06f48"
+  integrity sha512-uF9Ubn6luOPrcAYKfsXWimcJ1tPFtQ8I85wb4T3NgJQrXazEzojcFZVk46ZlLHby3eEJChgkV/0T689IsXh2Gw==
+  dependencies:
+    cron-parser "^2.18.0"
+    long-timeout "0.1.1"
+    sorted-array-functions "^1.3.0"
 
 node-uuid@^1.4.8:
   version "1.4.8"
@@ -4794,6 +4883,11 @@ socket.io@~2.2.0:
     socket.io-adapter "~1.1.0"
     socket.io-client "2.2.0"
     socket.io-parser "~3.3.0"
+
+sorted-array-functions@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
+  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
 
 source-map-resolve@^0.5.0:
   version "0.5.2"


### PR DESCRIPTION
Fork the autoRetryFailedCRR Zenko script to requeueFailedCRRCronJob:

- make it work for S3C

- requeue to the specified Kafka topic

- run in a cron schedule

This is a temporary solution until we productize the auto-retry logic.

@nicolas2bert @naren-rajendran This PR is almost identical to https://github.com/scality/s3utils/pull/117, except the script name has been changed and @watsaqat patch integrated (https://github.com/scality/s3utils/pull/141). Would you mind having a quick look since you already reviewed the original PR and don't need to go through all the script code again?

All reviewers, feel free to suggest an alternative name for the script if you don't like this one for any reason, I am not deeply satisfied with this name but could not find something better.