### PR TITLE
INTEGRATION [PR#194 > development/1.12] bf(S3UTILS-50): Change scality user uid:gid to match federation defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,11 @@ ENV NO_PROXY localhost,127.0.0.1
 ENV no_proxy localhost,127.0.0.1
 
 ## This section duplicates S3C Federation Dockerfile, this needs to be refactored
-# Create the "scality" user with associated env variables
+# Rename the "node" user to "scality" and setup associated env variables
 # for augmented images to use.
+RUN usermod --login scality --home /home/scality --move-home node && \
+    groupmod --new-name scality node
 ENV USER="scality"
-RUN useradd -ms /bin/bash scality
 ENV HOME_DIR="/home/${USER}"
 
 # Create common Directories and matching env variables


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #194.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.12/bugfix/S3UTILS-50/fix_scality_uid_gid_in_container`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.12/bugfix/S3UTILS-50/fix_scality_uid_gid_in_container
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.12/bugfix/S3UTILS-50/fix_scality_uid_gid_in_container
```

Please always comment pull request #194 instead of this one.