### PR TITLE
INTEGRATION [PR#154 > development/1.10] update existing object key in map to use lower version

### DIFF
--- a/tests/unit/SproxydKeysScan/DuplicateKeysWindowTest.js
+++ b/tests/unit/SproxydKeysScan/DuplicateKeysWindowTest.js
@@ -1,6 +1,5 @@
-const { BoundedMap, MultiMap, SproxydKeysProcessor } = require('../../../SproxydKeysScan/DuplicateKeysWindow');
-const { DuplicateSproxydKeyFoundHandler } = require('../../../SproxydKeysScan/SproxydKeysSubscribers');
-
+const { BoundedMap, MultiMap } = require('../../../SproxydKeysScan/DuplicateKeysWindow');
+const { setupProcessor } = require('../../utils/setupProcessor');
 const randomize = require('randomatic');
 const range = require('lodash/range');
 
@@ -65,18 +64,8 @@ describe('DuplicateKeysWindow', () => {
     describe('SproxydKeyProcessor', () => {
         const windowSize = 10;
 
-        const setupProcessor = windowSize => {
-            const subscribers = new MultiMap();
-            const duplicateHandler = new DuplicateSproxydKeyFoundHandler();
-            duplicateHandler._repairObject = jest.fn().mockReturnValue((err, res) => [err, res]);
-            subscribers.set('duplicateSproxydKeyFound', duplicateHandler);
-
-            const processor = new SproxydKeysProcessor(windowSize, subscribers);
-            return [processor, duplicateHandler];
-        };
-
         test('sets and updates keys when all unique keys are inserted', () => {
-            const [processor, duplicateHandler] = setupProcessor();
+            const [processor, duplicateHandler] = setupProcessor(windowSize);
 
             const objectKey = 'objectKey-1';
             const sproxydKeys = range(windowSize).map(() => randomize('A0', 40));
@@ -86,7 +75,7 @@ describe('DuplicateKeysWindow', () => {
         });
 
         test('calls duplicateSproxydKeyFound handler when duplicate is found', () => {
-            const [processor, duplicateHandler] = setupProcessor();
+            const [processor, duplicateHandler] = setupProcessor(windowSize);
 
             const objectKey1 = 'objectKey-1';
             const sproxydKeys = range(windowSize).map(() => randomize('A0', 40));
@@ -100,3 +89,4 @@ describe('DuplicateKeysWindow', () => {
         });
     });
 });
+

--- a/tests/unit/SproxydKeysScan/SproxydKeysSubscribersTest.js
+++ b/tests/unit/SproxydKeysScan/SproxydKeysSubscribersTest.js
@@ -1,0 +1,34 @@
+const { setupProcessor } = require('../../utils/setupProcessor');
+const randomize = require('randomatic');
+const range = require('lodash/range');
+
+describe('SproxydKeysSubscribers', () => {
+    describe('DuplicateSproxydKeyFoundHandler', () => {
+        const [processor, duplicateHandler] = setupProcessor(10);
+
+        const key = 'test-2021-11-24T19-41-08-494Z/2\u000098362217123979999997RG001 ';
+        const version = () => `${randomize('0', 3)}.${randomize('0', 3)}`;
+
+        test('the higher (older) version is always repaired and then the lower (newer) version is set in map', () => {
+            range(100).forEach(() => {
+                const params = {
+                    objectKey: key + version(),
+                    existingObjectKey: key + version(),
+                    sproxydKey: '75FB916EF57176F3C28532E120D5FB59BDCF8020',
+                    context: processor,
+                    bucket: 'bucket-name',
+                };
+                const [newerVersion, olderVersion] = [params.objectKey, params.existingObjectKey].sort();
+
+                const [olderVersionURL, newerVersionURL] = [olderVersion, newerVersion]
+                    .map(obj => duplicateHandler._getObjectURL(params.bucket, obj));
+
+                duplicateHandler.handle(params);
+                expect(duplicateHandler._repairObject).toHaveBeenCalledWith(
+                      { objectUrl: olderVersionURL, objectUrl2: newerVersionURL }, expect.anything()
+                );
+                expect(processor.sproxydKeys.get(params.sproxydKey)).toEqual(newerVersion);
+            });
+        });
+    });
+});

--- a/tests/utils/setupProcessor.js
+++ b/tests/utils/setupProcessor.js
@@ -1,0 +1,14 @@
+const { MultiMap, SproxydKeysProcessor } = require('../../SproxydKeysScan/DuplicateKeysWindow');
+const { DuplicateSproxydKeyFoundHandler } = require('../../SproxydKeysScan/SproxydKeysSubscribers');
+
+const setupProcessor = windowSize => {
+    const subscribers = new MultiMap();
+    const duplicateHandler = new DuplicateSproxydKeyFoundHandler();
+    duplicateHandler._repairObject = jest.fn().mockReturnValue((err, res) => [err, res]);
+    subscribers.set('duplicateSproxydKeyFound', duplicateHandler);
+
+    const processor = new SproxydKeysProcessor(windowSize, subscribers);
+    return [processor, duplicateHandler];
+};
+
+module.exports = { setupProcessor };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #154.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.10/bugfix/S3UTILS-21-insert-lower-key-version-after-repair`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.10/bugfix/S3UTILS-21-insert-lower-key-version-after-repair
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.10/bugfix/S3UTILS-21-insert-lower-key-version-after-repair
```

Please always comment pull request #154 instead of this one.