### PR TITLE
improvement: S3UTILS-89 RaftOplogStream

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
     "plugins": ["jest"],
     "env": {
         "es6": true,
+        "jasmine": true,
         "jest/globals": true
     },
     "parserOptions": {

--- a/CompareRaftMembers/RaftOplogStream.js
+++ b/CompareRaftMembers/RaftOplogStream.js
@@ -1,0 +1,196 @@
+const async = require('async');
+const http = require('http');
+const stream = require('stream');
+
+const DEFAULT_REFRESH_PERIOD_MS = 5000;
+const DEFAULT_MAX_RECORDS_PER_REQUEST = 1000;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10000;
+
+const httpAgent = new http.Agent({
+    keepAlive: true,
+});
+
+// this mapping comes from Metadata, see DbMethod in lib/protocol.json
+const DbMethodToString = {
+    0: 'CREATE',
+    1: 'DELETE',
+    2: 'GET',
+    3: 'PUT',
+    4: 'LIST',
+    5: 'DEL',
+    6: 'GET_ATTRIBUTES',
+    7: 'PUT_ATTRIBUTES',
+    8: 'BATCH',
+    9: 'NOOP',
+};
+
+/**
+ * @class RaftOplogStream
+ *
+ * @classdesc Readable stream that tails a raft session's oplog from
+ * bucketd, and emits individual entries as stream data events, as
+ * well as notifications when reaching the tail of the oplog.
+ *
+ * Each data event emitted is an object containing a unique "entry" attribute:
+ * {null|object} entry
+ *
+ * When entry is an non-null object, it contains the following attributes:
+ *     {string} method - database method converted to an upper-case
+ *         string, e.g. "BATCH", see Metadata lib/protocol.json for
+ *         the full list
+ *     {string} bucket  - bucket name
+ *     {string} [key]   - object key
+ *     {string} [value] - object value
+ *     {string} [type]  - 'del' refers to a delete operation in a batch
+ *
+ * When entry is null, it is a special event to notify that the tail
+ * of the log has been reached for the time being. Later on, if there
+ * are new events in the oplog, they will be emitted, and periodically
+ * new null entries will be emitted as well.
+ */
+class RaftOplogStream extends stream.Readable {
+    /**
+     * @constructor
+     * @param {object} params - constructor params
+     * @param {string} params.bucketdHost - hostname or IP address of bucketd
+     * @param {number} params.bucketdPort - bucketd API port
+     * @param {number} params.raftSessionId - raft session ID to tail
+     * @param {number} [params.startSeq=1] - start fetching oplog from this cseq
+     * @param {number} [params.refreshPeriodMs=5000] - time in milliseconds
+     * between two polls when reaching the oplog's tail
+     * @param {number} [params.maxRecordsPerRequest=1000] - maximum number
+     * of records to fetch in a single request to bucketd
+     * @param {number} [params.retryDelayMs=1000] - initial delay in
+     * milliseconds before retrying a failed request to bucketd
+     * @param {number} [params.maxRetryDelayMs=10000] - maximum delay
+     * in milliseconds between retry attempts of failed requests to
+     * bucketd
+     */
+    constructor(params) {
+        super({ objectMode: true });
+        const {
+            bucketdHost,
+            bucketdPort,
+            raftSessionId,
+            startSeq,
+            refreshPeriodMs,
+            maxRecordsPerRequest,
+            retryDelayMs: userRetryDelayMs,
+            maxRetryDelayMs: userMaxRetryDelayMs,
+        } = params;
+        this.bucketdHost = bucketdHost;
+        this.bucketdPort = bucketdPort;
+        this.raftSessionId = raftSessionId;
+        this.nextSeq = startSeq || 1;
+        this.refreshPeriodMs = refreshPeriodMs || DEFAULT_REFRESH_PERIOD_MS;
+        this.maxRecordsPerRequest = maxRecordsPerRequest || DEFAULT_MAX_RECORDS_PER_REQUEST;
+        const retryDelayMs = userRetryDelayMs || DEFAULT_RETRY_DELAY_MS;
+        const maxRetryDelayMs = userMaxRetryDelayMs || DEFAULT_MAX_RETRY_DELAY_MS;
+        this.retryParams = {
+            times: 20,
+            interval: retryCount => Math.min(
+                // the first retry comes as "retryCount=2", hence substract 2
+                retryDelayMs * (2 ** (retryCount - 2)),
+                maxRetryDelayMs,
+            ),
+        };
+        this.fetchMoreTimer = null;
+        this.canPush = false;
+    }
+
+    _read() {
+        this.canPush = true;
+        if (!this.fetchMoreTimer) {
+            this._fetchMoreOplogEntries();
+        }
+    }
+
+    _destroy() {
+        clearTimeout(this.fetchMoreTimer);
+    }
+
+    _requestWrapper(reqParams, cb) {
+        const req = http.request({
+            hostname: this.bucketdHost,
+            port: this.bucketdPort,
+            agent: httpAgent,
+            ...reqParams,
+        }, res => {
+            const chunks = [];
+            res.on('data', chunk => chunks.push(chunk));
+            res.once('end', () => {
+                if (res.statusCode === 416) {
+                    // log tail reached
+                    return cb();
+                }
+                if (res.statusCode !== 200) {
+                    return cb(new Error(`GET ${reqParams.path} returned status ${res.statusCode}`));
+                }
+                const body = chunks.join('');
+                return cb(null, { statusCode: res.statusCode, body });
+            });
+            res.once('error', err => cb(err));
+        });
+        req.once('error', err => cb(err));
+        req.end();
+    }
+
+    _onOplogTail() {
+        this.push({ entry: null });
+        this.fetchMoreTimer = setTimeout(
+            () => this._fetchMoreOplogEntries(),
+            this.refreshPeriodMs,
+        );
+    }
+
+    _fetchMoreOplogEntries() {
+        if (this.fetchMoreTimer) {
+            clearTimeout(this.fetchMoreTimer);
+            this.fetchMoreTimer = null;
+        }
+        if (!this.canPush) {
+            return undefined;
+        }
+        return async.retry(
+            this.retryParams,
+            done => this._requestWrapper({
+                method: 'GET',
+                path: `/_/raft_sessions/${this.raftSessionId}/log`
+                    + `?begin=${this.nextSeq}&limit=${this.maxRecordsPerRequest}`,
+            }, done),
+            (err, response) => {
+                if (err) {
+                    // error after retries: emit a stream error
+                    return this.emit('error', err);
+                }
+                // we should wait for the next call to _read() before pushing more entries
+                this.canPush = false;
+                if (!response) {
+                    return this._onOplogTail();
+                }
+                const parsedBody = JSON.parse(response.body);
+                this.nextSeq += parsedBody.log.length;
+                for (const record of parsedBody.log) {
+                    const { db: bucket, method } = record;
+                    for (const entry of record.entries) {
+                        this.push({
+                            entry: {
+                                method: DbMethodToString[method],
+                                bucket,
+                                ...entry,
+                            },
+                        });
+                    }
+                }
+                const { start, cseq } = parsedBody.info;
+                if (start + parsedBody.log.length === cseq + 1) {
+                    this._onOplogTail();
+                }
+                return undefined;
+            },
+        );
+    }
+}
+
+module.exports = RaftOplogStream;

--- a/tests/unit/CompareRaftMembers/RaftOplogStream.js
+++ b/tests/unit/CompareRaftMembers/RaftOplogStream.js
@@ -1,0 +1,185 @@
+const http = require('http');
+
+const RaftOplogStream = require('../../../CompareRaftMembers/RaftOplogStream');
+
+const HTTP_TEST_PORT = 9090;
+const TEST_OPLOG_NB_RECORDS = 123;
+const DUMMY_VERSION_ID = '987654321 FOOBAR42.42';
+
+function buildTestOplog() {
+    const oplog = [];
+    for (let r = 0; r < TEST_OPLOG_NB_RECORDS; ++r) {
+        const record = {
+            db: `bucket-${r}`,
+            method: 8, // BATCH
+            entries: [
+                {
+                    key: `key-${r}`,
+                    value: `value-${r}`,
+                },
+                {
+                    key: `key-${r}\u0000${DUMMY_VERSION_ID}`,
+                    value: `value-${r}`,
+                },
+                {
+                    key: `key-${r}`,
+                    type: 'del',
+                },
+                {
+                    key: `key-${r}\u0000${DUMMY_VERSION_ID}`,
+                    type: 'del',
+                },
+            ],
+        };
+        oplog.push(record);
+    }
+    return oplog;
+}
+
+const TEST_OPLOG = buildTestOplog();
+
+describe('RaftOplogStream', () => {
+    let httpServer;
+    let reqCount = 0;
+    beforeAll(done => {
+        const handleGetOplogRequest = (req, res, url) => {
+            const qsBegin = url.searchParams.get('begin');
+            const qsLimit = url.searchParams.get('limit');
+            const begin = qsBegin !== undefined
+                ? Number.parseInt(qsBegin, 10) : 1;
+            const limit = qsLimit !== undefined
+                ? Number.parseInt(qsLimit, 10) : 10000;
+            const oplogToSend = TEST_OPLOG.slice(begin - 1, begin - 1 + limit);
+            if (begin < 1 || oplogToSend.length === 0) {
+                res.writeHead(416);
+                return res.end();
+            }
+            const responseBody = JSON.stringify({
+                info: {
+                    start: begin,
+                    cseq: TEST_OPLOG.length,
+                    prune: 1,
+                },
+                log: oplogToSend,
+            });
+            res.writeHead(200, {
+                'Content-Type': 'application/json',
+                'Content-Length': responseBody.length,
+            });
+            return res.end(responseBody);
+        };
+        httpServer = http.createServer((req, res) => {
+            req.resume();
+            reqCount += 1;
+            // fail 1/3 requests to check retry behavior
+            if (reqCount % 3 === 0) {
+                res.writeHead(500);
+                return res.end('OOPS');
+            }
+            const url = new URL(req.url, `http://${req.headers.host}`);
+            if (url.pathname === '/_/raft_sessions/1/log') {
+                return handleGetOplogRequest(req, res, url);
+            }
+            throw new Error(`unexpected request path ${url.pathname}`);
+        });
+        httpServer.listen(HTTP_TEST_PORT);
+        httpServer.on('listening', done);
+    });
+    afterAll(done => {
+        httpServer.close(done);
+    });
+
+    [
+        {
+            desc: 'complete oplog',
+            expectedRange: [0, TEST_OPLOG.length],
+        },
+        {
+            desc: 'last log record',
+            startSeq: TEST_OPLOG.length,
+            expectedRange: [TEST_OPLOG.length - 1, TEST_OPLOG.length],
+        },
+        {
+            desc: 'already on log tail',
+            startSeq: TEST_OPLOG.length + 1,
+            expectedRange: [0, 0],
+        },
+    ].forEach(testCase => {
+        test(testCase.desc, done => {
+            const oplogStream = new RaftOplogStream({
+                bucketdHost: 'localhost',
+                bucketdPort: HTTP_TEST_PORT,
+                raftSessionId: 1,
+                startSeq: testCase.startSeq,
+                refreshPeriodMs: 100,
+                maxRecordsPerRequest: 10,
+                retryDelayMs: 50,
+                maxRetryDelayMs: 1000,
+            });
+            const [rangeStart, rangeEnd] = testCase.expectedRange;
+            const expectedOplogEntries = [];
+            for (let i = rangeStart; i < rangeEnd; ++i) {
+                const record = TEST_OPLOG[i];
+                for (const entry of record.entries) {
+                    expectedOplogEntries.push({
+                        method: 'BATCH',
+                        bucket: record.db,
+                        ...entry,
+                    });
+                }
+            }
+            // first null should come immediately on reaching the log tail
+            expectedOplogEntries.push(null);
+            let nextIndex = 0;
+            let expectSecondNullAfter = null;
+            oplogStream
+                .on('data', event => {
+                    const { entry } = event;
+                    if (expectSecondNullAfter) {
+                        expect(entry).toEqual(null);
+                        expect(Date.now()).toBeGreaterThan(expectSecondNullAfter);
+                        oplogStream.destroy();
+                        return done();
+                    }
+                    expect(entry).toEqual(expectedOplogEntries[nextIndex]);
+                    nextIndex += 1;
+                    if (nextIndex === expectedOplogEntries.length) {
+                        // second null should come after the refresh
+                        // period: check it to be coming at least a
+                        // little less than the refresh period
+                        expectSecondNullAfter = Date.now() + 90;
+                    }
+                    return undefined;
+                })
+                .on('end', () => {
+                    fail('oplog stream should not emit "end" event');
+                })
+                .on('error', err => {
+                    fail(`an error occurred: ${err}`);
+                });
+        });
+    });
+    test('stream should emit error after all retries fail', done => {
+        const oplogStream = new RaftOplogStream({
+            bucketdHost: 'localhost',
+            // change port to get connection errors
+            bucketdPort: HTTP_TEST_PORT + 1,
+            raftSessionId: 1,
+            startSeq: 42,
+            retryDelayMs: 10,
+            maxRetryDelayMs: 100,
+        });
+        oplogStream
+            .on('data', event => {
+                fail('should not have received a "data" event', event);
+            })
+            .on('end', () => {
+                fail('oplog stream should not emit "end" event');
+            })
+            .on('error', err => {
+                expect(err).toBeTruthy();
+                expect(err.code).toEqual('ECONNREFUSED');
+                done();
+            });
+    });
+});


### PR DESCRIPTION
Create a stream class to fetch a raft session's oplog from a specified
sequence until the tail, then keep tailing it for new records.