### PR TITLE
Switch to alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16.15.1-alpine3.16
 
 WORKDIR /usr/src/app
 ENV BALLOT_VERSION 1.0.3
@@ -6,8 +6,18 @@ ENV BALLOT_VERSION 1.0.3
 # Keep the .git directory in order to properly report version
 COPY ./package.json .
 
-RUN apt-get update && \
-    apt-get install -y jq python3 python3-setuptools python3-pip git build-essential --no-install-recommends && \
+RUN apk add --update --no-cache \
+        bash \
+        git \
+        g++ \
+        jq \
+        make \
+        python3 \
+        py-pip \
+        py-setuptools \
+        shadow \
+        wget \
+    && \
     SUPERVISORURL="https://files.pythonhosted.org/packages/d3/7f/c780b7471ba0ff4548967a9f7a8b0bfce222c3a496c3dfad0164172222b0/supervisor-4.2.2.tar.gz" && \
     SUPERVISORTARFILE="supervisor-4.2.2.tar.gz" && \
     wget $SUPERVISORURL && \


### PR DESCRIPTION
This is needed to address CVEs in glibc package, which are not fixed in
debian buster; as well as in python, which are not fixed in debian
bullseye.

Reduce size of image, as well as the (most likely unused) dependencies
we silently get from base node.js image.

Issue: S3UTILS-69
