### PR TITLE
improvement: S3UTILS-47 verbose logging of sproxyd keys

### DIFF
--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -296,6 +296,12 @@ function checkSproxydKeys(objectUrl, locations, cb) {
         dupKey = true;
     }
     if (NO_MISSING_KEY_CHECK) {
+        if (VERBOSE) {
+            locations.forEach(loc => log.info('sproxyd key', {
+                objectUrl,
+                sproxydKey: loc.key,
+            }));
+        }
         return process.nextTick(onComplete);
     }
     return async.eachSeries(locations, (loc, locDone) => {


### PR DESCRIPTION
With VERBOSE=1 and NO_MISSING_KEY_CHECK=1 options, log 'sproxyd key'
lines for each sproxyd key seen in metadata, without checking them
individually through sproxyd.