### PR TITLE
S3UTILS-58 diff stream without digest checks

### DIFF
--- a/CompareRaftMembers/DiffStream.js
+++ b/CompareRaftMembers/DiffStream.js
@@ -1,0 +1,223 @@
+const stream = require('stream');
+
+const BucketStream = require('./BucketStream');
+
+/**
+ * Output differences between the input stream, consisting of
+ * { key: string, value: string } objects sorted by key, and a bucketd
+ * interface that can be queried via HTTP for ranges of keys from
+ * given buckets.
+ *
+ * Input items are meant to be coming from a raw leveldb database
+ * listing, transformed via a DBListStream object to be comparable with
+ * bucketd listing.
+ *
+ * @class DiffStream
+ */
+class DiffStream extends stream.Transform {
+    /**
+     * @constructor
+     * @param {object} params - constructor params
+     * @param {string} params.bucketdHost - bucketd host name or IP address
+     * @param {number} params.bucketdPort - bucketd API port
+     * @param {number} [params.maxBufferSize=1000] - maximum number of
+     * items to bufferize
+     * @param {class} [params.BucketStreamClass=BucketStream] -
+     * override the BucketStream class, used for unit tests only
+     */
+    constructor(params) {
+        super({ objectMode: true });
+        const {
+            bucketdHost, bucketdPort,
+            maxBufferSize,
+            BucketStreamClass,
+        } = params;
+
+        this.bucketdHost = bucketdHost;
+        this.bucketdPort = bucketdPort;
+        this.maxBufferSize = maxBufferSize || 1000;
+        this.BucketStreamClass = BucketStreamClass || BucketStream;
+
+        this.inputBuffer = [];
+        this.inputBufferBucket = null;
+        this.currentMarker = null;
+    }
+
+    _transform(item, encoding, callback) {
+        const itemInfo = this._parseItem(item);
+        this._processItem(itemInfo, callback);
+    }
+
+    _flush(callback) {
+        if (this.inputBuffer.length > 0) {
+            this._compareInputBufferWithBucketd(null, callback);
+        } else {
+            callback();
+        }
+    }
+
+    /**
+     * Parse the item coming from the stream input into a series of
+     * fields useful for later processing
+     *
+     * @param {object} item - item from DBListStream
+     * @return {object} - { fullKey, bucketName, objectKey, value }
+     */
+    _parseItem(item) {
+        const { key: fullKey, value } = item;
+        const slashIndex = fullKey.indexOf('/');
+        const [bucketName, objectKey] = [fullKey.slice(0, slashIndex), fullKey.slice(slashIndex + 1)];
+        return {
+            fullKey,
+            bucketName,
+            objectKey,
+            value,
+        };
+    }
+
+    /**
+     * Process a parsed item from the database input stream
+     *
+     * @param {object} itemInfo - parsed item (see _parseItem())
+     * @param {function} callback - called with no argument when the
+     * transform stream is ready to accept more input
+     * @return {undefined}
+     */
+    _processItem(itemInfo, callback) {
+        const { bucketName } = itemInfo;
+
+        const isNewBucket = (this.inputBufferBucket && bucketName !== this.inputBufferBucket);
+        if (isNewBucket || this.inputBuffer.length === this.maxBufferSize) {
+            const lastObjectKey = isNewBucket
+                ? null
+                : this.inputBuffer[this.inputBuffer.length - 1].objectKey;
+            this._compareInputBufferWithBucketd(lastObjectKey, () => {
+                this.inputBufferBucket = bucketName;
+                this.currentMarker = lastObjectKey;
+                this._ingestItem(itemInfo, callback);
+            });
+        } else {
+            this.inputBufferBucket = bucketName;
+            // due to the workaround described above, we may be
+            // processing a new bucket's key here and need to reset
+            // the marker in this case only, without querying bucketd
+            if (isNewBucket) {
+                this.currentMarker = null;
+            }
+            this._ingestItem(itemInfo, callback);
+        }
+    }
+
+    /**
+     * Compare the current input buffer populated from the database
+     * input stream with bucketd, by requesting bucketd on the
+     * appropriate ranges for key-by-key comparison, and output
+     * differences as readable stream data (see _compareBuffers() for
+     * details)
+     *
+     * @param {string|null} lastKey - key where the comparison should
+     * stop, or null for checking the rest of the bucket
+     * @param {function} callback - called with no argument when the
+     * comparison is finished
+     * @return {undefined}
+     */
+    _compareInputBufferWithBucketd(lastKey, callback) {
+        const bucketStream = new this.BucketStreamClass({
+            bucketdHost: this.bucketdHost,
+            bucketdPort: this.bucketdPort,
+            bucketName: this.inputBufferBucket,
+            marker: this.currentMarker,
+            lastKey,
+        });
+        let bucketBuffer = [];
+        bucketStream
+            .on('data', item => {
+                bucketBuffer.push(item);
+                // split the comparison job in chunks if the bucket
+                // buffer gets too big: for this we may also need to
+                // split the input buffer at the last bucket buffer's
+                // key, so that the comparison is meaningful
+                if (bucketBuffer.length === this.maxBufferSize) {
+                    const maxKey = bucketBuffer[bucketBuffer.length - 1].key;
+                    let inputBufferLimit = this.inputBuffer.findIndex(item => item.fullKey > maxKey);
+                    if (inputBufferLimit === -1) {
+                        inputBufferLimit = this.inputBuffer.length;
+                    }
+                    const inputBuffer = this.inputBuffer.splice(0, inputBufferLimit);
+                    this._compareBuffers(inputBuffer, bucketBuffer);
+                    bucketBuffer = [];
+                }
+            })
+            .on('end', () => {
+                const { inputBuffer } = this;
+                this.inputBuffer = [];
+                this._compareBuffers(inputBuffer, bucketBuffer);
+                callback();
+            })
+            .on('error', err => {
+                // unrecoverable error after retries: raise the error
+                this.emit('error', err);
+            });
+    }
+
+    /**
+     * Compare the input buffer built from streamed input coming from
+     * the database against the bucket buffer built from querying
+     * bucketd for ranges of keys, and output the differences as
+     * readable stream data.
+     *
+     * Each output data event is an array in one of the following forms:
+     *
+     * - [{ key, value }, null]: this key is only present in inputBuffer
+     *
+     * - [null, { key, value}]: this key is only present in the bucketBuffer
+     *
+     * - [{ key, value: 'value1' }, { key, value: 'value2' }]: this
+     *   key is present in both buffers but has a different value,
+     *   where 'value1' is the inputBuffer value and 'value2' the
+     *   bucketBuffer value
+     *
+     * @param {Array} inputBuffer - entries coming from the database input stream
+     * @param {Array} bucketBuffer - entries coming from a listing
+     * request to bucketd (via BucketStream)
+     * @return {undefined}
+     */
+    _compareBuffers(inputBuffer, bucketBuffer) {
+        let [inputIndex, bucketIndex] = [0, 0];
+        while (inputIndex < inputBuffer.length
+               && bucketIndex < bucketBuffer.length) {
+            const [inputItem, bucketItem] = [inputBuffer[inputIndex], bucketBuffer[bucketIndex]];
+            if (inputItem.fullKey < bucketItem.key) {
+                this.push([{ key: inputItem.fullKey, value: inputItem.value }, null]);
+                inputIndex += 1;
+            } else if (inputItem.fullKey > bucketItem.key) {
+                this.push([null, bucketItem]);
+                bucketIndex += 1;
+            } else {
+                if (inputItem.value !== bucketItem.value) {
+                    this.push([{ key: inputItem.fullKey, value: inputItem.value }, bucketItem]);
+                }
+                inputIndex += 1;
+                bucketIndex += 1;
+            }
+        }
+        while (inputIndex < inputBuffer.length) {
+            const inputItem = inputBuffer[inputIndex];
+            this.push([{ key: inputItem.fullKey, value: inputItem.value }, null]);
+            inputIndex += 1;
+        }
+        while (bucketIndex < bucketBuffer.length) {
+            const bucketItem = bucketBuffer[bucketIndex];
+            this.push([null, bucketItem]);
+            bucketIndex += 1;
+        }
+    }
+
+    _ingestItem(itemInfo, callback) {
+        const { fullKey } = itemInfo;
+        this.inputBuffer.push(itemInfo);
+        return callback();
+    }
+}
+
+module.exports = DiffStream;

--- a/tests/unit/CompareRaftMembers/DiffStream.js
+++ b/tests/unit/CompareRaftMembers/DiffStream.js
@@ -1,0 +1,542 @@
+const async = require('async');
+const stream = require('stream');
+
+const DiffStream = require('../../../CompareRaftMembers/DiffStream');
+
+// parameterized by tests
+let MOCK_BUCKET_STREAM_FULL_LISTING = null;
+
+// populated by each test
+let MOCK_BUCKET_STREAM_REQUESTS_MADE = null;
+
+class MockBucketStream extends stream.Readable {
+    constructor(params) {
+        super({ objectMode: true });
+
+        const {
+            bucketdHost,
+            bucketdPort,
+            bucketName,
+            marker,
+            lastKey,
+        } = params;
+        expect(bucketdHost).toEqual('dummy-host');
+        expect(bucketdPort).toEqual(4242);
+
+        MOCK_BUCKET_STREAM_REQUESTS_MADE.push({ bucketName, marker, lastKey });
+
+        this.listingToSend = MOCK_BUCKET_STREAM_FULL_LISTING.filter(item => {
+            const { key, value } = item;
+            const slashIndex = key.indexOf('/');
+            const [itemBucketName, objectKey] = [key.slice(0, slashIndex), key.slice(slashIndex + 1)];
+            if (itemBucketName !== bucketName) {
+                return false;
+            }
+            return (!marker || objectKey > marker)
+                && (!lastKey || objectKey <= lastKey);
+        });
+    }
+
+    _read() {
+        process.nextTick(() => {
+            if (this.listingToSend.length === 0) {
+                this.push(null);
+            } else {
+                const item = this.listingToSend.shift();
+                this.push(item);
+            }
+        });
+    }
+}
+
+describe('DiffStream', () => {
+    describe('should output differences between a stream of { key, value } items and bucketd', () => {
+        beforeEach(() => {
+            MOCK_BUCKET_STREAM_REQUESTS_MADE = [];
+        });
+
+        [
+            {
+                desc: 'with no contents in db nor in bucketd',
+                dbContents: [],
+                bucketdContents: [],
+                expectedOutput: [],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [],
+                    },
+                ],
+            },
+            {
+                desc: 'with a single identical entry in db and bucketd',
+                dbContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                expectedOutput: [],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with a single entry with different key in db and bucketd',
+                dbContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket/key2', value: '{}' },
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                        null,
+                    ],
+                    [
+                        null,
+                        { key: 'bucket/key2', value: '{}' },
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with a single entry with same key but different value in db and bucketd',
+                dbContents: [
+                    { key: 'bucket/key1', value: '{"foo":"bar"}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket/key1', value: '{"foo":"qux"}' },
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with single entry in db and two entries in bucketd',
+                dbContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                    { key: 'bucket/key2', value: '{"foo":"bar"}' },
+                ],
+                expectedOutput: [
+                    [
+                        null,
+                        { key: 'bucket/key2', value: '{"foo":"bar"}' },
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with an empty db and a single entry in bucketd',
+                dbContents: [],
+                bucketdContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                // here the absolute difference is not empty but the
+                // output is, because there is no input bucket from
+                // the db, hence no request can be made to bucketd to
+                // check for differences
+                expectedOutput: [],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [],
+                    },
+                ],
+            },
+            {
+                desc: 'with a single entry in db and an empty bucketd',
+                dbContents: [
+                    { key: 'bucket/key1', value: '{}' },
+                ],
+                bucketdContents: [],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                        null,
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with two entries for two buckets in db and bucketd',
+                dbContents: [
+                    { key: 'bucket1/key1', value: '{}' },
+                    { key: 'bucket2/key1', value: '{}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket1/key1', value: '{}' },
+                    { key: 'bucket2/key1', value: '{}' },
+                ],
+                expectedOutput: [],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket1',
+                                marker: null,
+                                lastKey: null,
+                            },
+                            {
+                                bucketName: 'bucket2',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with two different entries for two buckets in db and bucketd',
+                dbContents: [
+                    { key: 'bucket1/key1', value: '{"foo":"bar"}' },
+                    { key: 'bucket2/key1', value: '{"foo":"bar"}' },
+                ],
+                bucketdContents: [
+                    { key: 'bucket1/key1', value: '{"foo":"qux"}' },
+                    { key: 'bucket2/key1', value: '{"foo":"qux"}' },
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket1/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket1/key1', value: '{"foo":"qux"}' },
+                    ],
+                    [
+                        { key: 'bucket2/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket2/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket1',
+                                marker: null,
+                                lastKey: null,
+                            },
+                            {
+                                bucketName: 'bucket2',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with 7777 identical entries in db and bucketd',
+                get dbContents() {
+                    const dbList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        dbList.push({ key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' });
+                    }
+                    return dbList;
+                },
+                get bucketdContents() {
+                    const bucketdList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        bucketdList.push({ key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' });
+                    }
+                    return bucketdList;
+                },
+                expectedOutput: [
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: 'key-001999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-001999',
+                                lastKey: 'key-003999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-003999',
+                                lastKey: 'key-005999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-005999',
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with 7777 entries only in db',
+                get dbContents() {
+                    const dbList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        dbList.push({ key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' });
+                    }
+                    return dbList;
+                },
+                bucketdContents: [],
+                get expectedOutput() {
+                    const expectedDiff = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        expectedDiff.push([
+                            { key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' },
+                            null,
+                        ]);
+                    }
+                    return expectedDiff;
+                },
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: 'key-001999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-001999',
+                                lastKey: 'key-003999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-003999',
+                                lastKey: 'key-005999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-005999',
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with 7777 entries in db and bucketd with a few differences',
+                get dbContents() {
+                    const dbList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        if (i !== 2222) {
+                            const paddedI = `000000${i}`.slice(-6);
+                            let value;
+                            if (i === 3333) {
+                                value = '{"foo":"qux"}';
+                            } else {
+                                value = '{"foo":"bar"}';
+                            }
+                            dbList.push({ key: `bucket/key-${paddedI}`, value });
+                        }
+                    }
+                    return dbList;
+                },
+                get bucketdContents() {
+                    const bucketdList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        if (i !== 4444) {
+                            const paddedI = `000000${i}`.slice(-6);
+                            bucketdList.push({ key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' });
+                        }
+                    }
+                    return bucketdList;
+                },
+                expectedOutput: [
+                    [
+                        null,
+                        { key: 'bucket/key-002222', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket/key-003333', value: '{"foo":"qux"}' },
+                        { key: 'bucket/key-003333', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket/key-004444', value: '{"foo":"bar"}' },
+                        null,
+                    ],
+                ],
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: 'key-001999',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-001999',
+                                lastKey: 'key-004000',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-004000',
+                                lastKey: 'key-006000',
+                            },
+                            {
+                                bucketName: 'bucket',
+                                marker: 'key-006000',
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                desc: 'with two entries in db and 7777 entries in bucketd',
+                dbContents: [
+                    { key: 'bucket/key-001234', value: '{"foo":"bar"}' },
+                    { key: 'bucket/key-006667', value: '{"foo":"bar"}' },
+                ],
+                get bucketdContents() {
+                    const dbList = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        dbList.push({ key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' });
+                    }
+                    return dbList;
+                },
+                get expectedOutput() {
+                    const expectedDiff = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        if (![1234, 6667].includes(i)) {
+                            const paddedI = `000000${i}`.slice(-6);
+                            expectedDiff.push([
+                                null,
+                                { key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' },
+                            ]);
+                        }
+                    }
+                    return expectedDiff;
+                },
+                withDigests: [
+                    {
+                        desc: 'with no digests DB',
+                        storedDigests: null,
+                        expectedBucketStreamRequests: [
+                            {
+                                bucketName: 'bucket',
+                                marker: null,
+                                lastKey: null,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ].forEach(testCase => {
+            const { expectedOutput } = testCase;
+            testCase.withDigests.forEach(withDigests => {
+                test(`${testCase.desc} yielding ${expectedOutput.length} diff entries, ${withDigests.desc}`, done => {
+                    MOCK_BUCKET_STREAM_FULL_LISTING = testCase.bucketdContents;
+                    const { dbContents } = testCase;
+                    const output = [];
+                    const diffStream = new DiffStream({
+                        bucketdHost: 'dummy-host',
+                        bucketdPort: 4242,
+                        maxBufferSize: 2000,
+                        BucketStreamClass: MockBucketStream,
+                    });
+                    diffStream
+                        .on('data', data => {
+                            output.push(data);
+                        })
+                        .on('end', () => {
+                            expect(output).toEqual(expectedOutput);
+                            expect(MOCK_BUCKET_STREAM_REQUESTS_MADE)
+                                .toEqual(withDigests.expectedBucketStreamRequests);
+                            done();
+                        })
+                        .on('error', done);
+                    dbContents.forEach(item => {
+                        diffStream.write(item);
+                    });
+                    diffStream.end();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Output differences between the input stream, consisting of
{ key: string, value: string } objects sorted by key, and a bucketd
interface that can be queried via HTTP for ranges of keys from
given buckets.

Input items are meant to be coming from a raw leveldb database
listing, transformed via a DBListStream object to be comparable with
bucketd listing.