### PR TITLE
impr: S3UTILS-121 verify script reports empty metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.14",
+  "version": "1.13.15",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
Enhance verifyBucketSproxydKeys.js with the ability to report objects having empty metadata, such as those seen by S3C-5987.

Add an example script to delete such objects from the output logs of verifyBucketSproxydKeys.