### PR TITLE
bugfix: S3UTILS-98 fix scan procedure for /scality/ssd1/ mountpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Example command:
 DATABASE_VOLUME_MOUNTS=$(docker inspect scality-metadata-bucket-repd \
 | jq -r '.[0].Mounts | map(select(.Source | contains("scality-metadata-databases-bucket")) | "-v \(.Source):\(.Destination)") | .[]')
 DATABASE_MASTER_MOUNTPOINT=$(docker inspect scality-metadata-bucket-repd \
-| jq -r '.[0].Mounts | map(select(.Source | contains("scality-metadata-databases-bucket") and contains("ssd01")) | .Destination) | .[]')
+| jq -r '.[0].Mounts | map(select(.Source | contains("scality-metadata-databases-bucket") and (contains("/ssd01/") or contains("/ssd1/"))) | .Destination) | .[]')
 
 mkdir -p followerDiff-results
 docker run --net=host --rm \


### PR DESCRIPTION
Make the procedure work for both /scality/ssd01/ and /scality/ssd1/ types of mountpoints