### PR TITLE
bugfix: S3UTILS-94 exception if repairMaster=false

### DIFF
--- a/CompareRaftMembers/repairObjects.js
+++ b/CompareRaftMembers/repairObjects.js
@@ -314,7 +314,12 @@ function repairDiffEntry(diffEntry, cb) {
                     keyBucketdURL,
                     repairStrategy.repairMaster ? masterKeyBucketdURL : null,
                 ],
-                (url, urlDone) => repairObjectMD(url, repairMd, urlDone),
+                (url, urlDone) => {
+                    if (!url) {
+                        return urlDone();
+                    }
+                    return repairObjectMD(url, repairMd, urlDone);
+                },
                 err => {
                     if (err) {
                         log.error('error during repair of object metadata', {


### PR DESCRIPTION
Fix an exception occurring when not attempting to repair the master
key (missing check if url is null, do not attempt to repair it).