### PR TITLE
feature: S3UTILS-56 ignore special buckets

### DIFF
--- a/CompareRaftMembers/DBListStream.js
+++ b/CompareRaftMembers/DBListStream.js
@@ -49,6 +49,11 @@ class DBListStream extends stream.Transform {
             }
             [bucket, objectKey] = [key.slice(0, slashIndex), key.slice(slashIndex + 1)];
         }
+        // ignore special buckets, that cannot be listed from bucketd
+        // like regular buckets
+        if (bucket === 'users..bucket' || bucket.startsWith('mpuShadowBucket')) {
+            return callback();
+        }
         // ignore both internal replay keys and metadata v1 keys, by
         // skipping any key beginning with the '\x7f' byte
         //

--- a/tests/unit/CompareRaftMembers/DBListStream.js
+++ b/tests/unit/CompareRaftMembers/DBListStream.js
@@ -255,6 +255,21 @@ describe('DBListStream', () => {
                     },
                 ],
             },
+            {
+                desc: 'special buckets should be ignored',
+                dbName: 'storeDb42',
+                dbEntries: [
+                    { key: 'users..bucket/object', value: '{"foo":"bar"}' },
+                    { key: 'mpuShadowBucketfoobar/object', value: '{"foo":"bar"}' },
+                    { key: 'mpushadowbucketiamnotashadowbucket/object', value: '{"foo":"bar"}' },
+                ],
+                listEntries: [
+                    {
+                        key: 'mpushadowbucketiamnotashadowbucket/object',
+                        value: '{"foo":"bar"}',
+                    },
+                ],
+            },
         ].forEach(testCase => {
             test(testCase.desc, done => {
                 const dbStream = new MockDBStream(testCase.dbEntries);


### PR DESCRIPTION
Ignore "users..bucket" and "mpuShadowBucketXXX" so they don't appear
in the output listing, because they are not visible from bucketd
listing.