### PR TITLE
improvement: S3UTILS-80 parse OLDER_THAN as days in the past

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,9 +877,14 @@ of a previous invocation of the script, uses the format:
     "|" encodeURI(versionId)
   ```
 
-* **OLDER_THAN**: cleanup only objects which last modified date is
-older than this date, e.g. setting to "2021-01-09T00:00:00Z" limits
-the cleanup to objects created or modified before Jan 9th 2021.
+* **OLDER_THAN**: cleanup only objects which last modified date is older
+than this, as an ISO date or a number of days, e.g.:
+
+  * setting to "2021-01-09T00:00:00Z" limits the cleanup to objects
+  created or modified before Jan 9th 2021
+
+  * setting to "30 days" limits the cleanup to objects created more
+  than 30 days ago
 
 * **ONLY_DELETED**: if set to "1" or "true" or "yes", only remove
 otherwise eligible noncurrent versions if the object's current version

--- a/cleanupNoncurrentVersions.js
+++ b/cleanupNoncurrentVersions.js
@@ -7,6 +7,8 @@ const { doWhilst, eachSeries } = require('async');
 
 const { Logger } = require('werelogs');
 
+const parseOlderThan = require('./utils/parseOlderThan');
+
 const log = new Logger('s3utils::cleanupNoncurrentVersions');
 
 function _parseBoolean(value) {
@@ -24,7 +26,7 @@ const MAX_LISTED = (process.env.MAX_LISTED
     && Number.parseInt(process.env.MAX_LISTED, 10));
 const { MARKER } = process.env;
 const OLDER_THAN = (process.env.OLDER_THAN
-    ? new Date(process.env.OLDER_THAN) : null);
+    ? parseOlderThan(process.env.OLDER_THAN) : null);
 const DELETED_BEFORE = (process.env.DELETED_BEFORE
     ? new Date(process.env.DELETED_BEFORE) : null);
 const ONLY_DELETED = _parseBoolean(process.env.ONLY_DELETED) || DELETED_BEFORE !== null;
@@ -63,8 +65,11 @@ Optional environment variables:
                 "|" encodeURI(key)
                 "|" encodeURI(versionId)
     OLDER_THAN: cleanup only objects which last modified date is older
-    than this date, e.g. setting to "2021-01-09T00:00:00Z" limits the
-    cleanup to objects created or modified before Jan 9th 2021.
+    than this, as an ISO date or a number of days, e.g.:
+     - setting to "2021-01-09T00:00:00Z" limits the cleanup to objects
+       created or modified before Jan 9th 2021
+     - setting to "30 days" limits the cleanup to objects created more
+       than 30 days ago
     ONLY_DELETED: if set to "1" or "true" or "yes", only remove
     otherwise eligible noncurrent versions if the object's current
     version is a delete marker (also removes the delete marker as

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ioctl": "2.0.2"
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^9.1.2",
     "eslint": "^8.8.0",
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-scality": "github:scality/Guidelines#8.2.0",

--- a/tests/unit/utils/parseOlderThan.js
+++ b/tests/unit/utils/parseOlderThan.js
@@ -1,0 +1,27 @@
+const FakeTimers = require('@sinonjs/fake-timers');
+const parseOlderThan = require('../../../utils/parseOlderThan');
+
+describe('parseOlderThan', () => {
+    let clock;
+    beforeAll(() => {
+        clock = FakeTimers.install({
+            now: new Date('2022-07-14T00:00:00Z'),
+        });
+    });
+    afterAll(() => {
+        clock.restore();
+    });
+
+    test('as a date given in ISO format', () => {
+        const d = parseOlderThan('2022-02-02T02:02:02Z');
+        expect(d.toISOString()).toEqual('2022-02-02T02:02:02.000Z');
+    });
+    test('as one day past the current date', () => {
+        const d = parseOlderThan('1 day');
+        expect(d.toISOString()).toEqual('2022-07-13T00:00:00.000Z');
+    });
+    test('as 30 days past the current date', () => {
+        const d = parseOlderThan('30 days');
+        expect(d.toISOString()).toEqual('2022-06-14T00:00:00.000Z');
+    });
+});

--- a/utils/parseOlderThan.js
+++ b/utils/parseOlderThan.js
@@ -1,0 +1,22 @@
+/**
+ * Parse an "older than" string to an absolute cutoff date object.
+ *
+ * @param {string} olderThan - string to parse: it can be specified in
+ * the following forms:
+ * - As an ISO date like "2022-07-14T12:30:00Z"
+ * - As a relative number of days in the past compared to now, like
+ *   "1 day" or "30 days"
+ * @return {Date} - the absolute cutoff date
+ */
+function parseOlderThan(olderThan) {
+    const numberOfDaysMatch = /^([0-9]+) days?$/.exec(olderThan);
+    if (numberOfDaysMatch) {
+        const numberOfDays = Number.parseInt(numberOfDaysMatch[1], 10);
+        const cutoff = new Date();
+        cutoff.setDate(cutoff.getDate() - numberOfDays);
+        return cutoff;
+    }
+    return new Date(olderThan);
+}
+
+module.exports = parseOlderThan;

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,20 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@sinonjs/commons@^1.7.0":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -6081,6 +6095,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
In cleanupNoncurrentObjects script, parse the optional OLDER_THAN
parameter as a number of days in the past, like "30 days", in addition
to providing a cutoff date directly in ISO format.