### PR TITLE
improvement: S3UTILS-90 update followerDiff with oplog filtering

### DIFF
--- a/CompareRaftMembers/followerDiff.js
+++ b/CompareRaftMembers/followerDiff.js
@@ -76,13 +76,22 @@ Mandatory environment variables:
 Optional environment variables:
     LISTING_DIGESTS_INPUT_DIR: read listing digests from the specified LevelDB database
     PARALLEL_SCANS: number of databases to scan in parallel (default ${DEFAULT_PARALLEL_SCANS})
-    EXCLUDE_FROM_CSEQS: cseq values for a set of raft sessions, to filter
-        out diff entries which keys appear in the corresponding raft
-        journal later than the corresponding cseq value. The value must be
-        in the following JSON format:
+    EXCLUDE_FROM_CSEQS: mapping of raft sessions to filter on, where
+        keys are raft session IDs and values are the cseq value for that
+        raft session. Filtering will be based on all oplog records more
+        recent than the given "cseq" for the raft session. Input diff
+        entries not belonging to one of the declared raft sessions are
+        discarded from the output. The value must be in the following JSON
+        format:
             {"rsId":cseq[,"rsId":cseq...]}
         Example:
             {"1":1234,"4":4567,"6":6789}
+        This configuration would cause diff entries which bucket/key
+        appear in either of the following to be discarded from the output:
+        - oplog of raft session 1 after cseq=1234
+        - or oplog of raft session 4 after cseq=4567
+        - or oplog of raft session 6 after cseq=6789
+        - or any other raft session's oplog at any cseq
 `;
 
 if (!BUCKETD_HOSTPORT) {

--- a/README.md
+++ b/README.md
@@ -465,14 +465,28 @@ node followerDiff.js
 
 * **PARALLEL_SCANS**: number of databases to scan in parallel (default 4)
 
-* **EXCLUDE_FROM_CSEQS**: cseq values for a set of raft sessions, to
-  filter out diff entries which keys appear in the corresponding raft
-  journal later than the corresponding cseq value. The value must be
-  in the following JSON format:
+* **EXCLUDE_FROM_CSEQS**: mapping of raft sessions to filter on, where
+  keys are raft session IDs and values are the cseq value for that
+  raft session. Filtering will be based on all oplog records more
+  recent than the given "cseq" for the raft session. Input diff
+  entries not belonging to one of the declared raft sessions are
+  discarded from the output. The value must be in the following JSON
+  format:
 
   * `{"rsId":cseq[,"rsId":cseq...]}`
 
   * Example: `{"1":1234,"4":4567,"6":6789}`
+
+  * This configuration would cause diff entries which bucket/key
+    appear in either of the following to be discarded from the output:
+
+    * oplog of raft session 1 after cseq=1234
+
+    * or oplog of raft session 4 after cseq=4567
+
+    * or oplog of raft session 6 after cseq=6789
+
+    * or any other raft session's oplog at any cseq
 
 ## Scan Procedure
 

--- a/README.md
+++ b/README.md
@@ -461,9 +461,18 @@ node followerDiff.js
 ## Optional environment variables
 
 * **LISTING_DIGESTS_INPUT_DIR**: read listing digests from the
-    specified LevelDB database
+  specified LevelDB database
 
 * **PARALLEL_SCANS**: number of databases to scan in parallel (default 4)
+
+* **EXCLUDE_FROM_CSEQS**: cseq values for a set of raft sessions, to
+  filter out diff entries which keys appear in the corresponding raft
+  journal later than the corresponding cseq value. The value must be
+  in the following JSON format:
+
+  * `{"rsId":cseq[,"rsId":cseq...]}`
+
+  * Example: `{"1":1234,"4":4567,"6":6789}`
 
 ## Scan Procedure
 


### PR DESCRIPTION
Update the CompareRaftMembers/followerDiff script to accept a new
environment variable EXCLUDE_FROM_CSEQS: if passed with the current
cseq mapping of the raft sessions being scanned, it filters the diff
entries matching a key present in the corresponding bucket's raft
session oplog more recently than the given cseq.

The goal is to filter false positives due to the leader being ahead of
the follower being scanned (because the follower repds are stopped,
they cannot receive the newer updates).