### PR TITLE
Skip reading undefined properties

### DIFF
--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -400,17 +400,22 @@ function listBucketIter(bucket, cb) {
                 }
             }
 
-            if (MPU_ONLY && md['content-md5'].indexOf('-') === -1) {
-                // not an MPU object
-                status.objectsSkipped += 1;
-                findDuplicateSproxydKeys.skipVersion();
-                return itemDone();
+            if (md['content-md5'].indexOf('-') !== undefined) {
+                // not an "unreal" object, lacking content-md5
+                if (MPU_ONLY && md['content-md5'].indexOf('-') === -1) {
+                    // not an MPU object
+                    status.objectsSkipped += 1;
+                    findDuplicateSproxydKeys.skipVersion();
+                    return itemDone();
+                }
             }
-            if (md['content-length'] === 0) {
-                // empty object
-                status.objectsScanned += 1;
-                findDuplicateSproxydKeys.skipVersion();
-                return itemDone();
+            if (md['content-length'] !== undefined) {
+                if (md['content-length'] === 0) {
+                    // empty object
+                    status.objectsScanned += 1;
+                    findDuplicateSproxydKeys.skipVersion();
+                    return itemDone();
+                }
             }
             // big MPUs may not have their location in the listing
             // result, we need to fetch the locations array from


### PR DESCRIPTION
Attempt to skip over undefined properties from errors like:

/usr/src/app/verifyBucketSproxydKeys.js:403
            if (MPU_ONLY && md['content-md5'].indexOf('-') === -1) {
                                              ^
 
TypeError: Cannot read properties of undefined (reading 'indexOf')