### PR TITLE
INTEGRATION [PR#157 > development/1.10] refactor so that only env.js access process.env. Defaults are set in …

### DIFF
--- a/SproxydKeysScan/DuplicateKeysIngestion.js
+++ b/SproxydKeysScan/DuplicateKeysIngestion.js
@@ -4,12 +4,13 @@ const { SproxydKeysProcessor } = require('./DuplicateKeysWindow');
 const { subscribers } = require('./SproxydKeysSubscribers');
 const { Logger } = require('werelogs');
 const log = new Logger('s3utils:DuplicateKeysIngestion');
+const { env } = require('./env');
 
 const {
     BUCKETD_HOSTPORT,
     DUPLICATE_KEYS_WINDOW_SIZE,
     LOOKBACK_WINDOW,
-} = process.env;
+} = env;
 
 
 /**

--- a/SproxydKeysScan/env.js
+++ b/SproxydKeysScan/env.js
@@ -1,0 +1,9 @@
+const env = {
+    BUCKETD_HOSTPORT: process.env.BUCKETD_HOSTPORT,
+    SPROXYD_HOSTPORT: process.env.SPROXYD_HOSTPORT,
+    RAFT_SESSION_ID: process.env.RAFT_SESSION_ID,
+    RAFT_LOG_BATCH_SIZE: process.env.RAFT_LOG_BATCH_SIZE || 1000,
+    LOOKBACK_WINDOW: process.env.LOOKBACK_WINDOW || 10000,
+};
+
+module.exports = { env };

--- a/SproxydKeysScan/index.js
+++ b/SproxydKeysScan/index.js
@@ -2,16 +2,10 @@
 const { RaftJournalReader } = require('./DuplicateKeysIngestion');
 const { getSproxydAlias } = require('../repairDuplicateVersionsSuite');
 const { Logger } = require('werelogs');
+const { env } = require('./env');
 
 const log = new Logger('s3utils:SproxydKeysScan:run');
 
-const env = {
-    BUCKETD_HOSTPORT: process.env.BUCKETD_HOSTPORT,
-    SPROXYD_HOSTPORT: process.env.SPROXYD_HOSTPORT,
-    RAFT_SESSION_ID: process.env.RAFT_SESSION_ID,
-    RAFT_LOG_BATCH_SIZE: process.env.RAFT_LOG_BATCH_SIZE || 1000,
-    LOOKBACK_WINDOW: process.env.LOOKBACK_WINDOW || 10000,
-};
 
 const USAGE = `
 This script continously polls the Raft Journal of a given Raft session id.


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #157.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.10/bugfix/S3UTILS-24-fix-env-variables`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.10/bugfix/S3UTILS-24-fix-env-variables
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.10/bugfix/S3UTILS-24-fix-env-variables
```

Please always comment pull request #157 instead of this one.