### PR TITLE
Remove & upgrade dependencies from base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 on:
   workflow_dispatch:
@@ -31,16 +31,6 @@ jobs:
           username: ${{ secrets.REGISTRY_LOGIN }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: Release ${{ github.event.inputs.tag }}
-          tag_name: ${{ github.event.inputs.tag }}
-          generate_release_notes: true
-          target_commitish: ${{ github.sha }}
-
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -48,3 +38,16 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: "registry.scality.com/s3utils/s3utils:${{ github.event.inputs.tag }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: Release ${{ github.event.inputs.tag }}
+          tag_name: ${{ github.event.inputs.tag }}
+          prerelease: ${{ github.event.inputs.prerelease }}
+          generate_release_notes: true
+          target_commitish: ${{ github.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -49,15 +46,6 @@ jobs:
           username: ${{ secrets.REGISTRY_LOGIN }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          # Key is named differently to avoid collision
-          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
-
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -65,10 +53,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: "registry.scality.com/s3utils-dev/s3utils:${{ github.sha }}"
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,14 @@
-name: Basic Tests
+name: tests
 
 on:
-  - push
+  push:
+    branches-ignore:
+      - development/**
+      - q/*/**
 
+concurrency:
+  group: 'tests-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   tests:
@@ -28,7 +34,7 @@ jobs:
         env:
           MONGODB_REPLICASET: "localhost:27018"
 
-  release-commit:
+  build:
     runs-on: ubuntu-latest
     needs:
       - tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16.15.1-slim
 
 WORKDIR /usr/src/app
 ENV BALLOT_VERSION 1.0.3
@@ -7,7 +7,15 @@ ENV BALLOT_VERSION 1.0.3
 COPY ./package.json .
 
 RUN apt-get update && \
-    apt-get install -y jq python3 python3-setuptools python3-pip git build-essential --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        jq \
+        python3 \
+        python3-setuptools \
+        python3-pip \
+        wget \
+    && \
     SUPERVISORURL="https://files.pythonhosted.org/packages/d3/7f/c780b7471ba0ff4548967a9f7a8b0bfce222c3a496c3dfad0164172222b0/supervisor-4.2.2.tar.gz" && \
     SUPERVISORTARFILE="supervisor-4.2.2.tar.gz" && \
     wget $SUPERVISORURL && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM node:16.15.1-slim
+# Use separate builder to retrieve & build node modules
+FROM node:16.15.1-bullseye-slim AS builder
 
 WORKDIR /usr/src/app
-ENV BALLOT_VERSION 1.0.3
-
-# Keep the .git directory in order to properly report version
-COPY ./package.json .
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -12,21 +9,34 @@ RUN apt-get update && \
         git \
         jq \
         python3 \
-        python3-setuptools \
+        ssh
+
+COPY ./package.json .
+RUN npm install
+
+################################################################################
+FROM node:16.15.1-slim
+
+WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        jq \
+        python3 \
         python3-pip \
-        wget \
+        python3-setuptools \
     && \
-    SUPERVISORURL="https://files.pythonhosted.org/packages/d3/7f/c780b7471ba0ff4548967a9f7a8b0bfce222c3a496c3dfad0164172222b0/supervisor-4.2.2.tar.gz" && \
+    SUPERVISORURL="https://files.pythonhosted.org/packages/d3/7f/c780b7471ba0ff4548967a9f7a8b0bfce222c3a496c3dfad0164172222b0" && \
     SUPERVISORTARFILE="supervisor-4.2.2.tar.gz" && \
-    wget $SUPERVISORURL && \
-    pip3 install ./$SUPERVISORTARFILE && \
-    rm -v ./$SUPERVISORTARFILE && \
-    npm install
+    pip3 install $SUPERVISORURL/$SUPERVISORTARFILE && \
+    rm -rf /var/lib/apt/lists/* 
 
-COPY ./ ./
-
+ENV BALLOT_VERSION 1.0.3
 ADD https://github.com/scality/ballot/releases/download/v${BALLOT_VERSION}/ballot-v${BALLOT_VERSION}-linux-amd64 /usr/src/app/ballot
 RUN chmod +x /usr/src/app/ballot
+
+COPY ./ ./
+COPY --from=builder /usr/src/app/node_modules ./node_modules/
 
 ENV NO_PROXY localhost,127.0.0.1
 ENV no_proxy localhost,127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && \
         python3 \
         ssh
 
-COPY ./package.json .
-RUN npm install
+COPY ./package.json ./yarn.lock ./
+RUN yarn install --production
 
 ################################################################################
 FROM node:16.15.1-slim


### PR DESCRIPTION
- switch to the 'slim' variant, to avoid importing useless packages
- use multi-stage build to avoid including build tool in production image
- use `yarn install` to install packages

NOTE: this does not fix all issues, we would need to switch to different distribution for this (see #225 or #224), which would need better assessment of impact.

Issue: S3UTILS-69
