### PR TITLE
feature: S3UTILS-63 helper DiffStream._getDigestBlockForKey()

### DIFF
--- a/CompareRaftMembers/DiffStream.js
+++ b/CompareRaftMembers/DiffStream.js
@@ -20,6 +20,9 @@ class DiffStream extends stream.Transform {
      * @param {object} params - constructor params
      * @param {string} params.bucketdHost - bucketd host name or IP address
      * @param {number} params.bucketdPort - bucketd API port
+     * @param {Level} [params.digestsDb] - optional leveldb database
+     * handle where block digests precomputed from the leader's
+     * bucketd listing are stored, to speed up comparisons
      * @param {number} [params.maxBufferSize=1000] - maximum number of
      * items to bufferize
      * @param {class} [params.BucketStreamClass=BucketStream] -
@@ -29,23 +32,43 @@ class DiffStream extends stream.Transform {
         super({ objectMode: true });
         const {
             bucketdHost, bucketdPort,
+            digestsDb,
             maxBufferSize,
             BucketStreamClass,
         } = params;
 
         this.bucketdHost = bucketdHost;
         this.bucketdPort = bucketdPort;
+        this.digestsDb = digestsDb || null;
         this.maxBufferSize = maxBufferSize || 1000;
         this.BucketStreamClass = BucketStreamClass || BucketStream;
 
         this.inputBuffer = [];
         this.inputBufferBucket = null;
         this.currentMarker = null;
+
+        this.currentItem = null;
+        this.currentDbDigestsStream = null;
+        this.currentDbDigestBlock = null;
+        this.currentDbDigestBlockWaitCallback = null;
+        this.noMoreDigestsForCurrentBucket = false;
+    }
+
+    cleanup(callback) {
+        if (this.currentDbDigestsStream) {
+            this.currentDbDigestsStream.destroy();
+            this.currentDbDigestsStream.on('close', callback);
+        } else {
+            callback();
+        }
     }
 
     _transform(item, encoding, callback) {
         const itemInfo = this._parseItem(item);
-        this._processItem(itemInfo, callback);
+        // synchronize the input key with the digests database
+        this._getDigestBlockForItem(itemInfo, digestBlock => {
+            this._processItem(itemInfo, digestBlock, callback);
+        });
     }
 
     _flush(callback) {
@@ -79,11 +102,13 @@ class DiffStream extends stream.Transform {
      * Process a parsed item from the database input stream
      *
      * @param {object} itemInfo - parsed item (see _parseItem())
+     * @param {object} digestBlock - digest block used for efficient
+     * comparison purpose
      * @param {function} callback - called with no argument when the
      * transform stream is ready to accept more input
      * @return {undefined}
      */
-    _processItem(itemInfo, callback) {
+    _processItem(itemInfo, digestBlock, callback) {
         const { bucketName } = itemInfo;
 
         const isNewBucket = (this.inputBufferBucket && bucketName !== this.inputBufferBucket);
@@ -94,7 +119,7 @@ class DiffStream extends stream.Transform {
             this._compareInputBufferWithBucketd(lastObjectKey, () => {
                 this.inputBufferBucket = bucketName;
                 this.currentMarker = lastObjectKey;
-                this._ingestItem(itemInfo, callback);
+                this._ingestItem(itemInfo, digestBlock, callback);
             });
         } else {
             this.inputBufferBucket = bucketName;
@@ -104,7 +129,7 @@ class DiffStream extends stream.Transform {
             if (isNewBucket) {
                 this.currentMarker = null;
             }
-            this._ingestItem(itemInfo, callback);
+            this._ingestItem(itemInfo, digestBlock, callback);
         }
     }
 
@@ -213,10 +238,138 @@ class DiffStream extends stream.Transform {
         }
     }
 
-    _ingestItem(itemInfo, callback) {
+    _ingestItem(itemInfo, digestBlock, callback) {
         const { fullKey } = itemInfo;
         this.inputBuffer.push(itemInfo);
+        // TODO compute block digests and compare with digestBlock
         return callback();
+    }
+
+    /**
+     * Retrieve the digest block corresponding to the item to process,
+     * i.e. the block available from the digests database with the
+     * closest higher or equal "lastKey" attribute that belongs to the
+     * same bucket
+     *
+     * @param {object} itemInfo - parsed item
+     * @param {function} callback - callback(digestBlock
+     * {object|null}): called when the digest block is found and
+     * retrieved, with attributes { lastKey, digest, size }, or null
+     * if no digest block matches the provided itemInfo
+     * @return {undefined}
+     */
+    _getDigestBlockForItem(itemInfo, callback) {
+        if (this.currentItem && this.currentItem.bucketName !== itemInfo.bucketName) {
+            this.noMoreDigestsForCurrentBucket = false;
+        }
+        this.currentItem = itemInfo;
+        if (!this.digestsDb) {
+            return callback(null);
+        }
+        const digestBlock = this.currentDbDigestBlock;
+        if (digestBlock && itemInfo.fullKey <= digestBlock.lastKey) {
+            if (itemInfo.fullKey === digestBlock.lastKey) {
+                this.currentDbDigestBlock = null;
+                if (this.currentDbDigestsStream) {
+                    // resume the current digests stream to start
+                    // fetching the next block asynchronously to
+                    // prepare for the next key
+                    this.currentDbDigestsStream.resume();
+                }
+            }
+            return callback(digestBlock);
+        }
+        this.currentDbDigestBlock = null;
+        if (this.noMoreDigestsForCurrentBucket) {
+            return callback(null);
+        }
+        // register this callback to be called when the next block comes in
+        this.currentDbDigestBlockWaitCallback = callback;
+
+        if (!this.currentDbDigestsStream) {
+            // no digests stream exist yet: create it
+            this._createDigestsDbStream(itemInfo);
+        } else if (this.currentDbDigestsStream.isPaused()) {
+            // there is a digests stream but it's not actively
+            // fetching, which means that we did not see a key
+            // matching the current block's last key: we need to
+            // re-create a new stream starting from the current key
+            this.currentDbDigestsStream.destroy();
+            this._createDigestsDbStream(itemInfo);
+        }
+        // else if the digests db stream is actively fetching, nothing
+        // else to do than waiting for the next block to be read
+        return undefined;
+    }
+
+    /**
+     * Helper to create a new digests database read stream starting
+     * from the given item, used to provide digest information to
+     * _getDigestBlockForItem()
+     *
+     * @param {object} fromItem - parsed item from which the digests
+     * stream should start
+     * @return {undefined}
+     */
+    _createDigestsDbStream(fromItem) {
+        this.currentDbDigestsStream = this.digestsDb.createReadStream({
+            gte: fromItem.fullKey,
+            // '0' is the ASCII character following '/': this restricts
+            // the digest's lastKey to be from the current bucket
+            lt: `${fromItem.bucketName}0`,
+        });
+        this.currentDbDigestsStream
+            .on('data', ({ key: blockLastKey, value: blockValue }) => {
+                // we may encounter the case where the requested key
+                // is past the next streamed block: drop this stream
+                // and re-create a new stream from the requested key
+                // in this case
+                if (this.currentItem.fullKey > blockLastKey) {
+                    this.currentDbDigestsStream.destroy();
+                    return this._createDigestsDbStream(this.currentItem);
+                }
+                // only pause the stream if the requested key is
+                // strictly lower than the block's last key, because
+                // if it's equal, at the next invocation of
+                // _getDigestBlockForItem() we should just wait for the
+                // next digest block without re-creating a new stream
+                if (this.currentItem.fullKey < blockLastKey) {
+                    this.currentDbDigestsStream.pause();
+                }
+                const digestBlock = {
+                    lastKey: blockLastKey,
+                    ...JSON.parse(blockValue),
+                };
+                this.currentDbDigestBlock = digestBlock;
+                this._onCurrentDbDigestBlockEvent(digestBlock);
+                return undefined;
+            })
+            .on('end', () => {
+                this.currentDbDigestsStream = null;
+                if (this.currentItem.bucketName !== fromItem.bucketName) {
+                    this._createDigestsDbStream(this.currentItem);
+                } else {
+                    this.noMoreDigestsForCurrentBucket = true;
+                    this._onCurrentDbDigestBlockEvent(null);
+                }
+            })
+            .on('error', err => {
+                this.currentDbDigestBlock = null;
+                this.currentDbDigestsStream = null;
+                // on error, remove the digestsDb handle to avoid
+                // further use of the database
+                this.digestsDb = null;
+                this._onCurrentDbDigestBlockEvent(null);
+                this.emit('error', err);
+            });
+    }
+
+    _onCurrentDbDigestBlockEvent(digestBlock) {
+        const callback = this.currentDbDigestBlockWaitCallback;
+        if (callback) {
+            this.currentDbDigestBlockWaitCallback = null;
+            callback(digestBlock);
+        }
     }
 }
 


### PR DESCRIPTION
Create a helper function that abstracts details about how to retrieve
a specific digest block from the database for a particular input
key. Mainly it's spawning or re-spawning read streams from the
database to make sure the current key can be part of the block digest.