### PR TITLE
feature: S3UTILS-61 block digests storage

### DIFF
--- a/CompareRaftMembers/BlockDigestsStorage.js
+++ b/CompareRaftMembers/BlockDigestsStorage.js
@@ -1,0 +1,67 @@
+const async = require('async');
+const stream = require('stream');
+
+const Level = require('level');
+
+const MAX_BATCH_SIZE = 100;
+const MAX_QUEUE_SIZE = 1000;
+
+/**
+ * Writable stream to store block digests coming from a
+ * BlockDigestsStream instance into a LevelDB database or other
+ * API-compatible storage layer
+ *
+ * @class BlockDigestsStorage
+ */
+class BlockDigestsStorage extends stream.Writable {
+    /**
+     * @constructor
+     * @param {object} params - constructor params, must contain
+     * either "levelPath" or "db" attribute
+     * @param {string} [params.levelPath] - path to LevelDB database
+     * to write to
+     * @param {string} [params.db] - custom db object, must contain
+     * the methods "batch" and "close" following levelup's API -
+     * currently used for unit tests
+     */
+    constructor(params) {
+        super({ objectMode: true });
+        const { levelPath, db } = params;
+        if (params.levelPath) {
+            this.db = new Level(params.levelPath);
+        } else {
+            this.db = db;
+        }
+        this.cargo = async.cargo((tasks, cb) => {
+            this.db.batch(tasks, cb);
+        }, MAX_BATCH_SIZE);
+    }
+
+    _write(blockInfo, encoding, callback) {
+        const { size, digest } = blockInfo;
+        this.cargo.push({
+            type: 'put',
+            key: blockInfo.lastKey, // index by last block key for efficient lookup
+            value: JSON.stringify({ size, digest }),
+        });
+        // heuristic to have basic flow control: delay the callback
+        // while queue size is above a reasonable size
+        async.whilst(
+            () => this.cargo.length() > MAX_QUEUE_SIZE,
+            cb => setTimeout(cb, 100),
+            () => callback(),
+        );
+    }
+
+    _final(callback) {
+        if (this.cargo.idle()) {
+            this.db.close(callback);
+        } else {
+            this.cargo.drain = () => {
+                this.db.close(callback);
+            };
+        }
+    }
+}
+
+module.exports = BlockDigestsStorage;

--- a/tests/unit/CompareRaftMembers/BlockDigestsStorage.js
+++ b/tests/unit/CompareRaftMembers/BlockDigestsStorage.js
@@ -1,0 +1,44 @@
+const BlockDigestsStorage = require('../../../CompareRaftMembers/BlockDigestsStorage');
+
+describe('BlockDigestsStorage', () => {
+    [0, 1, 5000].forEach(nKeysToWrite => {
+        test(`should write ${nKeysToWrite} digest keys`, done => {
+            const keysRemainingToWrite = {};
+            let closeDone = false;
+            const dbMock = {
+                batch: (array, cb) => {
+                    setTimeout(() => {
+                        array.forEach(item => {
+                            expect(item.type).toEqual('put');
+                            expect(item.value).toEqual(keysRemainingToWrite[item.key]);
+                            delete keysRemainingToWrite[item.key];
+                        });
+                        cb();
+                    }, 10);
+                },
+                close: cb => {
+                    setTimeout(() => {
+                        closeDone = true;
+                        cb();
+                    }, 10);
+                },
+            };
+            const levelStream = new BlockDigestsStorage({ db: dbMock });
+            for (let i = 0; i < nKeysToWrite; ++i) {
+                const key = `000000${i}`.slice(-6);
+                const digest = `DIGEST${i}`;
+                const value = JSON.stringify({ size: 100 + i, digest });
+                keysRemainingToWrite[key] = value;
+                levelStream.write({ size: 100 + i, lastKey: key, digest });
+            }
+            levelStream.end();
+            levelStream.on('finish', () => {
+                // db should have been closed
+                expect(closeDone).toBeTruthy();
+                // all keys should have been written to leveldb after 'finish' is emitted
+                expect(keysRemainingToWrite).toEqual({});
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Writable stream to store block digests coming from a
BlockDigestsStream instance into a LevelDB database or other
API-compatible storage layer