### PR TITLE
bugfix: S3UTILS-85 enforce version ID suffix

### DIFF
--- a/CompareRaftMembers/DBListStream.js
+++ b/CompareRaftMembers/DBListStream.js
@@ -80,11 +80,12 @@ class DBListStream extends stream.Transform {
                 return callback();
             }
         }
-
+        const versionedKey = vidSepPos === -1 && md.versionId
+            ? `${item.key}\0${md.versionId}` : item.key;
         if (this.isLegacyDb) {
-            this.push({ key: `${bucket}/${objectKey}`, value });
+            this.push({ key: `${bucket}/${versionedKey}`, value });
         } else {
-            this.push(item);
+            this.push({ key: versionedKey, value: item.value });
         }
         return callback();
     }

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ docker run \
 -e 'LISTING_DIGESTS_OUTPUT_DIR=/digests' \
 -v "${DIGESTS_PATH}:/digests" \
 -e 'NO_MISSING_KEY_CHECK=1' \
-registry.scality.com/s3utils/s3utils:1.13.0 \
+registry.scality.com/s3utils/s3utils:1.13.1 \
 node verifyBucketSproxydKeys.js \
 | tee -a verifyBucketSproxydKeys.log
 ```
@@ -668,7 +668,7 @@ docker run --net=host --rm \
 -e "LISTING_DIGESTS_INPUT_DIR=/digests" \
 -v "${PWD}/followerDiff-results:/followerDiff-results" \
 -e "DIFF_OUTPUT_FILE=/followerDiff-results/followerDiff-results.jsonl" \
-registry.scality.com/s3utils/s3utils:1.13.0 \
+registry.scality.com/s3utils/s3utils:1.13.1 \
 bash -c 'DATABASES=$(echo $DATABASES_GLOB) node CompareRaftMembers/followerDiff' \
 | tee -a followerDiff.log
 ```

--- a/tests/unit/CompareRaftMembers/BucketStream.js
+++ b/tests/unit/CompareRaftMembers/BucketStream.js
@@ -226,7 +226,11 @@ describe('BucketStream', () => {
                     }
                     const listingItem = buildItemFromIndex(nextIndex, flags);
                     const parsedValue = JSON.parse(item.value);
-                    expect(item.key).toEqual(`test-bucket/${listingItem.key}`);
+                    if (flags.hasVersionId && !flags.versionKey) {
+                        expect(item.key).toEqual(`test-bucket/${listingItem.key}\0${DUMMY_VERSION_ID}`);
+                    } else {
+                        expect(item.key).toEqual(`test-bucket/${listingItem.key}`);
+                    }
                     expect(parsedValue).toEqual(listingItem.value);
                     nextIndex += 1;
                 })

--- a/tests/unit/CompareRaftMembers/DBListStream.js
+++ b/tests/unit/CompareRaftMembers/DBListStream.js
@@ -66,7 +66,7 @@ describe('DBListStream', () => {
                 ],
                 listEntries: [
                     {
-                        key: 'bucket/object',
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
                         value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
                     },
                 ],
@@ -82,7 +82,7 @@ describe('DBListStream', () => {
                 ],
                 listEntries: [
                     {
-                        key: 'bucket/object',
+                        key: 'bucket/object\u000098345767321527999998RG001  74.489.8',
                         value: '{"versionId":"98345767321527999998RG001  74.489.8"}',
                     },
                 ],
@@ -130,7 +130,7 @@ describe('DBListStream', () => {
                 ],
                 listEntries: [
                     {
-                        key: 'bucket/object',
+                        key: 'bucket/object\u000098345767320931999999RG001  74.505.48',
                         value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
                     },
                     {
@@ -189,11 +189,11 @@ describe('DBListStream', () => {
                 ],
                 listEntries: [
                     {
-                        key: 'bucket/object',
+                        key: 'bucket/object\u000098345767320931999999RG001  74.505.48',
                         value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
                     },
                     {
-                        key: 'bucket/object3',
+                        key: 'bucket/object3\u000098345767320611999999RG001  74.519.84',
                         value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
                     },
                 ],
@@ -246,11 +246,11 @@ describe('DBListStream', () => {
                 ],
                 listEntries: [
                     {
-                        key: 'legacy/object',
+                        key: 'legacy/object\u000098345767320931999999RG001  74.505.48',
                         value: '{"versionId":"98345767320931999999RG001  74.505.48"}',
                     },
                     {
-                        key: 'legacy/object3',
+                        key: 'legacy/object3\u000098345767320611999999RG001  74.519.84',
                         value: '{"versionId":"98345767320611999999RG001  74.519.84"}',
                     },
                 ],


### PR DESCRIPTION
Always output versioned keys with their version suffix, even if we are
processing the master version. The change occurs in all places that
are used for divergence detection:

- in verifyBucketSproxydKeys to generate the digests database

- in the BucketStream and DBListStream helper classes used for the
  diff algorithm between a bucket listing and raw databases

This is useful to have a cleaner diff output and avoids some
shenanigans later during the repair process.

Update the procedure in README.md to point to the correct s3utils
image version.