### PR TITLE
Fix builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use separate builder to retrieve & build node modules
-FROM node:16.15.1-bullseye-slim AS builder
+FROM node:16.15.1-slim AS builder
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This is actually a (partial) revert of incorrect base image used for the builder: builder should use the same base as the runtime image.

Issue: S3UTILS-69