### PR TITLE
Make sure crrExistingObjects does not break OOB object

### DIFF
--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -27,6 +27,7 @@ const MAX_SCANNED = (process.env.MAX_SCANNED
     && Number.parseInt(process.env.MAX_SCANNED, 10));
 let { KEY_MARKER } = process.env;
 let { VERSION_ID_MARKER } = process.env;
+const { GENERATE_INTERNAL_VERSION_ID } = process.env;
 
 const LISTING_LIMIT = (process.env.LISTING_LIMIT
     && Number.parseInt(process.env.LISTING_LIMIT, 10)) || 1000;
@@ -121,6 +122,13 @@ function _markObjectPending(
                 // the listed version is "null", the object may have
                 // an actual internal versionId, only if the bucket
                 // was versioning-suspended when the object was put.
+                return next();
+            }
+            if (!GENERATE_INTERNAL_VERSION_ID) {
+                // When the GENERATE_INTERNAL_VERSION_ID env variable is set,
+                // matching objects with no *internal* versionId will get
+                // "updated" to get an internal versionId. The external versionId
+                // will still be "null".
                 return next();
             }
             // The object does not have an *internal* versionId, as it

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -149,26 +149,9 @@ function _markObjectPending(
             if (skip) {
                 return next();
             }
-            const { Rules, Role } = repConfig;
-            const destination = Rules[0].Destination.Bucket;
-            // set replication properties
-            const ops = objMD.getContentLength() === 0 ? ['METADATA']
-                : ['METADATA', 'DATA'];
-            const backends = [{
-                site: storageClass,
-                status: 'PENDING',
-                dataStoreVersionId: '',
-            }];
-            const replicationInfo = {
-                status: 'PENDING',
-                backends,
-                content: ops,
-                destination,
-                storageClass,
-                role: Role,
-                storageType: STORAGE_TYPE,
-            };
-            objMD.setReplicationInfo(replicationInfo);
+
+            objMD.setReplicationSiteStatus(storageClass, 'PENDING');
+            objMD.setReplicationStatus('PENDING');
             objMD.updateMicroVersionId();
             const md = objMD.getValue();
             return metadataUtil.putMetadata({

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -150,6 +150,31 @@ function _markObjectPending(
                 return next();
             }
 
+            // Initialize replication info, if missing
+            if (!objMD.getReplicationInfo()
+                || !objMD.getReplicationSiteStatus(storageClass)) {
+                const { Rules, Role } = repConfig;
+                const destination = Rules[0].Destination.Bucket;
+                // set replication properties
+                const ops = objMD.getContentLength() === 0 ? ['METADATA']
+                    : ['METADATA', 'DATA'];
+                const backends = [{
+                    site: storageClass,
+                    status: 'PENDING',
+                    dataStoreVersionId: '',
+                }];
+                const replicationInfo = {
+                    status: 'PENDING',
+                    backends,
+                    content: ops,
+                    destination,
+                    storageClass,
+                    role: Role,
+                    storageType: STORAGE_TYPE,
+                };
+                objMD.setReplicationInfo(replicationInfo);
+            }
+
             objMD.setReplicationSiteStatus(storageClass, 'PENDING');
             objMD.setReplicationStatus('PENDING');
             objMD.updateMicroVersionId();


### PR DESCRIPTION
The code used to re-create the replication state, which could break some
fields (esp. dataLocation) or remove some replication backends.

We now simply update the status, which is safer (more future-proof) and
simpler.

In addition, the code will now avoid updating the internal version id (not
needed), or properly setup the "null version" flags if instructed to do this
"upgrade" of the object.

Issue: S3UTILS-77
