### PR TITLE
ft: S3C-5190 continuous integrity check

### DIFF
--- a/compareBuckets/ArrayUtils.js
+++ b/compareBuckets/ArrayUtils.js
@@ -1,0 +1,88 @@
+function indexOf(arr, value) {
+    if (!arr.length) {
+        return -1;
+    }
+    let lo = 0;
+    let hi = arr.length - 1;
+
+    while (hi - lo > 1) {
+        const i = lo + ((hi - lo) >> 1);
+        if (arr[i] > value) {
+            hi = i;
+        } else {
+            lo = i;
+        }
+    }
+    if (arr[lo] === value) {
+        return lo;
+    }
+    if (arr[hi] === value) {
+        return hi;
+    }
+    return -1;
+}
+
+function indexAtOrBelow(arr, value) {
+    let i;
+    let lo;
+    let hi;
+
+    if (!arr.length || arr[0] > value) {
+        return -1;
+    }
+    if (arr[arr.length - 1] <= value) {
+        return arr.length - 1;
+    }
+
+    lo = 0;
+    hi = arr.length - 1;
+
+    while (hi - lo > 1) {
+        i = lo + ((hi - lo) >> 1);
+        if (arr[i] > value) {
+            hi = i;
+        } else {
+            lo = i;
+        }
+    }
+
+    return lo;
+}
+
+/*
+ * perform symmetric diff in O(m + n)
+ */
+function
+symDiff(k1, k2, v1, v2, cb) {
+    let i = 0;
+    let j = 0;
+    const n = k1.length;
+    const m = k2.length;
+
+    while (i < n && j < m) {
+        if (k1[i] < k2[j]) {
+            cb(v1[i]);
+            i++;
+        } else if (k2[j] < k1[i]) {
+            cb(v2[j]);
+            j++;
+        } else {
+            i++;
+            j++;
+        }
+    }
+    while (i < n) {
+        cb(v1[i]);
+        i++;
+    }
+    while (j < m) {
+        cb(v2[j]);
+        j++;
+    }
+}
+
+module.exports = {
+    indexOf,
+    indexAtOrBelow,
+    symDiff,
+};

--- a/compareBuckets/BucketdOplogInterface.js
+++ b/compareBuckets/BucketdOplogInterface.js
@@ -1,0 +1,222 @@
+/*
+ * Main interface for bucketd oplog management
+ *
+ * persist is an interface with the following methods:
+ * - constructor(params)
+ * - load(bucketName, persistData, cb(err, offset))
+ * - save(bucketName, persistData, offset, cb(err))
+
+ * persistData is an interface with the following methods:
+ * - constuctor(params)
+ * - initState(cb(err)): initialize the structure, e.g. initial bucket scan
+ * - loadState(stream, cb(err)): load the state
+ * - saveState(stream, cb(err)): save the state
+ */
+const async = require('async');
+const BucketClient = require('bucketclient').RESTClient;
+const { jsutil } = require('arsenal');
+const LogConsumer = require('arsenal').storage.metadata.bucketclient.LogConsumer;
+const { isMasterKey } = require('arsenal/lib/versioning/Version');
+const Flusher = require('./Flusher');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class BucketdOplogInterface {
+
+    constructor(params) {
+        let bkBootstrap = ['localhost:9000'];
+        if (params && params.bootstrap) {
+            bkBootstrap = params.bootstrap;
+        }
+        this.bkClient = new BucketClient(bkBootstrap);
+        this.backendRetryTimes = 3;
+        this.backendRetryInterval = 300;
+        this.bucketdOplogQuerySize = 20;
+        this.raftId = 2; // XXX use route
+        this.logger = new werelogs.Logger('BucketdOplogInterface');
+    }
+
+    start(bucketName, persist, persistData, flusherParams, cb) {
+        async.waterfall([
+            next => {
+                let cseq = undefined;
+                // get stored offset if we have it
+                // load persistData if present
+                persist.load(bucketName, persistData, (err, offset) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    cseq = offset;
+                    return next(null, cseq, persistData);
+                });
+            },
+            (cseq, persistData, next) => {
+                if (cseq !== undefined) {
+                    this.logger.info(`skipping cseq acquisition (cseq=${cseq})`,
+                                     { bucketName });
+                    return next(null, cseq, persistData, true);
+                }
+                this.logger.info('cseq acquisition',
+                                 { bucketName });
+                async.retry(
+                    {
+                        times: this.backendRetryTimes,
+                        interval: this.backendRetryInterval,
+                    },
+                    done => {
+                        this.bkClient.getRaftLog(
+                            this.raftId,
+                            1,
+                            1,
+                            true,
+                            null,
+                            (err, stream) => {
+                                if (err) {
+                                    this.logger.info('retrying getRaftLog', { err, bucketName });
+                                    return done(err);
+                                }
+                                const chunks = [];
+                                stream.on('data', chunk => {
+                                    chunks.push(chunk);
+                                });
+                                stream.on('end', () => {
+                                    const info = JSON.parse(Buffer.concat(chunks));
+                                    return done(null, info);
+                                });
+                                return undefined;
+                            });
+                    },
+                    (err, res) => {
+                        if (err) {
+                            this.logger.error('getRaftLog too many failures', { err, bucketName });
+                            return next(err);
+                        }
+                        return next(null, res.info.cseq, persistData, false);
+                    });
+                return undefined;
+            },
+            (cseq, persistData, skipListing, next) => {
+                if (skipListing) {
+                    this.logger.info(`skipping listing cseq=${cseq}`,
+                                     { bucketName });
+                    return next(null, cseq, persistData);
+                }
+                this.logger.info(`listing cseq=${cseq}`,
+                                 { bucketName });
+                persistData.initState(err => {
+                    if (err) {
+                        return next(err);
+                    }
+                    persist.save(
+                        bucketName, persistData, cseq, err => {
+                            if (err) {
+                                return next(err);
+                            }
+                            return next(null, cseq, persistData);
+                        });
+                    return undefined;
+                });
+                return undefined;
+            },
+            (cseq, persistData, next) => {
+                this.logger.info(`reading oplog raftId=${this.raftId} cseq=${cseq}`,
+                                 { bucketName });
+                // only way to get out of the loop in all cases
+                const nextOnce = jsutil.once(next);
+                const doStop = false;
+                // resume reading the oplog from cseq. changes are idempotent
+                // setup oplog manager
+                const flusher = new Flusher(bucketName, persist, persistData, flusherParams);
+                flusher.events.on('stop', () => nextOnce());
+                flusher.startFlusher();
+                const logConsumer = new LogConsumer({
+                    bucketClient: this.bkClient,
+                    raftSession: this.raftId,
+                });
+                let _cseq = cseq;
+                async.until(
+                    () => doStop,
+                    _next => {
+                        // console.error(
+                        // 'readRecords', _cseq, this.bucketdOplogQuerySize);
+                        logConsumer.readRecords({
+                            startSeq: _cseq,
+                            limit: this.bucketdOplogQuerySize,
+                        }, (err, record) => {
+                            if (err) {
+                                this.logger.error('readRecords error', { err, bucketName });
+                                // return _next(err);
+                                return setTimeout(() => _next(), 5000);
+                            }
+                            // console.error('record info', record.info);
+                            if (!record.log) {
+                                // nothing to read
+                                return setTimeout(() => _next(), 5000);
+                            }
+                            const seqs = [];
+                            record.log.on('data', chunk => {
+                                seqs.push(chunk);
+                            });
+                            record.log.on('end', () => {
+                                for (let i = 0; i < seqs.length; i++) {
+                                    if (seqs[i].db === bucketName) {
+                                        for (let j = 0; j < seqs[i].entries.length; j++) {
+                                            // console.info(i, j, seqs[i].db, seqs[i].entries[j]);
+                                            let opType;
+                                            const _item = {};
+                                            _item.key = seqs[i].entries[j].key;
+                                            if (seqs[i].entries[j].type !== undefined &&
+                                                seqs[i].entries[j].type === 'del') {
+                                                opType = 'del';
+                                                if (!isMasterKey(_item.key)) {
+                                                    // ignore for now
+                                                    return;
+                                                }
+                                            } else {
+                                                opType = 'put';
+                                                const _value = seqs[i].entries[j].value;
+                                                _item.value = {};
+                                                _item.value.versionId = _value.versionId;
+                                                _item.value.size = _value['content-length'];
+                                                _item.value.md5 = _value['content-md5'];
+                                            }
+                                            flusher.addEvent(
+                                                _item,
+                                                _cseq + i + 1,
+                                                opType);
+                                        }
+                                    }
+                                }
+                                flusher.flushQueue(err => {
+                                    if (err) {
+                                        return _next(err);
+                                    }
+                                    _cseq += seqs.length;
+                                    return _next();
+                                });
+                            });
+                            return undefined;
+                        });
+                    }, err => {
+                        if (err) {
+                            return nextOnce(err);
+                        }
+                        return nextOnce();
+                    });
+            },
+        ], err => {
+            if (err) {
+                return cb(err);
+            }
+            this.logger.info('returning',
+                             { bucketName });
+            return cb();
+        });
+    }
+}
+
+module.exports = BucketdOplogInterface;

--- a/compareBuckets/Flusher.js
+++ b/compareBuckets/Flusher.js
@@ -1,0 +1,136 @@
+const assert = require('assert');
+const events = require('events');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class Flusher {
+
+    // params:
+    // - stopAt: for tests
+    // - flusherTimeout: Flush timeout
+    // - interactive: if true flush is done manually
+    constructor(bucketName, persist, persistData, params) {
+        this.bucketName = bucketName;
+        this.persist = persist;
+        this.persistData = persistData;
+        // params
+        this.stopAt = -1;
+        this.flusherTimeout = 5000;
+        this.interactive = false;
+        if (params) {
+            if (params.stopAt !== undefined) {
+                this.stopAt = params.stopAt;
+            }
+            if (params.flusherTimeout !== undefined) {
+                this.flusherTimeout = params.flusherTimeout;
+            }
+            if (params.interactive !== undefined) {
+                this.interactive = params.interactive;
+            }
+        }
+        this.events = new events.EventEmitter();
+        this.addedQueue = [];
+        this.deletedQueue = [];
+        this.prevOffset = null;
+        this.offset = null;
+        this.pending = false;
+        this.logger = new werelogs.Logger('Daemon');
+    }
+
+    addEvent(item, offset, opType) {
+        // console.log('addEvent', this.bucketName, item, opType);
+        if (opType === 'put') {
+            this.addedQueue.push(item);
+        } else if (opType === 'del') {
+            this.deletedQueue.push(item);
+        } else {
+            assert(false);
+        }
+        this.offset = offset;
+    }
+
+    _flushQueue(cb) {
+        // console.log(this.prevOffset, this.offset);
+        if (this.offset === null ||
+            this.prevOffset === this.offset) {
+            if (cb) {
+                return process.nextTick(cb);
+            }
+            return undefined;
+        }
+        if (this.pending) {
+            if (cb) {
+                return process.nextTick(cb);
+            }
+            return undefined;
+        }
+        this.pending = true;
+        const addedQueue = this.addedQueue;
+        this.addedQueue = [];
+        const deletedQueue = this.deletedQueue;
+        this.deletedQueue = [];
+        const offset = this.offset;
+        this.prevOffset = this.offset;
+        // console.log('offset/queue', this.bucketName, offset, addedQueue, deletedQueue);
+        this.persistData.updateState(
+            addedQueue, deletedQueue,
+            err => {
+                if (err) {
+                    this.logger.error('error updating state', { err });
+                    this.pending = false;
+                    if (cb) {
+                        cb(err);
+                    }
+                    return undefined;
+                }
+                this.persist.save(
+                    this.bucketName,
+                    this.persistData,
+                    offset,
+                    err => {
+                        this.pending = false;
+                        if (err) {
+                            if (cb) {
+                                cb(err);
+                            }
+                            return undefined;
+                        }
+                        if (this.stopAt !== -1) {
+                            if (offset >= this.stopAt) {
+                                this.events.emit('stop');
+                            }
+                        }
+                        if (cb) {
+                            return cb();
+                        }
+                        return undefined;
+                    });
+                return undefined;
+            });
+        return undefined;
+    }
+
+    flushQueue(cb) {
+        if (this.interactive) {
+            return this._flushQueue(cb);
+        }
+        return process.nextTick(cb);
+    }
+
+    doFlush() {
+        this._flushQueue();
+        setTimeout(this.doFlush.bind(this), this.flusherTimeout);
+    }
+
+    startFlusher() {
+        if (!this.interactive) {
+            setTimeout(this.doFlush.bind(this), this.flusherTimeout);
+        }
+    }
+}
+
+module.exports = Flusher;

--- a/compareBuckets/MongoOplogInterface.js
+++ b/compareBuckets/MongoOplogInterface.js
@@ -1,0 +1,156 @@
+/*
+  fake backend that uses MongoDB for oplog (manual debug)
+
+  - start mongodb (>=3.6)
+  $ git clone github.com/scality/Zenko-MD
+  $ cd Zenko-MD
+  $ MDP_DRIVER=mongodb npm start
+*/
+const MongoClient = require('mongodb').MongoClient;
+const bson = require('bson');
+const async = require('async');
+const Flusher = require('./Flusher');
+const { jsutil } = require('arsenal');
+const { isMasterKey } = require('arsenal/lib/versioning/Version');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+const databaseName = 'metadata';
+
+class MongoOplogInterface {
+
+    constructor() {
+        this.logger = new werelogs.Logger('MongoOplogInterface');
+    }
+
+    start(bucketName, persist, persistData, stopAt, cb) {
+        let db;
+        let collection;
+        async.waterfall([
+            next => {
+                MongoClient.connect(
+                    'mongodb://localhost:27017',
+                    (err, client) => {
+                        if (err) {
+                            this.logger.error('error connecting to mongodb', { err, bucketName });
+                            return next(err);
+                        }
+                        db = client.db(databaseName, {
+                            ignoreUndefined: true,
+                        });
+                        collection = db.collection(bucketName);
+                        return next();
+                    });
+            },
+            next => {
+                let resumeToken = undefined;
+                // get stored offset if we have it
+                // load persistData if we have it
+                persist.load(bucketName, persistData, (err, offset) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    if (offset && offset._data) {
+                        resumeToken = {};
+                        resumeToken._data = new bson.Binary(new Buffer(offset._data, 'base64'));
+                    }
+                    return next(null, resumeToken, persistData);
+                });
+            },
+            (resumeToken, persistData, next) => {
+                if (resumeToken !== undefined) {
+                    this.logger.info(
+                        `skipping resumeToken acquisition (resumeToken=${resumeToken})`,
+                        { bucketName });
+                    return next(null, resumeToken, persistData, true);
+                }
+                this.logger.info('resumeToken acquisition',
+                                 { bucketName });
+                const changeStream = collection.watch();
+                // big hack to extract resumeToken
+                changeStream.once('change', () => next(null, changeStream.resumeToken, persistData, false));
+                return undefined;
+            },
+            (resumeToken, persistData, skipListing, next) => {
+                if (skipListing) {
+                    this.logger.info(`skipping listing resumeToken=${resumeToken}`,
+                                     { bucketName });
+                    return next(null, resumeToken, persistData);
+                }
+                this.logger.info(`listing resumeToken=${resumeToken}`,
+                                 { bucketName });
+                persistData.initState(
+                    err => {
+                        if (err) {
+                            // eslint-disable-next-line
+                            console.error(err);
+                            process.exit(1);
+                        }
+                        persist.save(
+                            bucketName, persistData, resumeToken, err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                return next(null, resumeToken, persistData);
+                            });
+                        return undefined;
+                    });
+                return undefined;
+            },
+            (resumeToken, persistData, next) => {
+                this.logger.info(`reading oplog resumeToken=${resumeToken}`,
+                                 { bucketName });
+                const nextOnce = jsutil.once(next);
+                const flusher = new Flusher(bucketName, persist, persistData, null);
+                flusher.events.on('stop', () => nextOnce());
+                flusher.startFlusher();
+                // console.log('resumeToken', resumeToken);
+                const changeStream = collection.watch({ resumeAfter: resumeToken });
+                changeStream.on(
+                    'change', item => {
+                        if (item.ns.db === databaseName) {
+                            let opType;
+                            const _item = {};
+                            _item.key = item.documentKey._id;
+                            if (item.operationType === 'insert' ||
+                                item.operationType === 'replace') {
+                                _item.value = {};
+                                _item.value.versionId = item.fullDocument.value.versionId;
+                                _item.value.size = item.fullDocument.value['content-length'];
+                                _item.value.md5 = item.fullDocument.value['content-md5'];
+                            }
+                            if (item.operationType === 'insert') {
+                                opType = 'put';
+                            } else if (item.operationType === 'replace') {
+                                opType = 'put';
+                            } else if (item.operationType === 'delete') {
+                                opType = 'del';
+                                if (!isMasterKey(_item.key)) {
+                                    // ignore for now
+                                    return;
+                                }
+                            } else {
+                                return;
+                            }
+                            flusher.addEvent(
+                                _item,
+                                changeStream.resumeToken,
+                                opType);
+                        }
+                    });
+            }], err => {
+            if (err) {
+                return cb(err);
+            }
+            this.logger.info('returning',
+                             { bucketName });
+            return cb();
+        });
+    }
+}
+
+module.exports = MongoOplogInterface;

--- a/compareBuckets/PersistFileInterface.js
+++ b/compareBuckets/PersistFileInterface.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class PersistFileInterface {
+
+    constructor() {
+        this.folder = '/tmp';
+        this.logger = new werelogs.Logger('PersistFileInterface');
+        fs.access(this.folder, err => {
+            if (err) {
+                fs.mkdirSync(this.folder, { recursive: true });
+            }
+        });
+    }
+
+    getFileName(bucketName) {
+        return `${this.folder}/${bucketName}.json`;
+    }
+
+    getOffsetFileName(bucketName) {
+        return `${this.folder}/${bucketName}.offset.json`;
+    }
+
+    // cb(err, offset)
+    load(bucketName, persistData, cb) {
+        const fileName = this.getFileName(bucketName);
+        const offsetFileName = this.getOffsetFileName(bucketName);
+        let obj = {};
+        fs.readFile(
+            offsetFileName,
+            'utf-8', (err, data) => {
+                if (err) {
+                    if (err.code === 'ENOENT') {
+                        this.logger.info(`${offsetFileName} non-existent`);
+                    } else {
+                        this.logger.error('error loading', { err });
+                        return cb(err);
+                    }
+                } else {
+                    obj = JSON.parse(data);
+                }
+                if (fs.existsSync(fileName)) {
+                    const file = fs.createReadStream(fileName);
+                    persistData.loadState(file, err => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        this.logger.info(`${fileName} loaded: offset ${obj.offset}`);
+                        return cb(null, obj.offset);
+                    });
+                } else {
+                    this.logger.info(`${fileName} non-existent`);
+                    return cb(null, obj.offset);
+                }
+                return undefined;
+            });
+    }
+
+    // cb(err)
+    save(bucketName, persistData, offset, cb) {
+        const fileName = this.getFileName(bucketName);
+        const offsetFileName = this.getOffsetFileName(bucketName);
+        const file = fs.createWriteStream(fileName);
+        persistData.saveState(file, err => {
+            if (err) {
+                return cb(err);
+            }
+            const obj = {
+                offset,
+            };
+            fs.writeFile(
+                offsetFileName, JSON.stringify(obj),
+                'utf-8',
+                err => {
+                    if (err) {
+                        this.logger.error('error saving', { err });
+                        return cb(err);
+                    }
+                    this.logger.info(`${fileName} saved: offset ${offset}`);
+                    return cb();
+                });
+            return undefined;
+        });
+        return undefined;
+    }
+}
+
+module.exports = PersistFileInterface;

--- a/compareBuckets/PersistMemInterface.js
+++ b/compareBuckets/PersistMemInterface.js
@@ -1,0 +1,75 @@
+// fake backend for unit tests
+const assert = require('assert');
+const MemoryStream = require('memorystream');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class PersistMemInterface {
+
+    constructor() {
+        this.memoryStreams = {};
+        this.offsets = {};
+        this.logger = new werelogs.Logger('PersistMemInterface');
+    }
+
+    getOffset(bucketName) {
+        if (!this.offsets[bucketName]) {
+            return {};
+        }
+        return this.offsets[bucketName];
+    }
+
+    setOffset(bucketName, offset) {
+        if (!this.memoryStreams[bucketName]) {
+            this.memoryStreams[bucketName] = new MemoryStream();
+        }
+        if (!this.offsets[bucketName]) {
+            this.offsets[bucketName] = {};
+        }
+        Object.assign(
+            this.offsets[bucketName],
+            offset);
+    }
+
+    // cb(err, offset)
+    load(bucketName, persistData, cb) {
+        this.logger.info(`loading ${bucketName}`);
+        const stream = this.memoryStreams[bucketName];
+        const offset = this.offsets[bucketName];
+        if (stream === undefined) {
+            this.logger.info(`${bucketName} non-existent`);
+            return cb(null, undefined);
+        }
+        assert(offset !== undefined);
+        persistData.loadState(stream, err => {
+            if (err) {
+                return cb(err);
+            }
+            this.logger.info(`${bucketName} loaded: offset ${offset}`);
+            return cb(null, offset);
+        });
+        return undefined;
+    }
+
+    // cb(err)
+    save(bucketName, persistData, offset, cb) {
+        this.logger.info(`saving ${bucketName} offset ${JSON.stringify(offset)}`);
+        const stream = new MemoryStream();
+        this.memoryStreams[bucketName] = stream;
+        persistData.saveState(stream, err => {
+            if (err) {
+                return cb(err);
+            }
+            this.offsets[bucketName] = offset;
+            this.logger.info(`${bucketName} saved: offset ${offset}`);
+            return cb();
+        });
+    }
+}
+
+module.exports = PersistMemInterface;
+

--- a/compareBuckets/PersistRingInterface.js
+++ b/compareBuckets/PersistRingInterface.js
@@ -1,0 +1,244 @@
+// Ring backend that persists on Sproxyd and offsets on ZK
+// const assert = require('assert');
+const async = require('async');
+const { pipeline } = require('stream');
+const MemoryStream = require('memorystream');
+const zlib = require('zlib');
+const zookeeper = require('node-zookeeper-client');
+const Sproxy = require('sproxydclient');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class PersistRingInterface {
+
+    constructor() {
+        const zkConnectionString = 'localhost:2181';
+        const zkPath = '/persist-ring-interface';
+        const spBootstrap = ['localhost:8181'];
+        const spPath = '/proxy/DC1/'; // do not forget "/" at the end !!!
+        this.reqUid = 'persist-ring-interface-req-uid';
+        this.logger = new werelogs.Logger('PersistRingInterface');
+        this.zkClient = zookeeper.createClient(zkConnectionString);
+        this.zkPath = zkPath;
+        this.zkClient.connect();
+        this.zkClient.on('error', err => {
+            this.logger.error('error connecting', { err });
+        });
+        this.zkClient.once('connected', () => {
+            this.logger.info('connected');
+        });
+        this.spClient = new Sproxy({
+            bootstrap: spBootstrap,
+            path: spPath,
+        });
+    }
+
+    getZKPath(bucketName) {
+        return `${this.zkPath}/${bucketName}`;
+    }
+
+    // cb(err, offset)
+    load(bucketName, persistData, cb) {
+        this.logger.info(`loading ${bucketName}`);
+        async.waterfall([
+            next => {
+                this.zkClient.getData(
+                    this.getZKPath(bucketName),
+                    (err, data) => {
+                        if (err) {
+                            if (err.name === 'NO_NODE') {
+                                this.logger.info(`${bucketName} non-existent`);
+                            } else {
+                                this.logger.error(`getData ${bucketName} error`, { err });
+                            }
+                            return next(err);
+                        }
+                        return next(null, data);
+                    });
+            },
+            (data, next) => {
+                const _data = JSON.parse(data.toString());
+                this.spClient.get(
+                    _data.key,
+                    undefined,
+                    this.reqUid,
+                    (err, stream) => {
+                        if (err) {
+                            this.logger.error(`sproxyd ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        return next(null, _data, stream);
+                    });
+            },
+            (_data, stream, next) => {
+                const ostream = new MemoryStream();
+                pipeline(
+                    stream,
+                    zlib.createGunzip(),
+                    ostream,
+                    err => {
+                        if (err) {
+                            this.logger.error(`pipeline ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        return next(null, _data, ostream);
+                    });
+            },
+            (_data, stream, next) => {
+                persistData.loadState(stream, err => {
+                    if (err) {
+                        this.logger.error(`load ${bucketName} error`, { err });
+                        return next(err);
+                    }
+                    this.logger.info(`${bucketName} loaded: offset ${_data.offset}`);
+                    return next(null, _data);
+                });
+            }], (err, _data) => {
+            if (err) {
+                if (err.name === 'NO_NODE') {
+                    return cb(null, undefined);
+                }
+                this.logger.error(`load ${bucketName} error`, { err });
+                return cb(err);
+            }
+            return cb(null, _data.offset);
+        });
+    }
+
+    // cb(err)
+    save(bucketName, persistData, offset, cb) {
+        this.logger.info(`saving ${bucketName} offset ${offset}`);
+        async.waterfall([
+            next => {
+                const stream = new MemoryStream();
+                persistData.saveState(
+                    stream, err => {
+                        if (err) {
+                            this.logger.error(`save ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        return next(null, stream);
+                    });
+            },
+            (stream, next) => {
+                const ostream = new MemoryStream();
+                pipeline(
+                    stream,
+                    zlib.createGzip(),
+                    ostream,
+                    err => {
+                        if (err) {
+                            this.logger.error(`pipeline ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        return next(null, ostream);
+                    });
+            },
+            (stream, next) => {
+                const parameters = {
+                    bucketName,
+                    namespace: 'persist-ring-interface',
+                    owner: 'persist-ring-interface',
+                };
+                const size = stream._readableState.length;
+                this.spClient.put(
+                    stream,
+                    size,
+                    parameters,
+                    this.reqUid,
+                    (err, key) => {
+                        if (err) {
+                            this.logger.error(`sproxyd put ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        const newData = {};
+                        newData.offset = offset;
+                        newData.key = key;
+                        return next(null, newData);
+                    });
+            },
+            (newData, next) => {
+                this.zkClient.exists(
+                    this.getZKPath(bucketName),
+                    (err, stat) => {
+                        if (err) {
+                            this.logger.error(`exists ${bucketName} error`, { err });
+                            return next(err);
+                        }
+                        let doesExist = false;
+                        if (stat) {
+                            doesExist = true;
+                        }
+                        return next(null, newData, doesExist);
+                    });
+            },
+            (newData, doesExist, next) => {
+                if (doesExist) {
+                    this.zkClient.getData(
+                        this.getZKPath(bucketName),
+                        (err, _oldData) => {
+                            if (err) {
+                                this.logger.error(`getData ${bucketName} error`, { err });
+                                return next(err);
+                            }
+                            const oldData = JSON.parse(_oldData);
+                            return next(null, newData, oldData);
+                        });
+                } else {
+                    this.zkClient.mkdirp(
+                        this.getZKPath(bucketName),
+                        null,
+                        err => {
+                            if (err) {
+                                this.logger.error(`mkdirp ${bucketName} error`, { err });
+                                return next(err);
+                            }
+                            return next(null, newData, null);
+                        });
+                }
+            },
+            (newData, oldData, next) => {
+                const _newData = JSON.stringify(newData);
+                this.zkClient.setData(
+                    this.getZKPath(bucketName),
+                    new Buffer(_newData),
+                    err => {
+                        if (err) {
+                            this.logger.error(`setData ${bucketName} error`, { err });
+                            return cb(err);
+                        }
+                        this.logger.info(`${bucketName} saved: new key ${newData.key} offset ${offset}`);
+                        // console.log('oldData', oldData);
+                        if (oldData) {
+                            this.spClient.delete(
+                                oldData.key,
+                                this.reqUid,
+                                err => {
+                                    if (err) {
+                                        this.logger.error(
+                                            `sproxyd del ${bucketName} old key ${oldData.key} error`,
+                                            { err });
+                                        return next(err);
+                                    }
+                                    return next();
+                                });
+                        } else {
+                            return next();
+                        }
+                        return undefined;
+                    });
+            }], err => {
+            if (err) {
+                this.logger.error(`save ${bucketName} error`, { err });
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+}
+
+module.exports = PersistRingInterface;

--- a/compareBuckets/SortedSet.js
+++ b/compareBuckets/SortedSet.js
@@ -1,0 +1,52 @@
+const ArrayUtils = require('./ArrayUtils');
+
+class SortedSet {
+
+    constructor(obj) {
+        if (obj) {
+            this.keys = obj.keys;
+            this.values = obj.values;
+        } else {
+            this.clear();
+        }
+    }
+
+    clear() {
+        this.keys = [];
+        this.values = [];
+    }
+
+    getSize() {
+        return this.keys.length;
+    }
+
+    set(key, value) {
+        const index = ArrayUtils.indexAtOrBelow(this.keys, key);
+        if (this.keys[index] === key) {
+            this.values[index] = value;
+            return;
+        }
+        this.keys.splice(index + 1, 0, key);
+        this.values.splice(index + 1, 0, value);
+    }
+
+    isSet(key) {
+        const index = ArrayUtils.indexOf(this.keys, key);
+        return index >= 0;
+    }
+
+    get(key) {
+        const index = ArrayUtils.indexOf(this.keys, key);
+        return index >= 0 ? this.values[index] : undefined;
+    }
+
+    del(key) {
+        const index = ArrayUtils.indexOf(this.keys, key);
+        if (index >= 0) {
+            this.keys.splice(index, 1);
+            this.values.splice(index, 1);
+        }
+    }
+}
+
+module.exports = SortedSet;

--- a/compareBuckets/compareBuckets.js
+++ b/compareBuckets/compareBuckets.js
@@ -2,9 +2,16 @@
 /* eslint-disable no-console */
 /* eslint-disable comma-dangle */
 
+const assert = require('assert');
 const async = require('async');
+const SortedSet = require('./SortedSet');
 
 const { listBucketMasterKeys } = require('./utils');
+
+// const BucketdOplogInterface = require('./BucketdOplogInterface');
+const MongoOplogInterface = require('./MongoOplogInterface');
+const PersistFileInterface = require('./PersistFileInterface');
+const PersistMemInterface = require('./PersistMemInterface');
 
 function getReportObject(bucket, entry, verbose) {
     const md = JSON.parse(entry.value);
@@ -21,7 +28,7 @@ function getReportObject(bucket, entry, verbose) {
     return obj;
 }
 
-function compareObjectsReport(srcBucket, src, dstBucket, dst, options) {
+function compareObjectsReport(diffMgr, srcBucket, src, dstBucket, dst, options) {
     const srcMD = JSON.parse(src.value);
     const dstMD = JSON.parse(dst.value);
 
@@ -66,7 +73,7 @@ function compareObjectsReport(srcBucket, src, dstBucket, dst, options) {
     return null;
 }
 
-function compareBuckets(params, log, cb) {
+function compareBuckets(diffMgr, params, log, cb) {
     const {
         bucketdSrcParams,
         bucketdDstParams,
@@ -139,6 +146,7 @@ function compareBuckets(params, log, cb) {
                                 dstContents[dstIdx],
                                 verbose
                             ));
+                        diffMgr.srcAdd(dstContents[dstIdx], diffMgr.MismatchNoExist);
                         ++statusObj.dstProcessedCount;
                         ++statusObj.missingInSrcCount;
                         ++dstIdx;
@@ -153,6 +161,7 @@ function compareBuckets(params, log, cb) {
                                 srcContents[srcIdx],
                                 verbose
                             ));
+                        diffMgr.dstAdd(srcContents[srcIdx], diffMgr.MismatchNoExist);
                         ++statusObj.srcProcessedCount;
                         ++statusObj.missingInDstCount;
                         ++srcIdx;
@@ -167,6 +176,7 @@ function compareBuckets(params, log, cb) {
                                 srcContents[srcIdx],
                                 verbose
                             ));
+                        diffMgr.dstAdd(srcContents[srcIdx], diffMgr.MismatchNoExist);
                         ++statusObj.srcProcessedCount;
                         ++statusObj.missingInDstCount;
                         ++srcIdx;
@@ -180,6 +190,7 @@ function compareBuckets(params, log, cb) {
                                 dstContents[dstIdx],
                                 verbose
                             ));
+                        diffMgr.srcAdd(dstContents[dstIdx], diffMgr.MismatchNoExist);
                         ++statusObj.dstProcessedCount;
                         ++statusObj.missingInSrcCount;
                         ++dstIdx;
@@ -187,6 +198,7 @@ function compareBuckets(params, log, cb) {
                     }
 
                     const report = compareObjectsReport(
+                        diffMgr,
                         bucketdSrcParams.bucket,
                         srcContents[srcIdx],
                         bucketdDstParams.bucket,
@@ -221,7 +233,254 @@ function compareBuckets(params, log, cb) {
     );
 }
 
-module.exports = {
-    compareBuckets,
-    compareObjectsReport,
-};
+function updateMissingCount(diffMgr, source, incr) {
+    if (source === diffMgr.IdxSrc) {
+        // eslint-disable-next-line
+        diffMgr.params.statusObj.missingInSrcCount += incr;
+    } else {
+        // eslint-disable-next-line
+        diffMgr.params.statusObj.missingInDstCount += incr;
+    }
+}
+
+function genericUpdate(diffMgr, source, target, addQueue, delQueue) {
+    // console.log('genericUpdate', source, target);
+    assert(source === diffMgr.IdxSrc ||
+           source === diffMgr.IdxDst);
+    assert(target === diffMgr.IdxSrc ||
+           target === diffMgr.IdxDst);
+    addQueue.forEach(item => {
+        // console.log('update add', item);
+        const value = diffMgr.state[source].get(item.key);
+        if (value !== undefined) {
+            // console.log('found', item.key, value, item.value);
+            assert(value.mismatch === diffMgr.MismatchNoExist);
+            diffMgr.state[source].del(item.key);
+            updateMissingCount(diffMgr, source, -1);
+        } else {
+            // console.log('not found', item.key, item.value);
+            const _value = {};
+            Object.assign(_value, item.value);
+            _value.mismatch = diffMgr.MismatchNoExist;
+            diffMgr.state[target].set(item.key, _value);
+            updateMissingCount(diffMgr, target, 1);
+        }
+    });
+    delQueue.forEach(item => {
+        // console.log('update del', item);
+        const value = diffMgr.state[target].get(item.key);
+        if (value !== undefined) {
+            // console.log('found', item.key, value);
+            assert(value.mismatch === diffMgr.MismatchNoExist);
+            diffMgr.state[target].del(item.key);
+            updateMissingCount(diffMgr, target, -1);
+        } else {
+            // console.log('not found', item.key);
+            const _value = {};
+            Object.assign(_value, item.value);
+            _value.mismatch = diffMgr.MismatchNoExist;
+            diffMgr.state[source].set(item.key, _value);
+            updateMissingCount(diffMgr, source, 1);
+        }
+    });
+}
+
+class PersistDataTargetInterface {
+
+    constructor(diffMgr) {
+        this.diffMgr = diffMgr;
+    }
+
+    initState(cb) {
+        return process.nextTick(cb);
+    }
+
+    updateState(addQueue, delQueue, cb) {
+        this.diffMgr.params.statusObj.dstOplogProcessedPutCount += addQueue.length;
+        this.diffMgr.params.statusObj.dstOplogProcessedDelCount += delQueue.length;
+        genericUpdate(this.diffMgr,
+                      this.diffMgr.IdxDst,
+                      this.diffMgr.IdxSrc,
+                      addQueue,
+                      delQueue);
+        return process.nextTick(cb);
+    }
+
+    loadState(stream, cb) {
+        return process.nextTick(cb);
+    }
+
+    saveState(stream, cb) {
+        return process.nextTick(cb);
+    }
+}
+
+class DiffManager {
+
+    constructor(params, log) {
+        assert(params !== undefined);
+        this.params = params;
+        /*
+          bucketdSrcParams,
+          bucketdDstParams,
+          statusObj,
+          verbose,
+          compareVersionId,
+          compareObjectSize,
+        */
+        this.log = log;
+        this.srcPersist = new PersistFileInterface();
+        this.dstPersist = new PersistMemInterface();
+        this.dstOffset = {};
+        this.dstPersistData = new PersistDataTargetInterface(this);
+        this.srcOplogInterface = new MongoOplogInterface();
+        this.dstOplogInterface = new MongoOplogInterface();
+        this.state = [new SortedSet(), // src
+                      new SortedSet(), // dst
+                      this.dstOffset,
+                      this.params.statusObj];
+    }
+
+    get IdxSrc() {
+        return 0;
+    }
+
+    get IdxDst() {
+        return 1;
+    }
+
+    get MismatchNoExist() {
+        return 0;
+    }
+
+    // not yet supported
+    get MismatchContent() {
+        return 1;
+    }
+
+    dumpState() {
+        console.log('src', this.state[0].keys, this.state[0].values);
+        console.log('dst', this.state[1].keys, this.state[1].values);
+    }
+
+    start(cb) {
+        this.srcOplogInterface.start(
+            this.params.bucketdSrcParams.bucket,
+            this.srcPersist,
+            this,
+            -1,
+            cb);
+    }
+
+    startTarget() {
+        this.dstOplogInterface.start(
+            this.params.bucketdDstParams.bucket,
+            this.dstPersist,
+            this.dstPersistData,
+            -1,
+            err => {
+                if (err) {
+                    this.log.error('error on target bucket', { err });
+                    process.exit(1);
+                }
+                this.log.info('end on target bucket');
+                process.exit(0);
+            });
+    }
+
+    initState(cb) {
+        this.compareBuckets(err => {
+            this.startTarget();
+            return cb(err);
+        });
+    }
+
+    loadState(stream, cb) {
+        const chunks = [];
+        stream.on('data', chunk => {
+            chunks.push(chunk);
+        });
+        stream.on('end', () => {
+            const _state = JSON.parse(Buffer.concat(chunks));
+            Object.assign(this.dstOffset, _state[2]);
+            Object.assign(this.params.statusObj, _state[3]);
+            this.state = [new SortedSet(_state[this.IdxSrc]),
+                          new SortedSet(_state[this.IdxDst]),
+                          this.dstOffset,
+                          this.params.statusObj];
+            this.dstPersist.setOffset(
+                this.params.bucketdDstParams.bucket,
+                this.dstOffset);
+            this.startTarget();
+            return cb();
+        });
+    }
+
+    saveState(stream, cb) {
+        Object.assign(
+            this.dstOffset,
+            this.dstPersist.getOffset(this.params.bucketdDstParams.bucket));
+        stream.write(JSON.stringify(this.state));
+        stream.end();
+        return cb();
+    }
+
+    updateState(addQueue, delQueue, cb) {
+        this.params.statusObj.srcOplogProcessedPutCount += addQueue.length;
+        this.params.statusObj.srcOplogProcessedDelCount += delQueue.length;
+        genericUpdate(this, this.IdxSrc, this.IdxDst, addQueue, delQueue);
+        return process.nextTick(cb);
+    }
+
+    // item value is already parsed
+    _add(idx, item, mismatch) {
+        // console.log('add', idx, item, mismatch);
+        this.state[idx].set(item.key, {
+            mismatch,
+            versionId: item.value.versionId,
+            size: item.value.size,
+            md5: item.value.md5,
+        });
+    }
+
+    add(idx, item, mismatch) {
+        const _value = JSON.parse(item.value);
+        const _item = {
+            key: item.key,
+            value: {
+                versionId: _value.versionId,
+                size: _value['content-length'],
+                md5: _value['content-md5'],
+            },
+        };
+        return this._add(idx, _item, mismatch);
+    }
+
+    // add a missing object in src set
+    srcAdd(item, mismatch) {
+        return this.add(this.IdxSrc, item, mismatch);
+    }
+
+    // add a missing object in dst set
+    dstAdd(item, mismatch) {
+        return this.add(this.IdxDst, item, mismatch);
+    }
+
+    dump() {
+        console.log('state', this.state);
+    }
+
+    compareObjectsReport(srcBucket, src, dstBucket, dst, options) {
+        return compareObjectsReport(this, srcBucket, src, dstBucket, dst, options);
+    }
+
+    compareBuckets(cb) {
+        return compareBuckets(this, this.params, this.log, cb);
+    }
+
+    genericUpdate(source, target, addQueue, delQueue) {
+        return genericUpdate(this, source, target, addQueue, delQueue);
+    }
+}
+
+module.exports = DiffManager;

--- a/package.json
+++ b/package.json
@@ -30,10 +30,16 @@
     "arsenal": "github:scality/arsenal#8.1.12",
     "async": "^2.6.1",
     "aws-sdk": "^2.333.0",
+    "bson": "^4.0.0",
+    "bucketclient": "scality/bucketclient#8.1.0",
     "heapdump": "^0.3.15",
+    "memorystream": "^0.3.1",
+    "mongodb": "^3.0.1",
     "node-rdkafka": "2.2.0",
     "node-schedule": "^1.3.2",
+    "node-zookeeper-client": "^0.2.2",
     "node-uuid": "^1.4.8",
+    "sproxydclient": "github:scality/sproxydclient#8.0.2",
     "werelogs": "scality/werelogs",
     "zenkoclient": "scality/zenkoclient#5c7f655"
   },
@@ -43,6 +49,7 @@
     "eslint-config-scality": "github:scality/Guidelines#20dfffc",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-react": "^4.3.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "prando": "^6.0.1"
   }
 }

--- a/tests/unit/compareBuckets/ArrayUtils.js
+++ b/tests/unit/compareBuckets/ArrayUtils.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const symDiff = require('../../../compareBuckets/ArrayUtils').symDiff;
+
+describe('ArrayUtils', () => {
+    it('shall find symmetric difference', () => {
+        const arr1 = [2, 4, 5, 7, 8, 10, 12, 15];
+        const arr2 = [5, 8, 11, 12, 14, 15];
+        const arr3 = [];
+        symDiff(arr1, arr2, arr1, arr2, x => arr3.push(x));
+        assert.deepEqual(arr3, [2, 4, 7, 10, 11, 14]);
+    });
+});

--- a/tests/unit/compareBuckets/BucketInfo.json
+++ b/tests/unit/compareBuckets/BucketInfo.json
@@ -1,0 +1,26 @@
+{
+    "acl": {
+        "Canned": "private",
+        "FULL_CONTROL": [],
+        "WRITE": [],
+        "WRITE_ACP": [],
+        "READ": [],
+        "READ_ACP": []
+    },
+    "name": "BucketName",
+    "owner": "9d8fe19a78974c56dceb2ea4a8f01ed0f5fecb9d29f80e9e3b84104e4a3ea520",
+    "ownerDisplayName": "anonymousCoward",
+    "creationDate": "2018-06-04T17:45:42.592Z",
+    "mdBucketModelVersion": 8,
+    "transient": false,
+    "deleted": false,
+    "serverSideEncryption": null,
+    "versioningConfiguration": null,
+    "websiteConfiguration": null,
+    "locationConstraint": "us-east-1",
+    "readLocationConstraint": "us-east-1",
+    "cors": null,
+    "replicationConfiguration": null,
+    "lifecycleConfiguration": null,
+    "uid": "fea97818-6a9a-11e8-9777-e311618cc5d4"
+}

--- a/tests/unit/compareBuckets/BucketdOplogInterface.js
+++ b/tests/unit/compareBuckets/BucketdOplogInterface.js
@@ -1,0 +1,198 @@
+const async = require('async');
+const bucketInfo = require('./BucketInfo.json');
+const BucketdOplogInterface = require('../../../compareBuckets/BucketdOplogInterface');
+const MetadataWrapper = require('arsenal').storage.metadata.MetadataWrapper;
+const PersistMemInterface = require('../../../compareBuckets/PersistMemInterface');
+const Injector = require('./Injector');
+const http = require('http');
+const url = require('url');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class PersistDataInterface {
+
+    constructor() {
+        this.data = null;
+    }
+
+    initState(cb) {
+        this.data = {};
+        return process.nextTick(cb);
+    }
+
+    loadState(stream, cb) {
+        const chunks = [];
+        stream.on('data', chunk => {
+            chunks.push(chunk);
+        });
+        stream.on('end', () => {
+            this.data = JSON.parse(Buffer.concat(chunks));
+            return process.nextTick(cb);
+        });
+    }
+
+    saveState(stream, cb) {
+        stream.write(JSON.stringify(this.data));
+        stream.end();
+        return process.nextTick(cb);
+    }
+
+    updateState(addQueue, deleteQueue, cb) {
+        // console.log('addQueue', addQueue);
+        // console.log('deleteQueue', deleteQueue);
+        return process.nextTick(cb);
+    }
+}
+
+describe('BucketdOplogInterface', () => {
+    const logger = new werelogs.Logger('BucketOplogInterface');
+
+    const fakePort = 9090;
+    const fakeBucket = 'fake';
+    const fakeRaftId = 2;
+    const numObjs = 20000;
+    const fakeCseq = 20001;
+    let oplogInjected = false;
+    const numOplogSeqs = 100;
+    const oplogBatchSize = 2;
+    const endCseq = fakeCseq + numOplogSeqs;
+    const maxLimit = 2;
+    const oplogKeys = [];
+    const oplogValues = [];
+    let oplogKeysIdx = 0;
+
+    const params = {
+        bootstrap: [`localhost:${fakePort}`],
+    };
+
+    const bucketdOplog = new BucketdOplogInterface(params);
+    const memBackend = new MetadataWrapper(
+        'mem', {}, null, logger);
+    const injector = new Injector(memBackend);
+    const persist = new PersistMemInterface();
+
+    const requestListener = (req, res) => {
+        const _url = url.parse(req.url, true);
+        // console.error(_url.pathname, _url.query);
+        if (_url.pathname === `/_/raft_sessions/${fakeRaftId}/log`) {
+            const begin = _url.query.begin;
+            const limit = _url.query.limit;
+            if (begin === '1' && limit === '1') {
+                res.writeHead(200);
+                res.end(JSON.stringify(
+                    {
+                        info: {
+                            start: 1,
+                            cseq: fakeCseq,
+                            prune: 1,
+                        },
+                    }));
+            } else {
+                // console.error(begin, limit);
+                const realLimit = Math.min(limit, maxLimit);
+                async.until(
+                    () => oplogInjected,
+                    next => {
+                        // inject similar but different random objects
+                        // console.error('injecting...');
+                        injector.inject(
+                            fakeBucket,
+                            numOplogSeqs * oplogBatchSize,
+                            numObjs, 1,
+                            true, 'obj_', '_bis',
+                            oplogKeys, oplogValues,
+                            err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                oplogInjected = true;
+                                return next();
+                            });
+                    }, err => {
+                        if (err) {
+                            res.writeHead(404);
+                            res.end('error', err);
+                            return undefined;
+                        }
+                        if (begin < endCseq) {
+                            res.writeHead(200);
+                            const resp = {};
+                            resp.info = {
+                                start: begin,
+                                cseq: endCseq,
+                                prune: 1,
+                            };
+                            // console.error('replying', begin, endCseq, realLimit, oplogBatchSize, oplogKeysIdx);
+                            resp.log = [];
+                            for (let i = 0; i < realLimit; i++) {
+                                resp.log[i] = {};
+                                resp.log[i].db = fakeBucket;
+                                resp.log[i].method = 8;
+                                resp.log[i].entries = [];
+                                for (let j = 0; j < oplogBatchSize; j++) {
+                                    resp.log[i].entries[j] = {};
+                                    resp.log[i].entries[j].key = oplogKeys[oplogKeysIdx];
+                                    resp.log[i].entries[j].value = oplogValues[oplogKeysIdx];
+                                    oplogKeysIdx++;
+                                }
+                            }
+                            res.end(JSON.stringify(resp));
+                        } else {
+                            // console.error('end...');
+                        }
+                        return undefined;
+                    });
+            }
+        } else if (_url.pathname === `/default/bucket/${fakeBucket}`) {
+            const marker = _url.query.marker === '' ? null : _url.query.marker;
+            const maxKeys = parseInt(_url.query.maxKeys, 10);
+            // console.error('listing', marker, maxKeys);
+            memBackend.listObjects(fakeBucket, {
+                listingType: 'Delimiter',
+                marker,
+                maxKeys,
+            }, (err, result) => {
+                if (err) {
+                    res.writeHead(404);
+                    res.end('error', err);
+                    return undefined;
+                }
+                res.writeHead(200);
+                res.end(JSON.stringify(result));
+                return undefined;
+            });
+        }
+    };
+
+    beforeAll(done => {
+        const server = http.createServer(requestListener);
+        server.listen(fakePort);
+        async.waterfall([
+            next => memBackend.createBucket(fakeBucket, bucketInfo, logger, next),
+            next => injector.inject(
+                fakeBucket, numObjs, numObjs, 1, false, 'obj_', '', null, null, next),
+        ], done);
+    });
+
+    afterAll(done => {
+        memBackend.deleteBucket(fakeBucket, logger, done);
+    });
+
+    it('simulation', done => {
+        const oplogMgrParams = {
+            stopAt: numObjs + numOplogSeqs,
+            interactive: true,
+        };
+        const persistData = new PersistDataInterface();
+        bucketdOplog.start(
+            fakeBucket,
+            persist,
+            persistData,
+            oplogMgrParams,
+            done);
+    });
+});

--- a/tests/unit/compareBuckets/Injector.js
+++ b/tests/unit/compareBuckets/Injector.js
@@ -1,0 +1,165 @@
+const async = require('async');
+const assert = require('assert');
+const Prando = require('prando');
+const werelogs = require('werelogs');
+
+werelogs.configure({
+    level: 'info',
+    dump: 'error',
+});
+
+class Injector {
+
+    constructor(backend) {
+        this.backend = backend;
+        this.nOps = 0;
+        this.nPuts = 0;
+        this.nDeletes = 0;
+        this.rnd = new Prando(0);
+        this.logger = new werelogs.Logger('Injector');
+    }
+
+    printStats() {
+        // eslint-disable-next-line
+        console.error('nOps', this.nOps);
+        // eslint-disable-next-line
+        console.error('nPuts', this.nPuts);
+        // eslint-disable-next-line
+        console.error('nDeletes', this.nDeletes);
+    }
+
+    genKey(len) {
+        let result = '';
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        const charactersLen = characters.length;
+        for (let i = 0; i < len; i++) {
+            result += characters.charAt(
+                Math.floor(
+                    this.rnd.next() *
+                        charactersLen));
+        }
+        return result;
+    }
+
+    genBase16(len) {
+        let result = '';
+        const characters = 'abcdef0123456789';
+        const charactersLen = characters.length;
+        for (let i = 0; i < len; i++) {
+            result += characters.charAt(
+                Math.floor(
+                    this.rnd.next() *
+                        charactersLen));
+        }
+        return result;
+    }
+
+    _zeroPad(s, n, width) {
+        const _n = `${n}`;
+        return s + (_n.length >= width ? _n :
+            new Array(width - _n.length + 1).join('0') + _n);
+    }
+
+    inject(bucketName, numKeys, maxSeq, op, randomSeq, prefix, suffix, keys, values, cb) {
+        const injectParams = {};
+        injectParams.numKeys = numKeys;
+        injectParams.maxSeq = maxSeq;
+        injectParams.op = op;
+        injectParams.randomSeq = randomSeq;
+        injectParams.prefix = prefix;
+        injectParams.suffix = suffix;
+        return this.injectExt(
+            bucketName,
+            injectParams,
+            null,
+            keys,
+            values,
+            cb);
+    }
+
+    injectExt(bucketName, params, inputKeys, outputKeys, outputValues, cb) {
+        async.timesLimit(
+            params.numKeys,
+            10,
+            (n, next) => {
+                let key;
+                if (inputKeys) {
+                    const idx = Math.floor(this.rnd.next() * inputKeys.length);
+                    key = inputKeys[idx];
+                    inputKeys.splice(idx, 1);
+                } else {
+                    if (params.randomKey) {
+                        const len = Math.floor(this.rnd.next() * 255) + 1;
+                        key = this.genKey(len);
+                    } else {
+                        let x;
+                        if (params.randomSeq) {
+                            x = Math.floor(this.rnd.next() * params.maxSeq);
+                        } else {
+                            x = n;
+                        }
+                        key = this._zeroPad(params.prefix, x, 10) +
+                            params.suffix;
+                    }
+                }
+                if (outputKeys) {
+                    outputKeys.push(key);
+                }
+                // eslint-disable-next-line
+                const value = {
+                    versionId: this.genBase16(32),
+                    'content-length': Math.floor(this.rnd.next() * 64000),
+                    'content-md5': this.genBase16(32),
+                };
+                if (outputValues) {
+                    outputValues.push(value);
+                }
+                if (params.op === 1) {
+                    this.backend.putObjectMD(
+                        bucketName,
+                        key,
+                        value,
+                        {},
+                        this.logger,
+                        next);
+                    return undefined;
+                } else if (params.op === 0) {
+                    this.backend.deleteObjectMD(
+                        bucketName,
+                        key,
+                        {},
+                        this.logger,
+                        err => {
+                            if (err) {
+                                if (err.code !== 404) {
+                                    return next(err);
+                                }
+                            }
+                            return next();
+                        });
+                    return undefined;
+                }
+                return next(new Error('unknow op'));
+            },
+            err => {
+                if (err) {
+                    // eslint-disable-next-line
+                    console.error('inject error', err);
+                    process.exit(1);
+                }
+                if (cb) {
+                    return cb();
+                }
+                return undefined;
+            });
+    }
+}
+
+module.exports = Injector;
+
+describe('Injector', () => {
+    it('zeropad', () => {
+        const injector = new Injector();
+        assert(injector._zeroPad('foo', 42, 10) === 'foo0000000042');
+    });
+});

--- a/tests/unit/compareBuckets/PersistMem.js
+++ b/tests/unit/compareBuckets/PersistMem.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+const PersistMemInterface = require('../../../compareBuckets/PersistMemInterface');
+
+class PersistDataInterface {
+
+    constructor(obj) {
+        this.obj = obj;
+    }
+
+    loadState(stream, cb) {
+        const chunks = [];
+        stream.on('data', chunk => {
+            chunks.push(chunk);
+        });
+        stream.on('end', () => {
+            this.obj = JSON.parse(Buffer.concat(chunks));
+            return cb();
+        });
+    }
+
+    saveState(stream, cb) {
+        stream.write(JSON.stringify(this.obj));
+        stream.end();
+        return cb();
+    }
+}
+
+describe('Persist Mem', () => {
+    const persist = new PersistMemInterface();
+    const bucketName = 'foo';
+
+    it('basic operations', done => {
+        const pd1 = new PersistDataInterface({
+            foo: 'bar',
+            bar: {
+                qux: 42,
+                quuux: false,
+            },
+        });
+        const pd2 = new PersistDataInterface();
+        persist.save(bucketName, pd1, 42, err => {
+            if (err) {
+                return done(err);
+            }
+            persist.load(bucketName, pd2, err => {
+                if (err) {
+                    return done(err);
+                }
+                assert.deepEqual(pd1.obj, pd2.obj);
+                return done();
+            });
+            return undefined;
+        });
+    });
+});

--- a/tests/unit/compareBuckets/SortedSet.js
+++ b/tests/unit/compareBuckets/SortedSet.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const SortedSet = require('../../../compareBuckets/SortedSet');
+
+describe('SortedSet', () => {
+    it('basic', () => {
+        const set = new SortedSet();
+        set.set('foo', 'bar');
+        assert(set.isSet('foo'));
+        assert(!set.isSet('foo2'));
+        assert(set.get('foo') === 'bar');
+        set.set('foo', 'bar2');
+        assert(set.get('foo') === 'bar2');
+        set.del('foo');
+        assert(!set.isSet('foo'));
+    });
+});

--- a/tests/unit/compareBuckets/compareBuckets.js
+++ b/tests/unit/compareBuckets/compareBuckets.js
@@ -1,11 +1,9 @@
+const assert = require('assert');
 const utils = require('../../../compareBuckets/utils');
 
 const listBucketMasterKeys = jest.spyOn(utils, 'listBucketMasterKeys');
 
-const {
-    compareBuckets,
-    compareObjectsReport,
-} = require('../../../compareBuckets/compareBuckets');
+const DiffManager = require('../../../compareBuckets/compareBuckets');
 const DummyLogger = require('../../mocks/DummyLogger');
 
 const log = new DummyLogger();
@@ -62,7 +60,8 @@ describe('compareBuckets', () => {
         dstStack.push([false, '', []]);
         srcStack.push([false, '', []]);
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('');
             expect(status.dstKeyMarker).toEqual('');
@@ -80,7 +79,8 @@ describe('compareBuckets', () => {
         );
         dstStack.push([false, '', []]);
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('3');
             expect(status.dstKeyMarker).toEqual('');
@@ -98,7 +98,8 @@ describe('compareBuckets', () => {
             [false, '3', [newEntry('1'), newEntry('2'), newEntry('3')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('');
             expect(status.dstKeyMarker).toEqual('3');
@@ -118,7 +119,8 @@ describe('compareBuckets', () => {
             [false, '6', [newEntry('4'), newEntry('5'), newEntry('6')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('3');
             expect(status.dstKeyMarker).toEqual('6');
@@ -143,7 +145,8 @@ describe('compareBuckets', () => {
             [true, '4', [newEntry('4')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('3');
             expect(status.dstKeyMarker).toEqual('6');
@@ -172,7 +175,8 @@ describe('compareBuckets', () => {
             [true, '2', [newEntry('0'), newEntry('1'), newEntry('2')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('9');
             expect(status.dstKeyMarker).toEqual('9');
@@ -201,7 +205,8 @@ describe('compareBuckets', () => {
             [true, '12', [newEntry('10'), newEntry('11'), newEntry('12')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('9');
             expect(status.dstKeyMarker).toEqual('19');
@@ -229,7 +234,8 @@ describe('compareBuckets', () => {
             [true, '0', [newEntry('0')]]
         );
 
-        compareBuckets(params, log, err => {
+        const diffMgr = new DiffManager(params, log);
+        diffMgr.compareBuckets(err => {
             expect(err).toBeNull();
             expect(status.srcKeyMarker).toEqual('9');
             expect(status.dstKeyMarker).toEqual('9');
@@ -262,7 +268,8 @@ describe('commpareObjectsReports', () => {
     });
 
     it('should return null if compare options are not set', () => {
-        const report = compareObjectsReport(
+        const diffMgr = new DiffManager({ statusObj: {} }, log);
+        const report = diffMgr.compareObjectsReport(
             'sourceBucket',
             { key: 'key1', value: objectMDVersion1Size100 },
             'destinationBucket',
@@ -274,7 +281,8 @@ describe('commpareObjectsReports', () => {
     });
 
     it('should return report if content-length does match', () => {
-        const report = compareObjectsReport(
+        const diffMgr = new DiffManager({ statusObj: {} }, log);
+        const report = diffMgr.compareObjectsReport(
             'sourceBucket',
             { key: 'key1', value: objectMDVersion1Size100 },
             'destinationBucket',
@@ -301,7 +309,8 @@ describe('commpareObjectsReports', () => {
     });
 
     it('should return report if content-length does not match', () => {
-        const report = compareObjectsReport(
+        const diffMgr = new DiffManager({ statusObj: {} }, log);
+        const report = diffMgr.compareObjectsReport(
             'sourceBucket',
             { key: 'key1', value: objectMDVersion1Size100 },
             'destinationBucket',
@@ -329,7 +338,8 @@ describe('commpareObjectsReports', () => {
     });
 
     it('should return report if version-id does not match', () => {
-        const report = compareObjectsReport(
+        const diffMgr = new DiffManager({ statusObj: {} }, log);
+        const report = diffMgr.compareObjectsReport(
             'sourceBucket',
             { key: 'key1', value: objectMDVersion1Size100 },
             'destinationBucket',
@@ -356,7 +366,8 @@ describe('commpareObjectsReports', () => {
     });
 
     it('should return report if version-id does not match', () => {
-        const report = compareObjectsReport(
+        const diffMgr = new DiffManager({ statusObj: {} }, log);
+        const report = diffMgr.compareObjectsReport(
             'sourceBucket',
             { key: 'key1', value: objectMDVersion1Size100 },
             'destinationBucket',
@@ -381,5 +392,135 @@ describe('commpareObjectsReports', () => {
             },
             error: 'destination object version-id does not match source object',
         });
+    });
+});
+
+describe('genericUpdate', () => {
+    const status = {
+        srcProcessedCount: 0,
+        dstProcessedCount: 0,
+        missingInSrcCount: 0,
+        missingInDstCount: 0,
+        dstBucketInProgress: null,
+        srcBucketInProgress: null,
+        srcKeyMarker: '',
+        dstKeyMarker: '',
+    };
+
+    const params = {
+        bucketdSrcParams: {
+            bucket: 'src',
+            marker: '',
+            hostPort: '',
+        },
+        bucketdDstParams: {
+            bucket: 'dst',
+            marker: '',
+            hostPort: '',
+        },
+        statusObj: status,
+    };
+
+    // for add events
+    const obj1 = {
+        key: 'obj1',
+        value: {
+            versionId: 'a4f22157b6ad554d0e35fd5a7bb2c560',
+            size: 46573,
+            md5: '2df22eba370784b0af011f06a633ce8a',
+        },
+    };
+
+    // for delete events
+    const _obj1 = {
+        key: 'obj1',
+        value: {
+            versionId: 'a4f22157b6ad554d0e35fd5a7bb2c560',
+            // size and md5 are note available in bucketd
+        },
+    };
+
+    it('a new object on source shall be added on target', () => {
+        const addQueue = [];
+        const deleteQueue = [];
+        const diffMgr = new DiffManager(params, log);
+        params.statusObj.missingInDstCount = 0;
+        params.statusObj.missingInSrcCount = 0;
+        addQueue.push(obj1);
+        diffMgr.genericUpdate(
+            diffMgr.IdxSrc,
+            diffMgr.IdxDst,
+            addQueue,
+            deleteQueue);
+        assert(diffMgr.state[diffMgr.IdxSrc].getSize() === 0);
+        assert(diffMgr.state[diffMgr.IdxDst].getSize() === 1);
+        assert(diffMgr.state[diffMgr.IdxDst].get(obj1.key).mismatch === diffMgr.MismatchNoExist);
+        assert(diffMgr.state[diffMgr.IdxDst].get(obj1.key).versionId === obj1.value.versionId);
+        assert(diffMgr.params.statusObj.missingInSrcCount === 0);
+        assert(diffMgr.params.statusObj.missingInDstCount === 1);
+    });
+
+    it('a missing object on target shall be removed if received identical in target', () => {
+        const addQueue = [];
+        const deleteQueue = [];
+        const diffMgr = new DiffManager(params, log);
+        diffMgr._add(
+            diffMgr.IdxDst,
+            obj1,
+            diffMgr.MismatchNoExist);
+        params.statusObj.missingInDstCount = 1;
+        params.statusObj.missingInSrcCount = 0;
+        addQueue.push(obj1);
+        diffMgr.genericUpdate(
+            diffMgr.IdxDst,
+            diffMgr.IdxSrc,
+            addQueue,
+            deleteQueue);
+        assert(diffMgr.state[diffMgr.IdxSrc].getSize() === 0);
+        assert(diffMgr.state[diffMgr.IdxDst].getSize() === 0);
+        assert(diffMgr.params.statusObj.missingInSrcCount === 0);
+        assert(diffMgr.params.statusObj.missingInDstCount === 0);
+    });
+
+    it('a delete in target oplog add it to source', () => {
+        const addQueue = [];
+        const deleteQueue = [];
+        const diffMgr = new DiffManager(params, log);
+        params.statusObj.missingInDstCount = 0;
+        params.statusObj.missingInSrcCount = 0;
+        deleteQueue.push(_obj1);
+        diffMgr.genericUpdate(
+            diffMgr.IdxDst,
+            diffMgr.IdxSrc,
+            addQueue,
+            deleteQueue);
+        assert(diffMgr.state[diffMgr.IdxSrc].getSize() === 0);
+        assert(diffMgr.state[diffMgr.IdxDst].getSize() === 1);
+        assert(diffMgr.state[diffMgr.IdxDst].get(_obj1.key).mismatch === diffMgr.MismatchNoExist);
+        assert(diffMgr.state[diffMgr.IdxDst].get(_obj1.key).versionId === _obj1.value.versionId);
+        assert(diffMgr.params.statusObj.missingInSrcCount === 0);
+        assert(diffMgr.params.statusObj.missingInDstCount === 1);
+    });
+
+    it('a missing object on source shall be removed if del received in target oplog', () => {
+        const addQueue = [];
+        const deleteQueue = [];
+        const diffMgr = new DiffManager(params, log);
+        diffMgr._add(
+            diffMgr.IdxSrc,
+            obj1,
+            diffMgr.MismatchNoExist);
+        params.statusObj.missingInDstCount = 0;
+        params.statusObj.missingInSrcCount = 1;
+        deleteQueue.push(_obj1);
+        diffMgr.genericUpdate(
+            diffMgr.IdxDst,
+            diffMgr.IdxSrc,
+            addQueue,
+            deleteQueue);
+        assert(diffMgr.state[diffMgr.IdxSrc].getSize() === 0);
+        assert(diffMgr.state[diffMgr.IdxDst].getSize() === 0);
+        assert(diffMgr.params.statusObj.missingInSrcCount === 0);
+        assert(diffMgr.params.statusObj.missingInDstCount === 0);
     });
 });


### PR DESCRIPTION
Continuous integrity check based on the existing `compareBuckets` tool.

The tool maintains 2 sets of differences, and follow the oplog to update the sets in real-time.

It persists the state in ZK/RING to avoid rescanning the bucket each time, in using the snapshot/scan/oplog pattern.