### PR TITLE
feature: S3UTILS-56 raw listing stream from DB

### DIFF
--- a/CompareRaftMembers/DBListStream.js
+++ b/CompareRaftMembers/DBListStream.js
@@ -1,0 +1,88 @@
+const stream = require('stream');
+
+/**
+ * List entries from a low-level Metadata database, filtered to be
+ * compatible with repd listings done by verifyBucketSproxydKeys
+ * script to create the block digests database, so that digests can be
+ * computed from the stream and compared against the digests database.
+ *
+ * @class DBListStream
+ */
+class DBListStream extends stream.Transform {
+    /**
+     * @constructor
+     * @param {object} params - params object
+     * @param {string} params.dbName - name of the database: it is
+     * used to support legacy databases, where the database name is
+     * the bucket name, in which case we need to prefix the key by the
+     * bucket name. If the name is of the form "storeDbX[Y]", the
+     * bucket name is already prefixed to the key.
+     */
+    constructor(params) {
+        super({ objectMode: true });
+
+        if (typeof params !== 'object') {
+            throw new Error('DBListStream.constructor(): params must be an object');
+        }
+        if (typeof params.dbName !== 'string') {
+            throw new Error('DBListStream.constructor(): params.dbName must be a string');
+        }
+        this.dbName = params.dbName;
+        this.isLegacyDb = !(/^storeDb[0-9]+$/.test(this.dbName));
+
+        this.lastMasterKey = null;
+        this.lastMasterVersionId = null;
+    }
+
+    _transform(item, encoding, callback) {
+        const { key, value } = item;
+        let bucket;
+        let objectKey;
+        if (this.isLegacyDb) {
+            bucket = this.dbName;
+            objectKey = key;
+        } else {
+            const slashIndex = key.indexOf('/');
+            if (slashIndex === -1 || slashIndex === key.length - 1) {
+                // ignore keys that do not match the expected `bucket/key` scheme
+                return callback();
+            }
+            [bucket, objectKey] = [key.slice(0, slashIndex), key.slice(slashIndex + 1)];
+        }
+        // ignore both internal replay keys and metadata v1 keys, by
+        // skipping any key beginning with the '\x7f' byte
+        //
+        // Note: metadata v1 keys may be supported in the future, in
+        // which case we should still ignore replay keys
+        if (objectKey.startsWith('\x7f')) {
+            return callback();
+        }
+        const vidSepPos = objectKey.lastIndexOf('\0');
+        const md = JSON.parse(value);
+        if (md.isPHD) {
+            // object is a Place Holder Delete (PHD)
+            return callback();
+        }
+        if (vidSepPos === -1) {
+            this.lastMasterKey = objectKey;
+            this.lastMasterVersionId = md.versionId;
+        } else {
+            const masterKey = objectKey.slice(0, vidSepPos);
+            if (masterKey === this.lastMasterKey
+                && md.versionId === this.lastMasterVersionId) {
+                // we have already processed this versioned key as
+                // the master key, so skip it
+                return callback();
+            }
+        }
+
+        if (this.isLegacyDb) {
+            this.push({ key: `${bucket}/${objectKey}`, value });
+        } else {
+            this.push(item);
+        }
+        return callback();
+    }
+}
+
+module.exports = DBListStream;

--- a/tests/unit/CompareRaftMembers/DBListStream.js
+++ b/tests/unit/CompareRaftMembers/DBListStream.js
@@ -1,0 +1,276 @@
+const assert = require('assert');
+const stream = require('stream');
+
+const { versioning } = require('arsenal');
+
+const DBListStream = require('../../../CompareRaftMembers/DBListStream');
+
+class MockDBStream extends stream.Readable {
+    constructor(items) {
+        super({ objectMode: true });
+        this.items = items;
+    }
+
+    _read() {
+        this.items.forEach(item => {
+            this.push(item);
+        });
+        this.push(null);
+    }
+}
+
+describe('DBListStream', () => {
+    describe('DBListStream.isLegacyDb', () => {
+        [
+            { dbName: 'legacy', isLegacyDb: true },
+            { dbName: 'storedb42', isLegacyDb: true },
+            { dbName: 'storeDb0', isLegacyDb: false },
+            { dbName: 'storeDb42', isLegacyDb: false },
+        ].forEach(testCase => {
+            test(`${testCase.dbName} => ${testCase.isLegacyDb ? 'is' : 'is not'} a legacy DB`, () => {
+                const dbListStream = new DBListStream({ dbName: testCase.dbName });
+                assert.strictEqual(dbListStream.isLegacyDb, testCase.isLegacyDb);
+            });
+        });
+    });
+    describe('DBListStream output', () => {
+        [
+            {
+                desc: 'empty DB',
+                dbName: 'storeDb42',
+                dbEntries: [],
+                listEntries: [],
+            },
+            {
+                desc: 'single master version',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    { key: 'bucket/object', value: '{"foo":"bar"}' },
+                ],
+                listEntries: [
+                    { key: 'bucket/object', value: '{"foo":"bar"}' },
+                ],
+            },
+            {
+                desc: 'single versioned entry',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+            },
+            {
+                desc: 'single versioning-suspended entry',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+            },
+            {
+                desc: 'single version with PHD master',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"isPHD":true}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+            },
+            {
+                desc: 'single object with three versions',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767320931999999RG001  74.505.48',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321257999999RG001  74.499.29',
+                        value: '{"versionId":"98345767321257999999RG001  74.499.29"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321257999999RG001  74.499.29',
+                        value: '{"versionId":"98345767321257999999RG001  74.499.29"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
+                        value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
+                    },
+                ],
+            },
+            {
+                desc: 'bucket attributes entry',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/',
+                        value: '{"attributes":"{}"}',
+                    },
+                ],
+                listEntries: [],
+            },
+            {
+                desc: 'two objects + PHD, replay keys and keys with no "/"',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object\u000098345767320931999999RG001  74.505.48',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object2',
+                        value: '{"isPHD":true}',
+                    },
+                    {
+                        key: 'bucket/object3',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                    {
+                        key: 'bucket/object3\u000098345767320611999999RG001  74.519.84',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                    {
+                        key: `bucket/${versioning.VersioningConstants.DbPrefixes.Replay}foobar`,
+                        value: '{}',
+                    },
+                    {
+                        key: 'noslash',
+                        value: '{}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'bucket/object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'bucket/object3',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                ],
+            },
+            {
+                desc: 'bucket in metadata versioning format v1',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    {
+                        key: `bucket/${versioning.VersioningConstants.DbPrefixes.Master}object`,
+                        value: '{}',
+                    },
+                    {
+                        key: `bucket/${versioning.VersioningConstants.DbPrefixes.Version}object\u000098345767320931999999RG001  74.505.48`,
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                ],
+                listEntries: [
+                    // metadata format v1 ignored for now
+                ],
+            },
+            {
+                desc: 'two objects + PHD, replay keys in legacy DB',
+                dbName: 'legacy',
+                dbEntries: [
+                    {
+                        key: 'object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'object\u000098345767320931999999RG001  74.505.48',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'object2',
+                        value: '{"isPHD":true}',
+                    },
+                    {
+                        key: 'object3',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                    {
+                        key: 'object3\u000098345767320611999999RG001  74.519.84',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                    {
+                        key: `${versioning.VersioningConstants.DbPrefixes.Replay}foobar`,
+                        value: '{}',
+                    },
+                ],
+                listEntries: [
+                    {
+                        key: 'legacy/object',
+                        value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
+                    },
+                    {
+                        key: 'legacy/object3',
+                        value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
+                    },
+                ],
+            },
+        ].forEach(testCase => {
+            test(testCase.desc, done => {
+                const dbStream = new MockDBStream(testCase.dbEntries);
+                const dbListStream = new DBListStream({ dbName: testCase.dbName });
+                const listedEntries = [];
+                dbStream.pipe(dbListStream);
+                dbListStream
+                    .on('data', data => listedEntries.push(data))
+                    .on('end', () => {
+                        assert.deepStrictEqual(listedEntries, testCase.listEntries);
+                        done();
+                    })
+                    .on('error', err => {
+                        assert.ifError(err);
+                    });
+            });
+        });
+    });
+});


### PR DESCRIPTION
List entries from a low-level Metadata database, filtered to be
compatible with repd listings done by verifyBucketSproxydKeys script
to create the block digests database, so that digests can be computed
from the stream and compared against the digests database.