### PR TITLE
improvement: S3UTILS-86 helper to filter recently updated keys

### DIFF
--- a/CompareRaftMembers/DiffStreamOplogFilter.js
+++ b/CompareRaftMembers/DiffStreamOplogFilter.js
@@ -1,0 +1,240 @@
+const async = require('async');
+const http = require('http');
+const stream = require('stream');
+
+const RaftOplogStream = require('./RaftOplogStream');
+
+const DEFAULT_MAX_BUFFERED_ENTRIES = 10000;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10000;
+
+const httpAgent = new http.Agent({
+    keepAlive: true,
+});
+
+class DiffStreamOplogFilter extends stream.Transform {
+    constructor(params) {
+        super({ objectMode: true });
+        const {
+            bucketdHost,
+            bucketdPort,
+            maxBufferedEntries: userMaxBufferedEntries,
+            retryDelayMs: userRetryDelayMs,
+            maxRetryDelayMs: userMaxRetryDelayMs,
+        } = params;
+        this.bucketdHost = bucketdHost;
+        this.bucketdPort = bucketdPort;
+        this.maxBufferedEntries = userMaxBufferedEntries || DEFAULT_MAX_BUFFERED_ENTRIES;
+        const retryDelayMs = userRetryDelayMs || DEFAULT_RETRY_DELAY_MS;
+        const maxRetryDelayMs = userMaxRetryDelayMs || DEFAULT_MAX_RETRY_DELAY_MS;
+        this.retryParams = {
+            times: 20,
+            interval: retryCount => Math.min(
+                // the first retry comes as "retryCount=2", hence substract 2
+                retryDelayMs * (2 ** (retryCount - 2)),
+                maxRetryDelayMs,
+            ),
+        };
+        this.bucketNameToRaftSessionId = {};
+        this._initRaftOplogStreams(params);
+
+        this.nBufferedEntries = 0;
+        this.pendingTransformCallback = null;
+        this.pendingFlushCallback = null;
+    }
+
+    _initRaftOplogStreams(params) {
+        const {
+            bucketdHost, bucketdPort,
+            excludeFromCseqs,
+        } = params;
+
+        this.raftSessionStates = {};
+        for (const rsId of Object.keys(excludeFromCseqs)) {
+            const raftSessionState = {};
+            this.raftSessionStates[rsId] = raftSessionState;
+            const oplogStream = new RaftOplogStream({
+                bucketdHost,
+                bucketdPort,
+                raftSessionId: rsId,
+                startSeq: excludeFromCseqs[rsId] + 1,
+            });
+            this._setupOplogStream(raftSessionState, oplogStream);
+            raftSessionState.oplogStream = oplogStream;
+            raftSessionState.oplogKeys = new Set();
+            raftSessionState.inputBuffer = [];
+        }
+    }
+
+    _setupOplogStream(raftSessionState, oplogStream) {
+        // no 'end' event handling is required since the oplog streams never end
+        oplogStream
+            .on('data', data => this._onOplogEvent(raftSessionState, data))
+            .on('error', err => {
+                this.emit('error', err);
+            });
+    }
+
+    _onOplogEvent(raftSessionState, data) {
+        const { entry } = data;
+        if (entry === null) {
+            // a null entry means we reached the end of
+            // the raft oplog, this is the point where
+            // it becomes safe to process the raft
+            // session's current input buffer
+            this._processInputBuffer(raftSessionState);
+        } else if (entry.method === 'BATCH') {
+            // only consider events from BATCH records
+            const fullKey = `${entry.bucket}/${entry.key}`;
+            raftSessionState.oplogKeys.add(fullKey);
+        }
+    }
+
+    _transform(diffEntry, encoding, callback) {
+        const bucketName = this._extractBucketName(diffEntry);
+        async.waterfall([
+            next => {
+                const rsId = this.bucketNameToRaftSessionId[bucketName];
+                if (rsId !== undefined) {
+                    return next(null, rsId);
+                }
+                return this._fetchBucketRaftSessionId(bucketName, next);
+            },
+        ], (err, rsId) => {
+            if (err) {
+                this.emit('error', err);
+                return callback();
+            }
+            // bucket not found: ignore the entry
+            if (rsId === null) {
+                return callback();
+            }
+            const raftSessionState = this.raftSessionStates[rsId];
+            // if for some reason the returned raft session ID is not
+            // managed by us (e.g. a bucket has been recently
+            // recreated with a different raft session ID), ignore the
+            // entry
+            if (!raftSessionState) {
+                return callback();
+            }
+            raftSessionState.inputBuffer.push(diffEntry);
+            this.nBufferedEntries += 1;
+            if (this.nBufferedEntries !== this.maxBufferedEntries) {
+                // we can accept more input
+                return callback();
+            }
+            // wait until the current read buffer is flushed before
+            // accepting more input
+            this.pendingTransformCallback = callback;
+            return undefined;
+        });
+    }
+
+    _flush(callback) {
+        if (this.nBufferedEntries === 0) {
+            // end the output stream if there are no entries to forward
+            this.push(null);
+            return callback();
+        }
+        this.pendingFlushCallback = callback;
+        return undefined;
+    }
+
+    _destroy() {
+        for (const rsState of Object.values(this.raftSessionStates)) {
+            rsState.oplogStream.destroy();
+        }
+    }
+
+    /**
+     * Extract the bucket name from a diff entry coming from the stream's input
+     *
+     * @param {object} diffEntry - entry coming from DiffStream
+     * @return {string} - bucket name
+     */
+    _extractBucketName(diffEntry) {
+        const nonNullEntry = diffEntry[0] || diffEntry[1];
+        const { key: fullKey } = nonNullEntry;
+        const slashIndex = fullKey.indexOf('/');
+        const bucketName = fullKey.slice(0, slashIndex);
+        return bucketName;
+    }
+
+    _requestWrapper(reqParams, cb) {
+        const req = http.request({
+            hostname: this.bucketdHost,
+            port: this.bucketdPort,
+            agent: httpAgent,
+            ...reqParams,
+        }, res => {
+            const chunks = [];
+            res.on('data', chunk => chunks.push(chunk));
+            res.once('end', () => {
+                if (res.statusCode === 404) {
+                    return cb();
+                }
+                const body = chunks.join('');
+                if (res.statusCode !== 200) {
+                    return cb(new Error(`GET ${reqParams.path} returned status ${res.statusCode}`));
+                }
+                return cb(null, { statusCode: res.statusCode, body });
+            });
+            res.once('error', err => cb(err));
+        });
+        req.once('error', err => cb(err));
+        req.end();
+    }
+
+    _fetchBucketRaftSessionId(bucketName, cb) {
+        return async.retry(
+            this.retryParams,
+            done => this._requestWrapper({
+                method: 'GET',
+                path: `/_/buckets/${bucketName}/id`,
+            }, done),
+            (err, response) => {
+                if (err) {
+                    // error after retries
+                    return cb(err);
+                }
+                // no response means the bucket does not exist
+                // (assuming it has been recently deleted since it
+                // appears in a diff entry)
+                const rsId = response ? Number.parseInt(response.body, 10) : null;
+                this.bucketNameToRaftSessionId[bucketName] = rsId;
+                return cb(null, rsId);
+            },
+        );
+    }
+
+    _processInputBuffer(raftSessionState) {
+        const { inputBuffer } = raftSessionState;
+        // eslint-disable-next-line no-param-reassign
+        raftSessionState.inputBuffer = [];
+        this.nBufferedEntries -= inputBuffer.length;
+        for (const diffEntry of inputBuffer) {
+            const nonNullEntry = diffEntry[0] || diffEntry[1];
+            const { key: fullKey } = nonNullEntry;
+            // this is where the filtering occurs: only forward the
+            // entry if its key hasn't been seen in the latest oplog
+            // entries of the bucket's raft session
+            if (!raftSessionState.oplogKeys.has(fullKey)) {
+                this.push(diffEntry);
+            }
+        }
+        const { pendingTransformCallback, pendingFlushCallback } = this;
+        if (pendingTransformCallback) {
+            // call the transform callback to accept more input
+            this.pendingTransformCallback = null;
+            pendingTransformCallback();
+        }
+        if (pendingFlushCallback && this.nBufferedEntries === 0) {
+            // end the output stream if there are no more entries to forward
+            this.push(null);
+            this.pendingFlushCallback = null;
+            pendingFlushCallback();
+        }
+    }
+}
+
+module.exports = DiffStreamOplogFilter;

--- a/tests/unit/CompareRaftMembers/DiffStreamOplogFilter.js
+++ b/tests/unit/CompareRaftMembers/DiffStreamOplogFilter.js
@@ -1,0 +1,252 @@
+const http = require('http');
+const stream = require('stream');
+
+const { shuffle } = require('arsenal');
+
+const DiffStreamOplogFilter = require('../../../CompareRaftMembers/DiffStreamOplogFilter');
+
+const HTTP_TEST_PORT = 9090;
+
+class MockRaftOplogStream extends stream.Readable {
+    constructor(entriesToEmit, refreshPeriodMs) {
+        super({ objectMode: true });
+        this.entriesToEmit = entriesToEmit;
+        this.refreshPeriodMs = refreshPeriodMs;
+    }
+
+    _read() {
+        if (this.entriesToEmit.length > 0) {
+            // introduce a little delay between events to make sure
+            // the filter waits for oplog events before emitting
+            // output entries
+            setTimeout(() => {
+                this.push(this.entriesToEmit.shift());
+                if (this.entriesToEmit.length === 0) {
+                    this.push({ entry: null });
+                }
+            }, 10);
+        } else {
+            setTimeout(() => {
+                this.push({ entry: null });
+            }, this.refreshPeriodMs);
+        }
+    }
+}
+
+describe('DiffStreamOplogFilter', () => {
+    let httpServer;
+    let reqCount = 0;
+    beforeAll(done => {
+        const handleGetBucketRSRequest = (res, bucketName) => {
+            // simple mock matching bucket names "foo-on-rsX" to raft
+            // session X as long as 1 <= X <= 5
+            const bucketMatch = /-on-rs([1-5])$/.exec(bucketName);
+            if (bucketMatch) {
+                const rsIdStr = bucketMatch[1];
+                res.writeHead(200, {
+                    'Content-Length': 1,
+                });
+                return res.end(rsIdStr);
+            }
+            if (bucketName === 'bucket-with-error') {
+                res.writeHead(500);
+            } else {
+                res.writeHead(404);
+            }
+            return res.end();
+        };
+        httpServer = http.createServer((req, res) => {
+            req.resume();
+            reqCount += 1;
+            // fail 1/3 requests to check retry behavior
+            if (reqCount % 3 === 0) {
+                res.writeHead(500);
+                return res.end('OOPS');
+            }
+            const url = new URL(req.url, `http://${req.headers.host}`);
+            const bucketRsMatch = /^\/_\/buckets\/([a-z0-9-]+)\/id$/.exec(url.pathname);
+            if (bucketRsMatch) {
+                const bucketName = bucketRsMatch[1];
+                return handleGetBucketRSRequest(res, bucketName);
+            }
+            throw new Error(`unexpected request path ${url.pathname}`);
+        });
+        httpServer.listen(HTTP_TEST_PORT);
+        httpServer.once('listening', done);
+    });
+    afterAll(done => {
+        httpServer.close(done);
+    });
+
+    test('filtering test with mocks', done => {
+        const oplogFilter = new DiffStreamOplogFilter({
+            bucketdHost: 'localhost',
+            bucketdPort: HTTP_TEST_PORT,
+            maxBufferedEntries: 5,
+            excludeFromCseqs: {
+                1: 10,
+                2: 20,
+                3: 30,
+                4: 40,
+            },
+            retryDelayMs: 10,
+            maxRetryDelayMs: 100,
+        });
+        // Prepare some test diff entries and oplog entries with a
+        // nested loop over raft sessions, buckets and keys
+        //
+        // Note: we loop over raft sessions 0 to 5 but only 1-4 are monitored:
+        //
+        // - use the first loop iteration (phony raft session 0) to
+        // - create buckets with no raft session
+        //
+        // - use raft session 5 to create buckets attached to a raft
+        //   session not monitored by the filter
+        //
+        // In both cases, all entries belonging to those buckets
+        // should be filtered hence not appear in the output. This is
+        // consistent with cases where buckets would have been deleted
+        // during the scan, and possibly recreated to another raft
+        // session: in such case, all bucket keys were necessarily
+        // updated, so should be ignored.
+        const inputDiffEntries = [];
+        const latestOplogs = [];
+        for (let rs = 0; rs <= 5; ++rs) {
+            const latestRsOplog = [];
+            latestOplogs[rs] = latestRsOplog;
+            for (let b = 1; b <= 5; ++b) {
+                for (let k = 1; k <= 5; ++k) {
+                    const bucketName = `bucket${b}-on-rs${rs}`;
+                    const key = `key${k}`;
+                    // insert a diff entry that should pass through if on RS 1-4
+                    inputDiffEntries.push([{
+                        key: `${bucketName}/${key}`,
+                        value: 'foobar',
+                    }, null]);
+                    // insert a diff entry that should be filtered out
+                    // because the key appears somewhere in the latest
+                    // oplog
+                    inputDiffEntries.push([{
+                        key: `${bucketName}/${key}-updated`,
+                        value: 'oldfoobar',
+                    }, null]);
+                    // insert the updated key's oplog entry
+                    latestRsOplog.push({
+                        entry: {
+                            method: 'BATCH',
+                            bucket: bucketName,
+                            key: `${key}-updated`,
+                            value: 'newfoobar',
+                        },
+                    });
+                }
+            }
+        }
+        // shuffle both the input diff entries and each oplog to
+        // increase fuzziness in the test, and replace actual oplog
+        // streams by mocks
+        shuffle(inputDiffEntries);
+        for (let rs = 1; rs <= 4; ++rs) {
+            shuffle(latestOplogs[rs]);
+            oplogFilter.raftSessionStates[rs].oplogStream.destroy();
+            const mockOplogStream = new MockRaftOplogStream(latestOplogs[rs], 100);
+            oplogFilter.raftSessionStates[rs].oplogStream = mockOplogStream;
+            oplogFilter._setupOplogStream(oplogFilter.raftSessionStates[rs], mockOplogStream);
+        }
+        // ingest all diff entries in the shuffled order in the filter
+        // stream
+        for (const diffEntry of inputDiffEntries) {
+            oplogFilter.write(diffEntry);
+        }
+        oplogFilter.end();
+
+        // listen for output diff events and store them in a set for
+        // checking that they correspond to what should have been sent
+        const filteredDiffEntries = new Set();
+        oplogFilter
+            .on('data', data => {
+                // stringify in JSON to support quick lookup from the set
+
+                // note: diff entries are forwarded as is, the
+                // javascript objects embedded have their fields in
+                // the same order, which is retained in the
+                // stringified version
+                filteredDiffEntries.add(JSON.stringify(data));
+            })
+            .on('end', () => {
+                // check that all diff entries expected to be output
+                // have been output, i.e. only non-updated diff
+                // entries from RS 1 to 4
+                for (let rs = 1; rs <= 4; ++rs) {
+                    for (let b = 1; b <= 5; ++b) {
+                        for (let k = 1; k <= 5; ++k) {
+                            const bucketName = `bucket${b}-on-rs${rs}`;
+                            const key = `key${k}`;
+                            const outputDiffEntry = [{
+                                key: `${bucketName}/${key}`,
+                                value: 'foobar',
+                            }, null];
+                            const jsonOutputDiffEntry = JSON.stringify(outputDiffEntry);
+                            expect(filteredDiffEntries.has(jsonOutputDiffEntry)).toBeTruthy();
+                            filteredDiffEntries.delete(jsonOutputDiffEntry);
+                        }
+                    }
+                }
+                // check that no other entry than what was expected has been output
+                expect(filteredDiffEntries.size).toEqual(0);
+                done();
+            })
+            .on('error', err => {
+                fail(`an error occurred during filtering: ${err}`);
+            });
+    });
+
+    test('should handle an empty input stream', done => {
+        const oplogFilter = new DiffStreamOplogFilter({
+            bucketdHost: 'localhost',
+            bucketdPort: HTTP_TEST_PORT,
+            maxBufferedEntries: 5,
+            excludeFromCseqs: {},
+        });
+        oplogFilter.end();
+        oplogFilter
+            .on('data', event => {
+                fail('should not have received a "data" event', event);
+            })
+            .on('end', () => {
+                done();
+            })
+            .on('error', err => {
+                fail(`an error occurred during filtering: ${err}`);
+            });
+    });
+
+    test('should emit a stream error if failing to fetch RSID after retries', done => {
+        const oplogFilter = new DiffStreamOplogFilter({
+            bucketdHost: 'localhost',
+            bucketdPort: HTTP_TEST_PORT,
+            maxBufferedEntries: 5,
+            excludeFromCseqs: {
+                1: 10,
+            },
+            retryDelayMs: 10,
+            maxRetryDelayMs: 100,
+        });
+        oplogFilter.raftSessionStates[1].oplogStream.destroy();
+        const mockOplogStream = new MockRaftOplogStream([], 100);
+        oplogFilter.raftSessionStates[1].oplogStream = mockOplogStream;
+        oplogFilter._setupOplogStream(oplogFilter.raftSessionStates[1], mockOplogStream);
+        // this bucket name triggers a 500 error in the HTTP server
+        // mock when requested for its raft session ID
+        oplogFilter.write([{ key: 'bucket-with-error/key', value: 'foobar' }, null]);
+        oplogFilter.end();
+        oplogFilter
+            .on('data', event => {
+                fail('should not have received a "data" event', event);
+            })
+            .on('error', err => {
+                expect(err).toBeTruthy();
+                done();
+            });
+    });
+});


### PR DESCRIPTION
Create a helper class DiffStreamOplogFilter that tails all raft
sessions from the specified cseq offset in the background, while
ingesting diff entries. It then only forwards those which do not
appear in their respective raft session's oplog to the stream's
output.