### PR TITLE
Improvement/s3 utils 119 modify count items for storage metrics

### DIFF
--- a/CountItems/masterProcess.js
+++ b/CountItems/masterProcess.js
@@ -1,6 +1,6 @@
 const werelogs = require('werelogs');
 const { reshapeExceptionError } = require('arsenal').errorUtils;
-const { MongoClientInterface } = require('arsenal').storage.metadata.mongoclient;
+const S3UtilsMongoClient = require('../utils/S3UtilsMongoClient');
 
 const CountMaster = require('./CountMaster');
 const CountManager = require('./CountManager');
@@ -31,7 +31,7 @@ const countMaster = new CountMaster({
         workers: createWorkers(numWorkers),
         maxConcurrent: concurrentCursors,
     }),
-    client: new MongoClientInterface(createMongoParams(log)),
+    client: new S3UtilsMongoClient(createMongoParams(log)),
 });
 
 const handleSignal = sig => countMaster.stop(sig, () => process.exit(0));

--- a/CountItems/utils/constants.js
+++ b/CountItems/utils/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+    validStorageMetricLevels: new Set(['bucket', 'location', 'account']),
+};

--- a/CountItems/utils/utils.js
+++ b/CountItems/utils/utils.js
@@ -1,0 +1,40 @@
+function consolidateDataMetrics(target, source) {
+    let resTarget = {};
+    if (target && (target instanceof Object)) {
+        resTarget = {
+            usedCapacity: target.usedCapacity,
+            objectCount: target.objectCount,
+        };
+    }
+    if (!resTarget.usedCapacity) {
+        Object.assign(resTarget, {
+            usedCapacity: {
+                current: 0,
+                nonCurrent: 0,
+            },
+        });
+    }
+    if (!resTarget.objectCount) {
+        Object.assign(resTarget, {
+            objectCount: {
+                current: 0,
+                nonCurrent: 0,
+                deleteMarker: 0,
+            },
+        });
+    }
+    if (!source) {
+        return resTarget;
+    }
+    const { usedCapacity, objectCount } = source;
+    resTarget.usedCapacity.current += usedCapacity && usedCapacity.current ? usedCapacity.current : 0;
+    resTarget.usedCapacity.nonCurrent += usedCapacity && usedCapacity.nonCurrent ? usedCapacity.nonCurrent : 0;
+    resTarget.objectCount.current += objectCount && objectCount.current ? objectCount.current : 0;
+    resTarget.objectCount.nonCurrent += objectCount && objectCount.nonCurrent ? objectCount.nonCurrent : 0;
+    resTarget.objectCount.deleteMarker += objectCount && objectCount.deleteMarker ? objectCount.deleteMarker : 0;
+    return resTarget;
+}
+
+module.exports = {
+    consolidateDataMetrics,
+};

--- a/CountItems/workerProcess.js
+++ b/CountItems/workerProcess.js
@@ -1,6 +1,6 @@
 const werelogs = require('werelogs');
 const { reshapeExceptionError } = require('arsenal').errorUtils;
-const { MongoClientInterface } = require('arsenal').storage.metadata.mongoclient;
+const S3UtilsMongoClient = require('../utils/S3UtilsMongoClient');
 
 const CountWorker = require('./CountWorker');
 const createMongoParams = require('../utils/createMongoParams');
@@ -16,7 +16,7 @@ const log = new werelogs.Logger('S3Utils::CountItems::Worker');
 const worker = new CountWorker({
     log,
     sendFn: process.send.bind(process),
-    client: new MongoClientInterface(createMongoParams(log)),
+    client: new S3UtilsMongoClient(createMongoParams(log)),
 });
 
 process.on('message', data => worker.handleMessage(data));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.11",
+  "version": "1.13.12",
   "engines": {
     "node": ">= 16"
   },
@@ -55,6 +55,7 @@
     "eslint-config-scality": "github:scality/Guidelines#8.2.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.6.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "mongodb-memory-server": "^8.10.2"
   }
 }

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -11,7 +11,7 @@ module.exports = {
         _name: 'test-bucket',
         _owner: 'test-owner',
         _ownerDisplayName: 'test-name',
-        _creationDate: '',
+        _creationDate: new Date().toJSON(),
         _mdBucketModelVersion: 10,
         _transient: false,
         _deleted: false,

--- a/tests/functional/utils/S3UtilsMongoClient.js
+++ b/tests/functional/utils/S3UtilsMongoClient.js
@@ -1,0 +1,677 @@
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { BucketInfo } = require('arsenal').models;
+const { versioning } = require('arsenal');
+
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const S3UtilsMongoClient = require('../../../utils/S3UtilsMongoClient');
+const { mongoMemoryServerParams, createMongoParamsFromMongoMemoryRepl } = require('../../utils/mongoUtils');
+
+const logger = new werelogs.Logger('S3UtilsMongoClient', 'debug', 'debug');
+
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+
+const BUCKET_NAME = 'test-bucket';
+const ACCOUNT_NAME = 'test-account';
+
+
+const variations = [
+    { it: '(v0)', vFormat: BucketVersioningKeyFormat.v0 },
+    { it: '(v1)', vFormat: BucketVersioningKeyFormat.v1 },
+];
+
+describe('S3UtilsMongoClient::getObjectMDStats', () => {
+    let client;
+    let repl;
+
+    beforeAll(async done => {
+        repl = await MongoMemoryReplSet.create(mongoMemoryServerParams);
+        client = new S3UtilsMongoClient({
+            ...createMongoParamsFromMongoMemoryRepl(repl),
+            logger,
+        });
+        return client.setup(done);
+    });
+
+
+    afterAll(done => async.series([
+        next => client.close(next),
+        next => repl.stop()
+            .then(() => next())
+            .catch(next),
+    ], done));
+
+    const bucketMD = BucketInfo.fromObj({
+        _name: BUCKET_NAME,
+        _owner: 'testowner',
+        _ownerDisplayName: ACCOUNT_NAME,
+        _creationDate: new Date().toJSON(),
+        _acl: {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        },
+        _mdBucketModelVersion: 10,
+        _transient: false,
+        _deleted: false,
+        _serverSideEncryption: null,
+        _versioningConfiguration: null,
+        _locationConstraint: 'us-east-1',
+        _readLocationConstraint: null,
+        _cors: null,
+        _replicationConfiguration: null,
+        _lifecycleConfiguration: null,
+        _uid: '',
+        _isNFS: null,
+        ingestion: null,
+    });
+    const versionedBucketMD = {
+        ...bucketMD,
+        _versioningConfiguration: {
+            Status: 'Enabled',
+        },
+    };
+    const suspendedBucketMD = {
+        ...bucketMD,
+        _versioningConfiguration: {
+            Status: 'Suspended',
+        },
+    };
+
+    describe('Should get correct results for versioning disabled bucket', () => {
+        const versionParams = {
+            versioning: false,
+            versionId: null,
+        };
+        const object1Params = {
+            'key': 'non-versioned-test-object1',
+            'content-length': 10,
+            'dataStoreName': 'us-east-1',
+            'owner-display-name': ACCOUNT_NAME,
+            'replicationInfo': {
+                backends: [],
+            },
+        };
+        const object2Params = {
+            ...object1Params,
+            key: 'non-versioned-test-object2',
+        };
+        variations.forEach(variation => {
+            describe(variation.it, () => {
+                beforeEach(done => {
+                    async.series([
+                        next => {
+                            client.defaultBucketKeyFormat = variation.vFormat;
+                            return next();
+                        },
+                        next => client.createBucket(BUCKET_NAME, bucketMD, logger, next),
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1 again
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object2Params.key,
+                            object2Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object2
+                    ], done);
+                });
+
+                afterEach(done => client.deleteBucket(BUCKET_NAME, logger, done));
+
+                it(`Should get correct results ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: { 'us-east-1': { curr: 20, prev: 0 } },
+                            total: { curr: 20, prev: 0 },
+                        },
+                        objects: 2,
+                        stalled: 0,
+                        versions: 0,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                        },
+                    };
+                    return client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(BUCKET_NAME, bucketInfo, false, logger, (err, data) => {
+                            assert.deepStrictEqual(err, null);
+                            assert.deepStrictEqual(data, expected);
+                            return done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Should get correct results for versioning enabled bucket', () => {
+        const versionParams = {
+            versioning: true,
+            versionId: null,
+        };
+        const object1Params = {
+            'key': 'versioned-test-object1',
+            'content-length': 10,
+            'dataStoreName': 'us-east-1',
+            'owner-display-name': ACCOUNT_NAME,
+            'replicationInfo': {
+                backends: [],
+            },
+        };
+        const object2Params = {
+            ...object1Params,
+            key: 'versioned-test-object2',
+        };
+        variations.forEach(variation => {
+            const itOnlyInV1 = variation.vFormat === 'v1' ? it : it.skip;
+            describe(variation.it, () => {
+                beforeEach(done => {
+                    async.series([
+                        next => {
+                            client.defaultBucketKeyFormat = variation.vFormat;
+                            return next();
+                        },
+                        next => client.createBucket(BUCKET_NAME, versionedBucketMD, logger, next),
+                    ], done);
+                });
+
+                afterEach(done => client.deleteBucket(BUCKET_NAME, logger, done));
+
+                it(`Should get correct results ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: { 'us-east-1': { curr: 20, prev: 10 } },
+                            total: { curr: 20, prev: 10 },
+                        },
+                        objects: 2,
+                        stalled: 0,
+                        versions: 1,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                        },
+                    };
+                    return async.series([
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1 again
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object2Params.key,
+                            object2Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object2
+                    ], () => client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(
+                            BUCKET_NAME,
+                            bucketInfo,
+                            false,
+                            logger,
+                            (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.deepStrictEqual(data, expected);
+                                return done();
+                            },
+                        );
+                    }));
+                });
+
+                itOnlyInV1(`Should get correct results with deleteMarker ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: { 'us-east-1': { curr: 0, prev: 20 } },
+                            total: { curr: 0, prev: 20 },
+                        },
+                        objects: 0,
+                        stalled: 0,
+                        versions: 2,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 0, deleteMarker: 1, nonCurrent: 2 },
+                                    usedCapacity: { current: 0, nonCurrent: 20 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 0, deleteMarker: 1, nonCurrent: 2 },
+                                    usedCapacity: { current: 0, nonCurrent: 20 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 0, deleteMarker: 1, nonCurrent: 2 },
+                                    usedCapacity: { current: 0, nonCurrent: 20 },
+                                },
+                            },
+                        },
+                    };
+                    return async.series([
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            versionParams,
+                            logger,
+                            next,
+                        ), // put object1 again
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            {
+                                ...object1Params,
+                                'isDeleteMarker': true,
+                                'content-length': 0,
+                            },
+                            versionParams,
+                            logger,
+                            next,
+                        ), // delete object1
+                    ], () => client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(
+                            BUCKET_NAME,
+                            bucketInfo,
+                            false,
+                            logger,
+                            (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.deepStrictEqual(data, expected);
+                                return done();
+                            },
+                        );
+                    }));
+                });
+
+                it('should get correct results with lifecycle replication enabled '
+                    + `and location transient is true ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: {
+                                'us-east-1': { curr: 10, prev: 0 },
+                                'completed': { curr: 10, prev: 0 },
+                            },
+                            total: { curr: 20, prev: 0 },
+                        },
+                        objects: 2,
+                        stalled: 0,
+                        versions: 0,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 1, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 10, nonCurrent: 0 },
+                                },
+                                'completed': {
+                                    objectCount: { current: 1, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 10, nonCurrent: 0 },
+                                },
+                            },
+                        },
+                    };
+                    return async.series([
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            {
+                                ...object1Params,
+                                replicationInfo: {
+                                    status: 'PENDING',
+                                    backends: [
+                                        {
+                                            status: 'PENDING',
+                                            site: 'not-completed',
+                                        },
+                                        {
+                                            status: 'COMPLETED',
+                                            site: 'completed',
+                                        },
+                                    ],
+                                },
+                            },
+                            versionParams,
+                            logger,
+                            next,
+                        ), // object1 with one site pending and one site complete
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object2Params.key,
+                            {
+                                ...object2Params,
+                                replicationInfo: {
+                                    status: 'COMPLETED',
+                                    backends: [
+                                        {
+                                            status: 'COMPLETE',
+                                            site: 'completed',
+                                        },
+                                    ],
+                                },
+                            },
+                            versionParams,
+                            logger,
+                            next,
+                        ), // object2 with one site complete
+                    ], () => client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(
+                            BUCKET_NAME,
+                            bucketInfo,
+                            true,
+                            logger,
+                            (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.deepStrictEqual(data, expected);
+                                return done();
+                            },
+                        );
+                    }));
+                });
+
+                it('should get correct results with lifecycle replication enabled'
+                    + `and location transient is false ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: {
+                                'us-east-1': { curr: 20, prev: 0 },
+                                'completed': { curr: 10, prev: 0 },
+                            },
+                            total: { curr: 30, prev: 0 },
+                        },
+                        objects: 2,
+                        stalled: 0,
+                        versions: 0,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 20, nonCurrent: 0 },
+                                },
+                                'completed': {
+                                    objectCount: { current: 1, deleteMarker: 0, nonCurrent: 0 },
+                                    usedCapacity: { current: 10, nonCurrent: 0 },
+                                },
+                            },
+                        },
+                    };
+                    return async.series([
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            {
+                                ...object1Params,
+                                replicationInfo: {
+                                    status: 'PENDING',
+                                    backends: [
+                                        {
+                                            status: 'PENDING',
+                                            site: 'not-completed',
+                                        },
+                                        {
+                                            status: 'COMPLETED',
+                                            site: 'completed',
+                                        },
+                                    ],
+                                },
+                            },
+                            versionParams,
+                            logger,
+                            next,
+                        ), // object1 with one site pending and one site complete
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object2Params.key,
+                            {
+                                ...object2Params,
+                                replicationInfo: {
+                                    status: 'COMPLETED',
+                                    backends: [
+                                        {
+                                            status: 'COMPLETE',
+                                            site: 'completed',
+                                        },
+                                    ],
+                                },
+                            },
+                            versionParams,
+                            logger,
+                            next,
+                        ), // object2 with one site complete
+                    ], () => client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(
+                            BUCKET_NAME,
+                            bucketInfo,
+                            false,
+                            logger,
+                            (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.deepStrictEqual(data, expected);
+                                return done();
+                            },
+                        );
+                    }));
+                });
+            });
+        });
+    });
+
+    describe('Should get correct results for versioning suspended bucket', () => {
+        const object1Params = {
+            'key': 'test-object1',
+            'content-length': 10,
+            'dataStoreName': 'us-east-1',
+            'owner-display-name': ACCOUNT_NAME,
+            'replicationInfo': {
+                backends: [],
+            },
+        };
+        const object2Params = {
+            ...object1Params,
+            key: 'test-object2',
+        };
+        variations.forEach(variation => {
+            describe(variation.it, () => {
+                beforeEach(done => {
+                    async.series([
+                        next => {
+                            client.defaultBucketKeyFormat = variation.vFormat;
+                            return next();
+                        },
+                        next => client.createBucket(BUCKET_NAME, suspendedBucketMD, logger, next),
+                    ], done);
+                });
+
+                afterEach(done => client.deleteBucket(BUCKET_NAME, logger, done));
+
+                it(`Should get correct results ${variation.it}`, done => {
+                    const expected = {
+                        dataManaged: {
+                            locations: { 'us-east-1': { curr: 20, prev: 10 } },
+                            total: { curr: 20, prev: 10 },
+                        },
+                        objects: 2,
+                        stalled: 0,
+                        versions: 1,
+                        dataMetrics: {
+                            account: {
+                                [ACCOUNT_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                            bucket: {
+                                [BUCKET_NAME]: {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                            location: {
+                                'us-east-1': {
+                                    objectCount: { current: 2, deleteMarker: 0, nonCurrent: 1 },
+                                    usedCapacity: { current: 20, nonCurrent: 10 },
+                                },
+                            },
+                        },
+                    };
+                    return async.series([
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            object1Params,
+                            {
+                                versionId: null,
+                                versioning: true,
+                            },
+                            logger,
+                            next,
+                        ), // versioned object1 put before suspend
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object1Params.key,
+                            {
+                                ...object1Params,
+                                isNull: true,
+                            },
+                            {
+                                versionId: null,
+
+                            },
+                            logger,
+                            next,
+                        ), // null versioned object1
+                        next => client.putObject(
+                            BUCKET_NAME,
+                            object2Params.key,
+                            {
+                                ...object2Params,
+                                isNull: true,
+                            },
+                            {
+                                versionId: null,
+                            },
+                            logger,
+                            next,
+                        ), // null versioned object2
+                    ], () => client.getBucketAttributes(BUCKET_NAME, logger, (err, bucketInfo) => {
+                        assert.deepStrictEqual(err, null);
+                        return client.getObjectMDStats(
+                            BUCKET_NAME,
+                            bucketInfo,
+                            false,
+                            logger,
+                            (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.deepStrictEqual(data, expected);
+                                return done();
+                            },
+                        );
+                    }));
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/CountItems/CountManager.js
+++ b/tests/unit/CountItems/CountManager.js
@@ -43,6 +43,11 @@ describe('CountItems::CountManager', () => {
                 byLocation: {},
             },
             stalled: 0,
+            dataMetrics: {
+                account: {},
+                bucket: {},
+                location: {},
+            },
         });
         m._consolidateData({
             versions: 10,
@@ -51,6 +56,26 @@ describe('CountItems::CountManager', () => {
             dataManaged: {
                 total: { curr: 100, prev: 100 },
                 locations: { location1: { curr: 100, prev: 100 } },
+            },
+            dataMetrics: {
+                account: {
+                    account1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
+                bucket: {
+                    bucket1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
+                location: {
+                    location1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
             },
         });
         expect(m.store).toEqual({
@@ -63,6 +88,26 @@ describe('CountItems::CountManager', () => {
                 byLocation: { location1: { curr: 100, prev: 100 } },
             },
             stalled: 10,
+            dataMetrics: {
+                account: {
+                    account1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
+                bucket: {
+                    bucket1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
+                location: {
+                    location1: {
+                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                        usedCapacity: { current: 100, nonCurrent: 100 },
+                    },
+                },
+            },
         });
     });
 

--- a/tests/unit/CountItems/utils/utils.js
+++ b/tests/unit/CountItems/utils/utils.js
@@ -1,0 +1,60 @@
+const { consolidateDataMetrics } = require('../../../../CountItems/utils/utils');
+
+describe('CountItems::utils::consolidateDataMetrics', () => {
+    const zeroValueRes = {
+        usedCapacity: { current: 0, nonCurrent: 0 },
+        objectCount: { current: 0, nonCurrent: 0, deleteMarker: 0 },
+    };
+
+    const example1 = {
+        usedCapacity: { current: 10, nonCurrent: 10 },
+        objectCount: { current: 10, nonCurrent: 10, deleteMarker: 10 },
+    };
+
+    const example2 = {
+        usedCapacity: { current: 20, nonCurrent: 20 },
+        objectCount: { current: 20, nonCurrent: 20, deleteMarker: 20 },
+    };
+
+    test('should return zero-value if target and source are both undefined', () => {
+        const res = consolidateDataMetrics(undefined, undefined);
+        expect(res).toEqual(zeroValueRes);
+    });
+
+    test('should return zero-value if target and source are both empty', () => {
+        const res = consolidateDataMetrics({}, {});
+        expect(res).toEqual(zeroValueRes);
+    });
+
+    test('should return value of target if source are empty', () => {
+        const target = example1;
+        const res = consolidateDataMetrics(target, {});
+        expect(res).toEqual(target);
+    });
+
+    test('should return value of source if target are empty', () => {
+        const source = example1;
+        const res = consolidateDataMetrics({}, source);
+        expect(res).toEqual(source);
+    });
+
+    test('should correctly consolidate source and target', () => {
+        const source = example1;
+        const target = example1;
+        const res = consolidateDataMetrics(target, source);
+        expect(res).toEqual(example2);
+    });
+
+    test('should not consolidate data other than usedCapacity and objectCount', () => {
+        const source = {
+            usedCapacity123: example1.usedCapacity,
+            objectCount456: example1.objectCount,
+        };
+        const target = {
+            usedCapacity123: example1.usedCapacity,
+            objectCount456: example1.objectCount,
+        };
+        const res = consolidateDataMetrics(target, source);
+        expect(res).toEqual(zeroValueRes);
+    });
+});

--- a/tests/unit/utils/S3UtilsMongoClient.js
+++ b/tests/unit/utils/S3UtilsMongoClient.js
@@ -1,0 +1,887 @@
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { BucketInfo, ObjectMD } = require('arsenal').models;
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const S3UtilsMongoClient = require('../../../utils/S3UtilsMongoClient');
+const {
+    mongoMemoryServerParams,
+    createMongoParamsFromMongoMemoryRepl,
+} = require('../../utils/mongoUtils');
+
+const logger = new werelogs.Logger('S3UtilsMongoClient', 'debug', 'debug');
+
+const mongoTestClient = new S3UtilsMongoClient({});
+
+describe('S3UtilsMongoClient::_handleResults', () => {
+    const testInput = {
+        bucket: {
+            bucket1: {
+                masterCount: 2,
+                masterData: 20,
+                nullCount: 2,
+                nullData: 20,
+                versionCount: 4,
+                versionData: 40,
+                deleteMarkerCount: 2,
+            },
+        },
+        location: {
+            location1: {
+                masterCount: 1,
+                masterData: 10,
+                nullCount: 1,
+                nullData: 10,
+                versionCount: 2,
+                versionData: 20,
+                deleteMarkerCount: 1,
+            },
+            location2: {
+                masterCount: 1,
+                masterData: 10,
+                nullCount: 1,
+                nullData: 10,
+                versionCount: 2,
+                versionData: 20,
+                deleteMarkerCount: 1,
+            },
+        },
+        account: {
+            account1: {
+                masterCount: 2,
+                masterData: 20,
+                nullCount: 2,
+                nullData: 20,
+                versionCount: 4,
+                versionData: 40,
+                deleteMarkerCount: 2,
+            },
+        },
+    };
+    it('should return zero-result when input is empty', () => {
+        const testInputEmpty = {
+            bucket: {},
+            location: {},
+            account: {},
+        };
+        const testResults = mongoTestClient._handleResults(testInputEmpty, true);
+        const expectedRes = {
+            versions: 0,
+            objects: 0,
+            dataManaged: {
+                total: { curr: 0, prev: 0 },
+                locations: {},
+            },
+            dataMetrics: {
+                bucket: {},
+                location: {},
+                account: {},
+            },
+        };
+        assert.deepStrictEqual(testResults, expectedRes);
+    });
+
+    it('should return zero-result when input metric keys are not valid', () => {
+        const testInputWithInvalidMetricKeys = {
+            InvalidMetric0: testInput.bucket,
+            InvalidMetric1: testInput.location,
+            InvalidMetric2: testInput.account,
+        };
+        const testResults = mongoTestClient._handleResults(testInputWithInvalidMetricKeys, true);
+        const expectedRes = {
+            versions: 0,
+            objects: 0,
+            dataManaged: {
+                total: { curr: 0, prev: 0 },
+                locations: {},
+            },
+            dataMetrics: {
+                bucket: {},
+                location: {},
+                account: {},
+            },
+        };
+        assert.deepStrictEqual(testResults, expectedRes);
+    });
+
+    it('should return correct value if isVer is false', () => {
+        const testResults = mongoTestClient._handleResults(testInput, false);
+        const expectedRes = {
+            versions: 0,
+            objects: 4,
+            dataManaged: {
+                total: { curr: 40, prev: 0 },
+                locations: {
+                    location1: { curr: 20, prev: 0 },
+                    location2: { curr: 20, prev: 0 },
+                },
+            },
+            dataMetrics: {
+                bucket: {
+                    bucket1: {
+                        objectCount: { current: 4, deleteMarker: 0, nonCurrent: 0 },
+                        usedCapacity: { current: 40, nonCurrent: 0 },
+                    },
+                },
+                location: {
+                    location1: {
+                        objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                        usedCapacity: { current: 20, nonCurrent: 0 },
+                    },
+                    location2: {
+                        objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                        usedCapacity: { current: 20, nonCurrent: 0 },
+                    },
+                },
+                account: {
+                    account1: {
+                        objectCount: { current: 4, deleteMarker: 0, nonCurrent: 0 },
+                        usedCapacity: { current: 40, nonCurrent: 0 },
+                    },
+                },
+            },
+        };
+        assert.deepStrictEqual(testResults, expectedRes);
+    });
+
+    it('should return correct value if isVer is true', () => {
+        const testResults = mongoTestClient._handleResults(testInput, true);
+        const expectedRes = {
+            versions: 0,
+            objects: 4,
+            dataManaged: {
+                total: { curr: 40, prev: 20 },
+                locations: {
+                    location1: { curr: 20, prev: 10 },
+                    location2: { curr: 20, prev: 10 },
+                },
+            },
+            dataMetrics: {
+                bucket: {
+                    bucket1: {
+                        objectCount: { current: 4, deleteMarker: 2, nonCurrent: 0 },
+                        usedCapacity: { current: 40, nonCurrent: 20 },
+                    },
+                },
+                location: {
+                    location1: {
+                        objectCount: { current: 2, deleteMarker: 1, nonCurrent: 0 },
+                        usedCapacity: { current: 20, nonCurrent: 10 },
+                    },
+                    location2: {
+                        objectCount: { current: 2, deleteMarker: 1, nonCurrent: 0 },
+                        usedCapacity: { current: 20, nonCurrent: 10 },
+                    },
+                },
+                account: {
+                    account1: {
+                        objectCount: { current: 4, deleteMarker: 2, nonCurrent: 0 },
+                        usedCapacity: { current: 40, nonCurrent: 20 },
+                    },
+                },
+            },
+        };
+        assert.deepStrictEqual(testResults, expectedRes);
+    });
+
+    it('should calculate dataManaged based on input location metrics', () => {
+        const testInputOnlyContainsLocation = {
+            bucket: {},
+            location: testInput.location,
+            account: {},
+        };
+        const testResults = mongoTestClient._handleResults(testInputOnlyContainsLocation, true);
+        const expectedRes = {
+            dataManaged: {
+                total: { curr: 40, prev: 20 },
+                locations: {
+                    location1: { curr: 20, prev: 10 },
+                    location2: { curr: 20, prev: 10 },
+                },
+            },
+        };
+        assert.deepStrictEqual(testResults.dataManaged, expectedRes.dataManaged);
+    });
+
+    it('should calculate total current and nonCurrent counts based on input bucket metrics', () => {
+        const testInputOnlyContainsLocation = {
+            bucket: testInput.bucket,
+            location: {},
+            account: {},
+        };
+        const testResults = mongoTestClient._handleResults(testInputOnlyContainsLocation, true);
+        const expectedRes = {
+            versions: 0, objects: 4,
+        };
+        assert.deepStrictEqual(testResults.versions, expectedRes.versions);
+        assert.deepStrictEqual(testResults.objects, expectedRes.objects);
+    });
+});
+
+describe('S3UtilsMongoClient::_processEntryData', () => {
+    const testBucketName = 'testBucket';
+    const objectMdTemp = {
+        'last-modified': new Date(),
+        'replicationInfo': {
+            status: 'PENDING',
+            backends: [],
+            content: [],
+            destination: '',
+            storageClass: '',
+            role: '',
+            storageType: '',
+            dataStoreVersionId: '',
+            isNFS: null,
+        },
+        'transient': false,
+        'dataStoreName': 'us-east-1',
+        'content-length': 42,
+        'versionId': '0123456789abcdefg',
+        'owner-display-name': 'account1',
+    };
+    const tests = [
+        [
+            'should add content-length to current dataStore but not replication destination '
+            + 'if replication status != COMPLETED and transient == true',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey0',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        backends: [{
+                            site: 'not-completed',
+                            status: 'PENDING',
+                        }],
+                        status: 'PENDING',
+                    },
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: { 'us-east-1': 42 },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should not add content-length to replication destination but not in current dataStore '
+            + 'if replication status == COMPLETED and transient == true',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey1',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        backends: [{
+                            site: 'completed',
+                            status: 'COMPLETED',
+                        }],
+                        status: 'COMPLETED',
+                    },
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: { completed: 42 },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should add content-length to current dataStore but not replication destination '
+            + 'if replication status != COMPLETED and transient == false',
+            testBucketName,
+            false,
+            {
+                _id: 'testkey2',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        backends: [{
+                            site: 'not-completed',
+                            status: 'PENDING',
+                        }],
+                        status: 'PENDING',
+                    },
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: { 'us-east-1': 42 },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should add content-length to current dataStore and replication destination '
+            + 'if replication status == COMPLETED and transient == false',
+            testBucketName,
+            false,
+            {
+                _id: 'testkey3',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        backends: [{
+                            site: 'completed',
+                            status: 'COMPLETED',
+                        }],
+                        status: 'COMPLETED',
+                    },
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: { 'us-east-1': 42, 'completed': 42 },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should add content-length to each COMPLETED replication destination but not current dataStore '
+            + '(object replication status: COMPLETED)',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey4',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        status: 'COMPLETED',
+                        backends: [
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-1',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-2',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-3',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: {
+                        'completed-1': 42,
+                        'completed-2': 42,
+                        'completed-3': 42,
+                    },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should add content-length to each COMPLETED replications destination and current dataStore '
+            + '(object replication status: PENDING)',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey5',
+                value: {
+                    ...objectMdTemp,
+                    replicationInfo: {
+                        ...objectMdTemp.replicationInfo,
+                        status: 'PENDING',
+                        backends: [
+                            {
+                                status: 'PENDING',
+                                site: 'not-completed',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-1',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-2',
+                            },
+                        ],
+                    },
+                    transient: true,
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: {
+                        'us-east-1': 42,
+                        'completed-1': 42,
+                        'completed-2': 42,
+                    },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should return error if content-length is invalid',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey6',
+                value: {
+                    ...objectMdTemp,
+                    'content-length': 'not-a-number',
+                },
+            },
+            {
+                data: {},
+                error: new Error('invalid content length'),
+            },
+        ],
+        [
+            'should correctly process entry with string typed content-length',
+            testBucketName,
+            true,
+            {
+                _id: 'testkey7',
+                value: {
+                    ...objectMdTemp,
+                    'content-length': '42',
+                },
+            },
+            {
+                data: {
+                    account: { account1: 42 },
+                    bucket: { [testBucketName]: 42 },
+                    location: { 'us-east-1': 42 },
+                },
+                error: null,
+            },
+        ],
+        [
+            'should return error if bucketName is empty',
+            undefined,
+            true,
+            {
+                _id: 'testkey8',
+                value: objectMdTemp,
+            },
+            {
+                data: {},
+                error: new Error('no bucket name provided'),
+            },
+        ],
+    ];
+    tests.forEach(([msg, bucketName, isTransient, params, expected]) => it(msg, () => {
+        assert.deepStrictEqual(
+            mongoTestClient._processEntryData(bucketName, params, isTransient),
+            expected,
+        );
+    }));
+});
+
+function createBucket(client, bucketName, isVersioned, callback) {
+    const bucketMD = BucketInfo.fromObj({
+        _name: bucketName,
+        _owner: 'testowner',
+        _ownerDisplayName: 'testdisplayname',
+        _creationDate: new Date().toJSON(),
+        _acl: {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        },
+        _mdBucketModelVersion: 10,
+        _transient: false,
+        _deleted: false,
+        _serverSideEncryption: null,
+        _versioningConfiguration: isVersioned
+            ? { Status: 'Enabled' }
+            : null,
+        _locationConstraint: 'us-east-1',
+        _readLocationConstraint: null,
+        _cors: null,
+        _replicationConfiguration: null,
+        _lifecycleConfiguration: null,
+        _uid: '',
+        _isNFS: null,
+        ingestion: null,
+    });
+    client.createBucket(bucketName, bucketMD, logger, callback);
+}
+
+function uploadObjects(client, bucketName, objectList, callback) {
+    async.eachSeries(objectList, (obj, done) => {
+        const objMD = new ObjectMD()
+            .setKey(obj.name)
+            .setDataStoreName('us-east-1')
+            .setContentLength(100)
+            .setLastModified(obj.lastModified)
+            .setOwnerDisplayName(obj.ownerDisplayName)
+            .setIsNull(obj.isNull)
+            .setIsDeleteMarker(obj.isDeleteMarker);
+        if (obj.repInfo) {
+            objMD.setReplicationInfo(obj.repInfo);
+        }
+        client.putObject(bucketName, obj.name, objMD.getValue(), {
+            versionId: obj.versionId,
+            versioning: obj.versioning,
+        }, logger, done);
+    }, callback);
+}
+
+describe('S3UtilsMongoClient, tests', () => {
+    const hr = 1000 * 60 * 60;
+    let client;
+    let repl;
+    beforeAll(async done => {
+        repl = await MongoMemoryReplSet.create(mongoMemoryServerParams);
+        client = new S3UtilsMongoClient({
+            ...createMongoParamsFromMongoMemoryRepl(repl),
+            logger,
+        });
+        return client.setup(done);
+    });
+
+    afterAll(done => async.series([
+        next => client.close(next),
+        next => repl.stop()
+            .then(() => next())
+            .catch(next),
+    ], done));
+
+    const nonVersionedObjectMdTemp = {
+        name: 'testkey',
+        versioning: false,
+        versionId: null,
+        lastModified: new Date(Date.now()),
+        ownerDisplayName: 'testAccount',
+    };
+    const objectMdTemp = {
+        name: 'testkey',
+        versioning: true,
+        versionId: null,
+        lastModified: new Date(Date.now()),
+        ownerDisplayName: 'testAccount',
+        repInfo: {
+            status: 'COMPLETED',
+            backends: [
+                {
+                    status: 'COMPLETED',
+                    site: 'rep-loc-1',
+                },
+            ],
+            content: [],
+            destination: '',
+            storageClass: '',
+            role: '',
+            storageType: '',
+            dataStoreVersionId: '',
+            isNFS: null,
+        },
+    };
+
+    const tests = [
+        [
+            'getObjectMDStats() should return zero-result when no objects in the bucket',
+            {
+                bucketName: 'test-bucket',
+                isVersioned: false,
+                objectList: [],
+            },
+            {
+                dataManaged: {
+                    locations: {},
+                    total: { curr: 0, prev: 0 },
+                },
+                objects: 0,
+                stalled: 0,
+                versions: 0,
+                dataMetrics: {
+                    bucket: {},
+                    location: {},
+                    account: {},
+                },
+            },
+        ],
+        [
+            'getObjectMDStats() should return correct results',
+            {
+                bucketName: 'test-bucket',
+                isVersioned: true,
+                objectList: [
+                    // versioned object 1,
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                    },
+                    // versioned object 2,
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                    },
+                    // stalled object 1
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                        lastModified: new Date(Date.now() - hr),
+                        repInfo: {
+                            ...objectMdTemp.repInfo,
+                            status: 'PENDING',
+                            backends: [
+                                {
+                                    status: 'PENDING',
+                                    site: 'rep-loc-1',
+                                },
+                            ],
+                        },
+                    },
+                    // null versioned object
+                    {
+                        name: 'nullkey',
+                        isNull: true,
+                        ownerDisplayName: 'testAccount',
+                        lastModified: new Date(Date.now() - hr),
+                    },
+                ],
+            },
+            {
+                dataManaged: {
+                    locations: {
+                        'rep-loc-1': {
+                            curr: 0,
+                            prev: 200,
+                        },
+                        'us-east-1': {
+                            curr: 200,
+                            prev: 200,
+                        },
+                    },
+                    total: {
+                        curr: 200,
+                        prev: 400,
+                    },
+                },
+                objects: 2,
+                stalled: 1,
+                versions: 2,
+                dataMetrics: {
+                    account: {
+                        testAccount: {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 2 },
+                            usedCapacity: { current: 200, nonCurrent: 200 },
+                        },
+                    },
+                    bucket: {
+                        'test-bucket': {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 2 },
+                            usedCapacity: { current: 200, nonCurrent: 200 },
+                        },
+                    },
+                    location: {
+                        'rep-loc-1': {
+                            objectCount: { current: 0, deleteMarker: 0, nonCurrent: 2 },
+                            usedCapacity: { current: 0, nonCurrent: 200 },
+                        },
+                        'us-east-1': {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 2 },
+                            usedCapacity: { current: 200, nonCurrent: 200 },
+                        },
+                    },
+                },
+            },
+        ],
+        [
+            'getObjectMDStats() should return correct results for non versioned bucket',
+            {
+                bucketName: 'test-bucket',
+                isVersioned: false,
+                objectList: [
+                    // non versioned object 1,
+                    {
+                        ...nonVersionedObjectMdTemp,
+                        name: 'testkey1',
+                    },
+                    // non versioned object 1,
+                    {
+                        ...nonVersionedObjectMdTemp,
+                        name: 'testkey1',
+                    },
+                    // non versioned object 2
+                    {
+                        ...nonVersionedObjectMdTemp,
+                        name: 'testkey2',
+                    },
+                ],
+            },
+            {
+                dataManaged: {
+                    locations: {
+                        'us-east-1': {
+                            curr: 200,
+                            prev: 0,
+                        },
+                    },
+                    total: {
+                        curr: 200,
+                        prev: 0,
+                    },
+                },
+                objects: 2,
+                stalled: 0,
+                versions: 0,
+                dataMetrics: {
+                    account: {
+                        testAccount: {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                            usedCapacity: { current: 200, nonCurrent: 0 },
+                        },
+                    },
+                    bucket: {
+                        'test-bucket': {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                            usedCapacity: { current: 200, nonCurrent: 0 },
+                        },
+                    },
+                    location: {
+                        'us-east-1': {
+                            objectCount: { current: 2, deleteMarker: 0, nonCurrent: 0 },
+                            usedCapacity: { current: 200, nonCurrent: 0 },
+                        },
+                    },
+                },
+            },
+        ],
+        [
+            'getObjectMDStats() should return correct results for versioned bucket',
+            {
+                bucketName: 'test-bucket',
+                isVersioned: true,
+                objectList: [
+                    // a version of object 1,
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                    },
+                    // a version of object 1,
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                    },
+                    // deleteMarker of object 1
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                        isDeleteMarker: true,
+                    },
+                    // a version of object 1,
+                    {
+                        ...objectMdTemp,
+                        versioning: true,
+                        repInfo: {
+                            ...objectMdTemp.repInfo,
+                            status: 'PENDING',
+                            backends: [
+                                {
+                                    status: 'PENDING',
+                                    site: 'rep-loc-1',
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                dataManaged: {
+                    locations: {
+                        'rep-loc-1': {
+                            curr: 0,
+                            prev: 300,
+                        },
+                        'us-east-1': {
+                            curr: 100,
+                            prev: 300,
+                        },
+                    },
+                    total: {
+                        curr: 100,
+                        prev: 600,
+                    },
+                },
+                objects: 1,
+                stalled: 0,
+                versions: 2,
+                dataMetrics: {
+                    account: {
+                        testAccount: {
+                            objectCount: { current: 1, deleteMarker: 1, nonCurrent: 2 },
+                            usedCapacity: { current: 100, nonCurrent: 300 },
+                        },
+                    },
+                    bucket: {
+                        'test-bucket': {
+                            objectCount: { current: 1, deleteMarker: 1, nonCurrent: 2 },
+                            usedCapacity: { current: 100, nonCurrent: 300 },
+                        },
+                    },
+                    location: {
+                        'rep-loc-1': {
+                            objectCount: { current: 0, deleteMarker: 1, nonCurrent: 2 },
+                            usedCapacity: { current: 0, nonCurrent: 300 },
+                        },
+                        'us-east-1': {
+                            objectCount: { current: 1, deleteMarker: 1, nonCurrent: 2 },
+                            usedCapacity: { current: 100, nonCurrent: 300 },
+                        },
+                    },
+                },
+            },
+        ],
+    ];
+    tests.forEach(([msg, testCase, expected]) => it(msg, done => {
+        const {
+            bucketName,
+            isVersioned,
+            objectList,
+        } = testCase;
+        return async.waterfall([
+            next => createBucket(client, bucketName, isVersioned, err => next(err)),
+            next => uploadObjects(client, bucketName, objectList, err => next(err)),
+            next => client.getBucketAttributes(bucketName, logger, next),
+            (bucketInfo, next) => client.getObjectMDStats(
+                bucketName,
+                BucketInfo.fromObj(bucketInfo),
+                false,
+                logger,
+                (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    assert.deepStrictEqual(res, expected);
+                    return next();
+                },
+            ),
+            next => client.deleteBucket(bucketName, logger, next),
+        ], done);
+    }));
+});

--- a/tests/utils/mongoUtils.js
+++ b/tests/utils/mongoUtils.js
@@ -1,0 +1,33 @@
+
+const mongoMemoryServerParams = {
+    debug: true,
+    instanceOpts: [
+        { port: 27018 },
+    ],
+    replSet: {
+        name: 'customSetName',
+        count: 1,
+        dbName: 'metadata',
+        storageEngine: 'ephemeralForTest',
+    },
+};
+
+function createMongoParamsFromMongoMemoryRepl(repl) {
+    const {
+        ip, port, dbName, replSet,
+    } = repl.servers[0].instanceInfo;
+    return {
+        replicaSetHosts:
+            `${ip}:${port}`,
+        writeConcern: 'majority',
+        replicaSet: replSet,
+        readPreference: 'primary',
+        database: dbName,
+        replicationGroupId: 'GR001',
+    };
+}
+
+module.exports = {
+    createMongoParamsFromMongoMemoryRepl,
+    mongoMemoryServerParams,
+};

--- a/utils/S3UtilsMongoClient.js
+++ b/utils/S3UtilsMongoClient.js
@@ -1,0 +1,243 @@
+const { MongoClientInterface } = require('arsenal').storage.metadata.mongoclient;
+const { validStorageMetricLevels } = require('../CountItems/utils/constants');
+
+class S3UtilsMongoClient extends MongoClientInterface {
+    getObjectMDStats(bucketName, bucketInfo, isTransient, log, callback) {
+        const c = this.getCollection(bucketName);
+        const cursor = c.find({}, {
+            projection: {
+                '_id': 1,
+                'value.last-modified': 1,
+                'value.replicationInfo': 1,
+                'value.dataStoreName': 1,
+                'value.content-length': 1,
+                'value.versionId': 1,
+                'value.owner-display-name': 1,
+                'value.isDeleteMarker': 1,
+                'value.isNull': 1,
+            },
+        });
+        const collRes = {
+            bucket: {}, // bucket level metrics
+            location: {}, // location level metrics
+            account: {}, // account level metrics
+        };
+        let stalledCount = 0;
+        const cmpDate = new Date();
+        cmpDate.setHours(cmpDate.getHours() - 1);
+
+        cursor.forEach(
+            res => {
+                const { data, error } = this._processEntryData(bucketName, res, isTransient);
+
+                if (error) {
+                    log.error('Failed to process entry data', {
+                        method: 'getObjectMDStats',
+                        entry: res,
+                        error,
+                    });
+                }
+
+                let targetCount;
+                let targetData;
+                if (res._id.indexOf('\0') !== -1) {
+                    // versioned item
+                    targetCount = 'versionCount';
+                    targetData = 'versionData';
+
+                    if (res.value.replicationInfo.backends.length > 0
+                        && this._isReplicationEntryStalled(res, cmpDate)) {
+                        stalledCount++;
+                    }
+                } else if (!!res.value.versionId && !res.value.isNull) {
+                    // master version
+                    // includes current objects in versioned bucket and
+                    // objects uploaded before bucket suspended
+                    targetCount = 'masterCount';
+                    targetData = 'masterData';
+                } else {
+                    // null version
+                    // include current objects in nonversioned bucket and
+                    // objects uploaded after bucket suspended
+                    targetCount = 'nullCount';
+                    targetData = 'nullData';
+                }
+                Object.keys(data).forEach(metricLevel => {
+                    // metricLevel can only be 'bucket', 'location' or 'account'
+                    if (validStorageMetricLevels.has(metricLevel)) {
+                        Object.keys(data[metricLevel]).forEach(resourceName => {
+                            // resourceName can be the name of bucket, location or account
+                            if (!collRes[metricLevel][resourceName]) {
+                                collRes[metricLevel][resourceName] = {
+                                    masterCount: 0,
+                                    masterData: 0,
+                                    nullCount: 0,
+                                    nullData: 0,
+                                    versionCount: 0,
+                                    versionData: 0,
+                                    deleteMarkerCount: 0,
+                                };
+                            }
+                            collRes[metricLevel][resourceName][targetData] += data[metricLevel][resourceName];
+                            collRes[metricLevel][resourceName][targetCount]++;
+                            collRes[metricLevel][resourceName].deleteMarkerCount += res.value.isDeleteMarker ? 1 : 0;
+                        });
+                    }
+                });
+            },
+            err => {
+                if (err) {
+                    log.error('Error when processing mongo entries', {
+                        method: 'getObjectMDStats',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                const bucketStatus = bucketInfo.getVersioningConfiguration();
+                const isVer = (bucketStatus && (bucketStatus.Status === 'Enabled'
+                    || bucketStatus.Status === 'Suspended'));
+                const retResult = this._handleResults(collRes, isVer);
+                retResult.stalled = stalledCount;
+                return callback(null, retResult);
+            },
+        );
+    }
+
+    /**
+     * @param{string} bucketName -
+     * @param{object} entry -
+     * @param{string} entry._id -
+     * @param{object} entry.value -
+     * @param{boolean} isTransient -
+     * @returns{object.<string, number>} results -
+     */
+    _processEntryData(bucketName, entry, isTransient) {
+        if (!bucketName) {
+            return {
+                data: {},
+                error: new Error('no bucket name provided'),
+            };
+        }
+
+        const size = Number.parseInt(entry.value['content-length'], 10);
+        if (Number.isNaN(size)) {
+            return {
+                data: {},
+                error: new Error('invalid content length'),
+            };
+        }
+
+        const results = {
+            // there will be only one bucket for an object entry
+            bucket: { [bucketName]: size },
+            // there can be multiple locations for an object entry
+            location: {},
+            // there will be only one account for an object entry
+            account: { [entry.value['owner-display-name']]: size },
+        };
+
+        if (!isTransient
+            || entry.value.replicationInfo.status !== 'COMPLETED') {
+            // only count it in current dataStore if object is not in transient or replication not completed
+            results.location[entry.value.dataStoreName] = size;
+        }
+        entry.value.replicationInfo.backends.forEach(rep => {
+            // count it in the replication destination location if replication compeleted
+            if (rep.status === 'COMPLETED') {
+                results.location[rep.site] = size;
+            }
+        });
+        return {
+            data: results,
+            error: null,
+        };
+    }
+
+    _handleResults(res, isVersioned) {
+        let totalNonCurrentCount = 0;
+        let totalCurrentCount = 0;
+        const totalBytes = { curr: 0, prev: 0 };
+        const locationBytes = {};
+        const dataMetrics = {
+            bucket: {},
+            location: {},
+            account: {},
+        };
+
+        Object.keys(res).forEach(metricLevel => {
+            // metricLevel can only be 'bucket', 'location' or 'account'
+            if (validStorageMetricLevels.has(metricLevel)) {
+                Object.keys(res[metricLevel]).forEach(resource => {
+                    // resource can be the name of bucket, location or account
+                    const resourceName = metricLevel === 'location' ? this._getLocName(resource) : resource;
+                    if (!dataMetrics[metricLevel][resourceName]) {
+                        dataMetrics[metricLevel][resourceName] = {
+                            usedCapacity: {
+                                current: 0,
+                                nonCurrent: 0,
+                            },
+                            objectCount: {
+                                current: 0,
+                                nonCurrent: 0,
+                                deleteMarker: 0,
+                            },
+                        };
+                    }
+                    const {
+                        masterCount,
+                        masterData,
+                        nullCount,
+                        nullData,
+                        versionCount,
+                        versionData,
+                        deleteMarkerCount,
+                    } = res[metricLevel][resourceName];
+
+                    dataMetrics[metricLevel][resourceName].usedCapacity.current += nullData + masterData;
+                    dataMetrics[metricLevel][resourceName].objectCount.current += nullCount + masterCount;
+
+                    if (isVersioned) {
+                        dataMetrics[metricLevel][resourceName].usedCapacity.nonCurrent
+                            += versionData - masterData; // masterData is duplicated in versionedData
+                        dataMetrics[metricLevel][resourceName].usedCapacity.nonCurrent = Math.max(dataMetrics[metricLevel][resourceName].usedCapacity.nonCurrent, 0);
+                        dataMetrics[metricLevel][resourceName].objectCount.nonCurrent
+                            += versionCount - masterCount - deleteMarkerCount;
+                        dataMetrics[metricLevel][resourceName].objectCount.nonCurrent = Math.max(dataMetrics[metricLevel][resourceName].objectCount.nonCurrent, 0);
+                        dataMetrics[metricLevel][resourceName].objectCount.deleteMarker += deleteMarkerCount;
+                    }
+
+                    if (metricLevel === 'location') { // calculate usedCapacity metrics at global and location level
+                        totalBytes.curr += nullData + masterData;
+                        if (!locationBytes[resourceName]) {
+                            locationBytes[resourceName] = { curr: 0, prev: 0 };
+                        }
+                        locationBytes[resourceName].curr += nullData + masterData;
+                        if (isVersioned) {
+                            totalBytes.prev += versionData;
+                            totalBytes.prev -= masterData;
+                            totalBytes.prev = Math.max(0, totalBytes.prev);
+                            locationBytes[resourceName].prev += versionData;
+                            locationBytes[resourceName].prev -= masterData;
+                            locationBytes[resourceName].prev = Math.max(0, locationBytes[resourceName].prev);
+                        }
+                    }
+                    if (metricLevel === 'bucket') { // count objects up of all buckets
+                        totalCurrentCount += (masterCount + nullCount);
+                        totalNonCurrentCount += isVersioned ? (versionCount - masterCount - deleteMarkerCount) : 0;
+                    }
+                });
+            }
+        });
+        return {
+            versions: Math.max(0, totalNonCurrentCount),
+            objects: totalCurrentCount,
+            dataManaged: {
+                total: totalBytes,
+                locations: locationBytes,
+            },
+            dataMetrics,
+        };
+    }
+}
+
+module.exports = S3UtilsMongoClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,752 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz#9c39f4a5558196636031a933ec1b4792de959d6a"
+  integrity sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz#c81e5d378b8a74ff1671b58632779986e50f4c99"
+  integrity sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==
+  dependencies:
+    "@aws-crypto/util" "^2.0.2"
+    "@aws-sdk/types" "^3.110.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz#9f02aafad8789cac9c0ab5faaebb1ab8aa841338"
+  integrity sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.2.tgz#adf5ff5dfbc7713082f897f1d01e551ce0edb9c0"
+  integrity sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==
+  dependencies:
+    "@aws-sdk/types" "^3.110.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz#3adffb8ee5af57ddb154e8544a8eeec76ad32271"
+  integrity sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-cognito-identity@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.236.0.tgz#bec1a6625d1b34b0014a8ded15d70557643ee7e9"
+  integrity sha512-lWGuTVA+q3h1KS3nxTWeRGOfsuQ+GNwq5IxFJ8ko441mpwo5A2t6u25Z+G6t5Eh+q4EcoxMX64HYA+cu91lr7g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.236.0"
+    "@aws-sdk/config-resolver" "3.234.0"
+    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/fetch-http-handler" "3.226.0"
+    "@aws-sdk/hash-node" "3.226.0"
+    "@aws-sdk/invalid-dependency" "3.226.0"
+    "@aws-sdk/middleware-content-length" "3.226.0"
+    "@aws-sdk/middleware-endpoint" "3.226.0"
+    "@aws-sdk/middleware-host-header" "3.226.0"
+    "@aws-sdk/middleware-logger" "3.226.0"
+    "@aws-sdk/middleware-recursion-detection" "3.226.0"
+    "@aws-sdk/middleware-retry" "3.235.0"
+    "@aws-sdk/middleware-serde" "3.226.0"
+    "@aws-sdk/middleware-signing" "3.226.0"
+    "@aws-sdk/middleware-stack" "3.226.0"
+    "@aws-sdk/middleware-user-agent" "3.226.0"
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/node-http-handler" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/smithy-client" "3.234.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.234.0"
+    "@aws-sdk/util-defaults-mode-node" "3.234.0"
+    "@aws-sdk/util-endpoints" "3.226.0"
+    "@aws-sdk/util-retry" "3.229.0"
+    "@aws-sdk/util-user-agent-browser" "3.226.0"
+    "@aws-sdk/util-user-agent-node" "3.226.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso-oidc@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz#501cc3f69bdfc1b538b3b89d1166bc80dd86a461"
+  integrity sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.234.0"
+    "@aws-sdk/fetch-http-handler" "3.226.0"
+    "@aws-sdk/hash-node" "3.226.0"
+    "@aws-sdk/invalid-dependency" "3.226.0"
+    "@aws-sdk/middleware-content-length" "3.226.0"
+    "@aws-sdk/middleware-endpoint" "3.226.0"
+    "@aws-sdk/middleware-host-header" "3.226.0"
+    "@aws-sdk/middleware-logger" "3.226.0"
+    "@aws-sdk/middleware-recursion-detection" "3.226.0"
+    "@aws-sdk/middleware-retry" "3.235.0"
+    "@aws-sdk/middleware-serde" "3.226.0"
+    "@aws-sdk/middleware-stack" "3.226.0"
+    "@aws-sdk/middleware-user-agent" "3.226.0"
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/node-http-handler" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/smithy-client" "3.234.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.234.0"
+    "@aws-sdk/util-defaults-mode-node" "3.234.0"
+    "@aws-sdk/util-endpoints" "3.226.0"
+    "@aws-sdk/util-retry" "3.229.0"
+    "@aws-sdk/util-user-agent-browser" "3.226.0"
+    "@aws-sdk/util-user-agent-node" "3.226.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz#eba16f73abb9639bfdafeeb64d5c9771db2a4cc9"
+  integrity sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.234.0"
+    "@aws-sdk/fetch-http-handler" "3.226.0"
+    "@aws-sdk/hash-node" "3.226.0"
+    "@aws-sdk/invalid-dependency" "3.226.0"
+    "@aws-sdk/middleware-content-length" "3.226.0"
+    "@aws-sdk/middleware-endpoint" "3.226.0"
+    "@aws-sdk/middleware-host-header" "3.226.0"
+    "@aws-sdk/middleware-logger" "3.226.0"
+    "@aws-sdk/middleware-recursion-detection" "3.226.0"
+    "@aws-sdk/middleware-retry" "3.235.0"
+    "@aws-sdk/middleware-serde" "3.226.0"
+    "@aws-sdk/middleware-stack" "3.226.0"
+    "@aws-sdk/middleware-user-agent" "3.226.0"
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/node-http-handler" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/smithy-client" "3.234.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.234.0"
+    "@aws-sdk/util-defaults-mode-node" "3.234.0"
+    "@aws-sdk/util-endpoints" "3.226.0"
+    "@aws-sdk/util-retry" "3.229.0"
+    "@aws-sdk/util-user-agent-browser" "3.226.0"
+    "@aws-sdk/util-user-agent-node" "3.226.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz#8f3d793d627edf72ae80ffc50e7982b6cbcfd3f7"
+  integrity sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.234.0"
+    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/fetch-http-handler" "3.226.0"
+    "@aws-sdk/hash-node" "3.226.0"
+    "@aws-sdk/invalid-dependency" "3.226.0"
+    "@aws-sdk/middleware-content-length" "3.226.0"
+    "@aws-sdk/middleware-endpoint" "3.226.0"
+    "@aws-sdk/middleware-host-header" "3.226.0"
+    "@aws-sdk/middleware-logger" "3.226.0"
+    "@aws-sdk/middleware-recursion-detection" "3.226.0"
+    "@aws-sdk/middleware-retry" "3.235.0"
+    "@aws-sdk/middleware-sdk-sts" "3.226.0"
+    "@aws-sdk/middleware-serde" "3.226.0"
+    "@aws-sdk/middleware-signing" "3.226.0"
+    "@aws-sdk/middleware-stack" "3.226.0"
+    "@aws-sdk/middleware-user-agent" "3.226.0"
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/node-http-handler" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/smithy-client" "3.234.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.234.0"
+    "@aws-sdk/util-defaults-mode-node" "3.234.0"
+    "@aws-sdk/util-endpoints" "3.226.0"
+    "@aws-sdk/util-retry" "3.229.0"
+    "@aws-sdk/util-user-agent-browser" "3.226.0"
+    "@aws-sdk/util-user-agent-node" "3.226.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    fast-xml-parser "4.0.11"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.234.0":
+  version "3.234.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz#29d8936b713b7ee59b26b335d4f6715d644fc089"
+  integrity sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-cognito-identity@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.236.0.tgz#7936ce9a7ceaeff9045d85b3e69af9865c467bfc"
+  integrity sha512-PDsUZ7gmSCwraDDYnmoSkmrA1tpmvDBDjNPUVe6E+/8tDw3SWiL2efGR6r8ajFh9m+6jF6B8Wy+YB3u3yjAjWQ==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.236.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz#0bcb89a9abc166b3a48f5c255b9fcabc4cb80daf"
+  integrity sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz#0a4558449eb261412b0490ea1c3242eb91659759"
+  integrity sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz#10270be0de0cd34b1a82187248ade3779ff02005"
+  integrity sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.226.0"
+    "@aws-sdk/credential-provider-imds" "3.226.0"
+    "@aws-sdk/credential-provider-process" "3.226.0"
+    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-web-identity" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz#288f10f65c8b94d8f20f431e77febbe6c285ab42"
+  integrity sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.226.0"
+    "@aws-sdk/credential-provider-imds" "3.226.0"
+    "@aws-sdk/credential-provider-ini" "3.236.0"
+    "@aws-sdk/credential-provider-process" "3.226.0"
+    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-web-identity" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz#bcd73a6d31d1b3181917d56e54aacbee242b077f"
+  integrity sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz#98deadb0b689546bd5e93fc73dc6d6c87fe1c562"
+  integrity sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==
+  dependencies:
+    "@aws-sdk/client-sso" "3.236.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/token-providers" "3.236.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz#2b7d20f93a40e2243c7e3857f54b103d19a946fb"
+  integrity sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-providers@^3.186.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.236.0.tgz#52c6f0e5baa1f0eab1f39171b47102806809d504"
+  integrity sha512-z7RU5E9xlk6KX16jJxByn8xa8mv8pPZoqAPkavCsFJS6pOYTtQJYYdjrUK/2EmOmbPpc62P6mqVP7qTVQKgafw==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.236.0"
+    "@aws-sdk/client-sso" "3.236.0"
+    "@aws-sdk/client-sts" "3.236.0"
+    "@aws-sdk/credential-provider-cognito-identity" "3.236.0"
+    "@aws-sdk/credential-provider-env" "3.226.0"
+    "@aws-sdk/credential-provider-imds" "3.226.0"
+    "@aws-sdk/credential-provider-ini" "3.236.0"
+    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/credential-provider-process" "3.226.0"
+    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-web-identity" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz#350f78fc18fe9cb0a889ef4870838a8fcfa8855c"
+  integrity sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/querystring-builder" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz#252d98bcbb1e13c8f26d9d416db03cf8cceac185"
+  integrity sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz#74586f60859ed1813985e3d642066cc46d2e9d40"
+  integrity sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz#06e557adc284fac2f26071c2944ae01f61b95854"
+  integrity sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz#6cc952049f6e3cdc3a3778c9dce9f2aee942b5fe"
+  integrity sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-endpoint@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz#d776480be4b5a9534c2805b7425be05497f840b7"
+  integrity sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==
+  dependencies:
+    "@aws-sdk/middleware-serde" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/signature-v4" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/url-parser" "3.226.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz#1e1ecb034929e0dbc532ae501fd93781438f9a24"
+  integrity sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz#37fd0e62f555befd526b03748c3aab60dcefecf3"
+  integrity sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz#e149b9138e94d2fa70e7752ba6b1ccb537009706"
+  integrity sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.235.0":
+  version "3.235.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz#c0d938db85a771812204ed5e981eaf5eef6b580b"
+  integrity sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/service-error-classification" "3.229.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-middleware" "3.226.0"
+    "@aws-sdk/util-retry" "3.229.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-sts@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz#e8a8cf42bba8963259546120cde1e408628863f9"
+  integrity sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/signature-v4" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz#c837ef33b34bec2af19a1c177a0c02a1ae20da5e"
+  integrity sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz#ebb1d142ac2767466f2e464bb7dba9837143b4d1"
+  integrity sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/signature-v4" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-middleware" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz#b0408370270188103987c457c758f9cf7651754f"
+  integrity sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz#26653189f3e8da86514f77688a80d0ad445c0799"
+  integrity sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz#a9e21512ef824142bb928a0b2f85b39a75b8964d"
+  integrity sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz#373886e949d214a99a3521bd6c141fa17b0e89fe"
+  integrity sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.226.0"
+    "@aws-sdk/protocol-http" "3.226.0"
+    "@aws-sdk/querystring-builder" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz#ef0ff37c319dc37a52f08fa7544f861308a3bbd8"
+  integrity sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz#0af7bdc331508e556b722aad0cb78eefa93466e3"
+  integrity sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz#11cd751abeac66f1f9349225454bac3e39808926"
+  integrity sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz#ba6a26727c98d46c95180e6cdc463039c5e4740d"
+  integrity sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.229.0":
+  version "3.229.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz#768f1eb92775ca2cc99c6451a2303a0008a28fc1"
+  integrity sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==
+
+"@aws-sdk/shared-ini-file-loader@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz#d0ade86834b1803ce4b9dcab459e57e0376fd6cf"
+  integrity sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz#100390b5c5b55a9b0abd05b06fceb36cfa0ecf98"
+  integrity sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    "@aws-sdk/types" "3.226.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-middleware" "3.226.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.234.0":
+  version "3.234.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz#8f0021e021f0e52730ed0a8f271f839eb63bc374"
+  integrity sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/token-providers@3.236.0":
+  version "3.236.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz#c98ad2abad2a3686dbe849d680572f11ce965605"
+  integrity sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==
+  dependencies:
+    "@aws-sdk/client-sso-oidc" "3.236.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/shared-ini-file-loader" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.226.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.226.0.tgz#3dba2ba223fbb8ac1ebc84de0e036ce69a81d469"
+  integrity sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/url-parser@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz#f53d1f868b27fe74aca091a799f2af56237b15a2"
+  integrity sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz#36b430e5396251f761590f7c2f0c5c12193f353c"
+  integrity sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.188.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz#e1d949318c10a621b38575a9ef01e39f9857ddb0"
+  integrity sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz#baabd1fa1206ff2bd4ce3785122d86eb3258dd20"
+  integrity sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz#285e86f6dc9030148a4147d65239e75cb254a1b0"
+  integrity sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz#c485fd83fbac051337e5f6be60ea3f9fa61c0139"
+  integrity sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.234.0":
+  version "3.234.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz#1151f0beabdb46c1aaca42a1ad0714b8e686acaa"
+  integrity sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.234.0":
+  version "3.234.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz#0607f1dc7a4dc896dfcaf377522535ca9ffba7a9"
+  integrity sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.234.0"
+    "@aws-sdk/credential-provider-imds" "3.226.0"
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/property-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-endpoints@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz#3728b2e30f6f757ae862a0b7cf3991e75f252c3f"
+  integrity sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz#21d7ec319240ee68c33d938e71cb79830bea315d"
+  integrity sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz#0f598fc238a1256e4bcb64d01459f03a922dd4c3"
+  integrity sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz#7069ae96e2e00f6bb82c722e073922fb2b051ca2"
+  integrity sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-retry@3.229.0":
+  version "3.229.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz#17aad47b067e81acf644d5c2c0f2325f2d8faf4f"
+  integrity sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==
+  dependencies:
+    "@aws-sdk/service-error-classification" "3.229.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz#5e708d4cde001a4558ee616f889ceacfadd2ab03"
+  integrity sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz#164bb2da8d6353133784e47f0a0ae463bc9ebb73"
+  integrity sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==
+  dependencies:
+    "@aws-sdk/types" "3.226.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.226.0":
+  version "3.226.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz#7569460b9efc6bbd5295275c51357e480ff469c2"
+  integrity sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.226.0"
+    "@aws-sdk/types" "3.226.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@3.188.0", "@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz#484762bd600401350e148277731d6744a4a92225"
+  integrity sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz#eba17de0f92f87b98481c2e2d0ceaa05c7994d67"
+  integrity sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -138,10 +884,33 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/node@*":
+  version "18.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.17.tgz#5c009e1d9c38f4a2a9d45c0b0c493fe6cdb4bcb5"
+  integrity sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==
+
+"@types/tmp@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
+
 "@types/utf8@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/utf8/-/utf8-3.0.1.tgz#bf081663d4fff05ee63b41f377a35f8b189f7e5b"
   integrity sha512-1EkWuw7rT3BMz2HpmcEOr/HL61mWNA6Ulr/KdbXR9AI0A55wD4Qfv8hizd8Q1DnknSIzzDvQmvvY/guvX7jjZA==
+
+"@types/webidl-conversions@*":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz#2b8e60e33906459219aa587e9d1a612ae994cfe7"
+  integrity sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==
+
+"@types/whatwg-url@^8.2.1":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.2.tgz#749d5b3873e845897ada99be4448041d4cc39e63"
+  integrity sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==
+  dependencies:
+    "@types/node" "*"
+    "@types/webidl-conversions" "*"
 
 "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.19.0"
@@ -627,6 +1396,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
+async-mutex@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 async@^2.1.4, async@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
@@ -947,6 +1723,15 @@ bl@^2.2.1:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bl@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
@@ -976,6 +1761,11 @@ body-parser@1.20.1:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1054,6 +1844,13 @@ bson@^1.1.4:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
 
+bson@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.7.0.tgz#7874a60091ffc7a45c5dd2973b5cad7cded9718a"
+  integrity sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==
+  dependencies:
+    buffer "^5.6.0"
+
 "bucketclient@git+https://github.com/scality/bucketclient#8.1.5":
   version "8.1.5"
   resolved "git+https://github.com/scality/bucketclient#3941311c147a36178caf02dfeea8c4041f017ef6"
@@ -1061,6 +1858,11 @@ bson@^1.1.4:
     agentkeepalive "^4.1.4"
     arsenal "git+https://github.com/scality/Arsenal#8.1.62"
     werelogs scality/werelogs#8.1.0
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1178,6 +1980,11 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -1343,6 +2150,11 @@ commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1522,6 +2334,13 @@ debug@^4.1.1, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1627,6 +2446,11 @@ denque@^1.1.0, denque@^1.4.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
   integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0:
   version "2.0.0"
@@ -1743,6 +2567,13 @@ encoding@^0.1.12:
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
   dependencies:
     iconv-lite "^0.6.2"
+
+end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 engine.io-client@~3.5.0:
   version "3.5.2"
@@ -2297,6 +3128,13 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-xml-parser@4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
+  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
+  dependencies:
+    strnum "^1.0.5"
+
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
@@ -2311,6 +3149,13 @@ fb-watchman@^2.0.0:
     bindings "^1.1.1"
     nan "^2.3.2"
     node-gyp "^8.0.0"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2378,6 +3223,15 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-cache-dir@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2392,6 +3246,14 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -2448,6 +3310,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -2528,6 +3395,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -2868,6 +3740,14 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -3040,6 +3920,11 @@ ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
+  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -4234,6 +5119,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -4336,6 +5228,13 @@ ltgt@~2.1.1:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
 
+make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 make-fetch-happen@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz#53085a09e7971433e6765f7971bf63f4e05cb968"
@@ -4399,6 +5298,11 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
+
+md5-file@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
+  integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -4668,6 +5572,44 @@ moment-timezone@^0.5.31:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+mongodb-connection-string-url@^2.5.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
+  dependencies:
+    "@types/whatwg-url" "^8.2.1"
+    whatwg-url "^11.0.0"
+
+mongodb-memory-server-core@8.10.2:
+  version "8.10.2"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-8.10.2.tgz#218289f041178131afad945e2d29cb9ed49b18b4"
+  integrity sha512-ro4k1eGcjk6p8214wFpv31dsB4eaBUMRr9WYLBcQDbmzCkM7ARn6vsJhlrKWH8eoayLZf0X6557j013t/Ld8aA==
+  dependencies:
+    "@types/tmp" "^0.2.3"
+    async-mutex "^0.3.2"
+    camelcase "^6.3.0"
+    debug "^4.3.4"
+    find-cache-dir "^3.3.2"
+    get-port "^5.1.1"
+    https-proxy-agent "^5.0.1"
+    md5-file "^5.0.0"
+    mongodb "~4.11.0"
+    new-find-package-json "^2.0.0"
+    semver "^7.3.8"
+    tar-stream "^2.1.4"
+    tmp "^0.2.1"
+    tslib "^2.4.1"
+    uuid "^8.3.1"
+    yauzl "^2.10.0"
+
+mongodb-memory-server@^8.10.2:
+  version "8.10.2"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-8.10.2.tgz#8b65015359b3ac306a70a20dab80481b0ce6acdb"
+  integrity sha512-f8v9rRiA7sL5UganOjTL8/hzmdU0Vd7pC5Nsgh6vLFySz23UzpGYwV+knPWreFlqToTdw1mHdPlofZ4Ss/gi7w==
+  dependencies:
+    mongodb-memory-server-core "8.10.2"
+    tslib "^2.4.1"
+
 mongodb@^3.0.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.7.3.tgz#b7949cfd0adc4cc7d32d3f2034214d4475f175a5"
@@ -4680,6 +5622,19 @@ mongodb@^3.0.1:
     safe-buffer "^5.1.2"
   optionalDependencies:
     saslprep "^1.0.0"
+
+mongodb@~4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.11.0.tgz#d28fdc7509f24d0d274f456529441fa3e570415c"
+  integrity sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==
+  dependencies:
+    bson "^4.7.0"
+    denque "^2.1.0"
+    mongodb-connection-string-url "^2.5.4"
+    socks "^2.7.1"
+  optionalDependencies:
+    "@aws-sdk/credential-providers" "^3.186.0"
+    saslprep "^1.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4775,6 +5730,13 @@ negotiator@0.6.3, negotiator@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+new-find-package-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/new-find-package-json/-/new-find-package-json-2.0.0.tgz#96553638781db35061f351e8ccb4d07126b6407d"
+  integrity sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==
+  dependencies:
+    debug "^4.3.4"
 
 node-forge@^1.3.0:
   version "1.3.1"
@@ -5131,12 +6093,26 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map@^2.1.0:
   version "2.1.0"
@@ -5154,6 +6130,11 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -5216,6 +6197,11 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -5255,6 +6241,11 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -5288,6 +6279,13 @@ pkg-dir@^2.0.0:
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -5555,7 +6553,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5781,7 +6779,7 @@ rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -5848,7 +6846,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
-saslprep@^1.0.0:
+saslprep@^1.0.0, saslprep@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
   integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
@@ -5875,7 +6873,7 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -5884,6 +6882,13 @@ semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -6014,7 +7019,7 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
-smart-buffer@^4.1.0:
+smart-buffer@^4.1.0, smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -6117,6 +7122,14 @@ socks@^2.6.1:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
+
+socks@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  dependencies:
+    ip "^2.0.0"
+    smart-buffer "^4.2.0"
 
 sorted-array-functions@^1.3.0:
   version "1.3.0"
@@ -6391,6 +7404,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -6426,6 +7444,17 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^4:
   version "4.4.6"
@@ -6484,6 +7513,13 @@ throat@^4.0.0:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -6560,6 +7596,13 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -6575,10 +7618,20 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@^1.11.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.3.1, tslib@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -6788,6 +7841,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@^8.3.1, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -6857,6 +7915,11 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
 "werelogs@git+https://github.com/scality/werelogs#8.1.0":
   version "8.1.0"
   resolved "git+https://github.com/scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313"
@@ -6893,6 +7956,14 @@ whatwg-mimetype@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"
   integrity sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"
@@ -7102,6 +8173,14 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
this PR implement a `CountItemsMongoClient` class which extends `MongoClientInterface` from arsenal
override `getObjectMDStats()` function  and some utils functions to output
```
{
        "objects" : 4,
        "versions" : 6,
        "buckets" : 3,
        "bucketList" : [ 
            {
                "name" : "bucket2",
                "location" : "us-east-1",
                "isVersioned" : true,
                "ownerCanonicalId" : "2fbfcc0125094acda54f0cabb5d1e66ae78aaf67f6060e8ac5b6abc9ada01d81",
                "ingestion" : false
            }, 
            {
                "name" : "bucket1",
                "location" : "us-east-1",
                "isVersioned" : true,
                "ownerCanonicalId" : "2fbfcc0125094acda54f0cabb5d1e66ae78aaf67f6060e8ac5b6abc9ada01d81",
                "ingestion" : false
            }
        ],
        "dataManaged" : {
            "total" : {
                "curr" : 392,
                "prev" : 222
            },
            "byLocation" : {
                "us-east-1" : {
                    "curr" : 392,
                    "prev" : 222
                }
            }
        },
        "stalled" : 0,
        "dataMetrics" : {
            "bucket" : {
                "bucket1" : {
                    "usedCapacity" : {
                        "current" : 376,
                        "nonCurrent" : 0
                    },
                    "objectCount" : {
                        "current" : 2,
                        "nonCurrent" : 0,
                        "deleteMarker" : 0
                    }
                },
                "bucket2" : {
                    "usedCapacity" : {
                        "current" : 6,
                        "nonCurrent" : 0
                    },
                    "objectCount" : {
                        "current" : 1,
                        "nonCurrent" : 0,
                        "deleteMarker" : 0
                    }
                },
            },
            "location" : {
                "us-east-1" : {
                    "usedCapacity" : {
                        "current" : 392,
                        "nonCurrent" : 222
                    },
                    "objectCount" : {
                        "current" : 4,
                        "nonCurrent" : 6,
                        "deleteMarker" : 1
                    }
                }
            },
            "account" : {
                "account2" : {
                    "usedCapacity" : {
                        "current" : 392,
                        "nonCurrent" : 222
                    },
                    "objectCount" : {
                        "current" : 4,
                        "nonCurrent" : 6,
                        "deleteMarker" : 1
                    }
                }
            }
        }
    }
}
```
added 3 metric levels: bucket/location/account and collect their usedCapacity and objectCount respectively
