### PR TITLE
bugfix: S3UTILS-48 verifyBucketSproxydKeys skips replay keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "engines": {
     "node": ">= 16"
   },

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -7,7 +7,7 @@ const async = require('async');
 const { URL } = require('url');
 const jsonStream = require('JSONStream');
 
-const { jsutil } = require('arsenal');
+const { jsutil, versioning } = require('arsenal');
 const { Logger } = require('werelogs');
 
 const getObjectURL = require('./VerifyBucketSproxydKeys/getObjectURL');
@@ -373,6 +373,9 @@ function listBucketIter(bucket, cb) {
         const { Contents, IsTruncated } = resp;
 
         return async.eachLimit(Contents, WORKERS, (item, itemDone) => {
+            if (item.key.startsWith(versioning.VersioningConstants.DbPrefixes.Replay)) {
+                return itemDone();
+            }
             const vidSepPos = item.key.lastIndexOf('\0');
             const objectUrl = getObjectURL(bucket, item.key);
 


### PR DESCRIPTION
Do not process internal replay keys returned from the raw bucketd listing, i.e. do not attempt to retrieve the locations array, just ignore them instead.
