### PR TITLE
bugfix: S3UTILS-105 fix bucket stream hanging condition

### DIFF
--- a/CompareRaftMembers/BucketStream.js
+++ b/CompareRaftMembers/BucketStream.js
@@ -149,6 +149,7 @@ class BucketStream extends stream.Readable {
                         // retries: destroy the stream
                         return this.destroy(err);
                     }
+                    let hasPushed = false;
                     for (const item of listing) {
                         if (item) {
                             const fullKey = `${this.bucketName}/${item.key}`;
@@ -156,10 +157,14 @@ class BucketStream extends stream.Readable {
                                 key: fullKey,
                                 value: item.value,
                             });
+                            hasPushed = true;
                         }
                     }
                     if (IsTruncated && !ended) {
                         this.marker = Contents[Contents.length - 1].key;
+                        if (!hasPushed) {
+                            this._listMore();
+                        }
                     } else {
                         this.push(null);
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
When all entries listed by BucketStream class (followerDiff helper) are ignored, BucketStream needs to trigger the next listing manually because it did not call `this.push()` at all and the nodejs streams engine would not call `_read` again in such case.
