### PR TITLE
Feature/s3 utils 122 data report collect metrics write capacity info

### DIFF
--- a/DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo.js
+++ b/DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo.js
@@ -1,0 +1,133 @@
+const async = require('async');
+const { MaxParallelLimit } = require('../utils/constants');
+
+function isSOSCapacityInfoEnabled(bucketInfo) {
+    /**
+     * a valid SOS CapacityInfo Enabled bucketMD looks like
+     * {
+     *     _capabilities: {
+     *         VeeamSOSApi: {
+     *             SystemInfo: {
+     *                 ...
+     *                 ProtocolCapabilities: {
+     *                     CapacityInfo: true,
+     *                     ...
+     *                 },
+     *             ...
+     *             },
+     *             CapacityInfo: {
+     *                 ...
+     *             },
+     *         }
+     *     },
+     * }
+     */
+    return !!(bucketInfo.getCapabilities() // should exist
+        && bucketInfo.getCapabilities().VeeamSOSApi // should exist
+        && bucketInfo.getCapabilities().VeeamSOSApi.SystemInfo // should exist
+        && bucketInfo.getCapabilities().VeeamSOSApi.SystemInfo.ProtocolCapabilities // should exist
+        && bucketInfo.getCapabilities().VeeamSOSApi.SystemInfo.ProtocolCapabilities.CapacityInfo === true // should be true
+        && bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo); // should exist
+}
+
+function isValidBucketStorageMetrics(bucketMetric) {
+    return bucketMetric
+    && bucketMetric.usedCapacity
+        && typeof bucketMetric.usedCapacity.current === 'number'
+        && typeof bucketMetric.usedCapacity.nonCurrent === 'number'
+    && bucketMetric.usedCapacity.current > -1
+    && bucketMetric.usedCapacity.nonCurrent > -1;
+}
+
+function isValidCapacityValue(capacity) {
+    return (Number.isSafeInteger(capacity) && capacity >= 0);
+}
+
+function collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, log, callback) {
+    let bucketMetrics;
+    return async.waterfall([
+        next => mongoClient.readCountItems(log, (err, doc) => {
+            if (err) {
+                log.error('an error occurred during readCountItems', {
+                    error: { message: err.message },
+                });
+                return next(err);
+            }
+            if (doc && doc.dataMetrics && doc.dataMetrics.bucket) {
+                bucketMetrics = doc.dataMetrics.bucket;
+            } else {
+                log.info('no buckets metrics in countItems, exit');
+                return callback(null);
+            }
+            return next();
+        }),
+        next => mongoClient.getBucketInfos(log, (err, bucketInfos) => {
+            if (err) {
+                log.error('error getting bucket list', {
+                    error: err,
+                });
+                return next(err);
+            }
+            return next(null, bucketInfos.bucketInfos);
+        }),
+        (bucketInfoList, next) => async.eachLimit(
+            bucketInfoList,
+            MaxParallelLimit,
+            (bucket, cb) => {
+                if (!isSOSCapacityInfoEnabled(bucket)) {
+                    return cb();
+                }
+                const bucketName = bucket.getName();
+
+                // get bucket storage used
+                let bucketStorageUsed = -1;
+                if (isValidBucketStorageMetrics(bucketMetrics[bucketName])) {
+                    bucketStorageUsed = bucketMetrics[bucketName].usedCapacity.current
+                            + bucketMetrics[bucketName].usedCapacity.nonCurrent;
+                }
+
+                // read Capacity from bucket._capabilities
+                const { Capacity } = bucket.getCapabilities().VeeamSOSApi.CapacityInfo;
+
+                let available = -1;
+                let capacity = -1;
+                if (isValidCapacityValue(Capacity)) { // is Capacity value is valid
+                    capacity = Capacity;
+                    // if bucket storage used is valid and capacity is bigger than used
+                    if (bucketStorageUsed !== -1 && (capacity - bucketStorageUsed) >= 0) {
+                        available = capacity - bucketStorageUsed;
+                    }
+                }
+
+                return mongoClient.updateBucketCapacityInfo(bucketName, {
+                    Capacity: capacity,
+                    Available: available,
+                    Used: bucketStorageUsed,
+                }, log, err => {
+                    if (err) {
+                        log.error('an error occurred during put bucket CapacityInfo attributes', {
+                            error: { message: err.message },
+                            bucketName,
+                        });
+                        return cb(err);
+                    }
+                    return cb();
+                });
+            },
+            err => {
+                if (err) {
+                    return next(err);
+                }
+                log.info('successfully updated CapacityInfo for all qualified buckets');
+                return next(null);
+            },
+        ),
+    ], callback);
+}
+
+module.exports = {
+    isSOSCapacityInfoEnabled,
+    isValidBucketStorageMetrics,
+    isValidCapacityValue,
+    collectBucketMetricsAndUpdateBucketCapacityInfo,
+};

--- a/DataReport/index.js
+++ b/DataReport/index.js
@@ -1,0 +1,39 @@
+const { Logger } = require('werelogs');
+const createMongoParams = require('../utils/createMongoParams');
+const { collectBucketMetricsAndUpdateBucketCapacityInfo } = require('./collectBucketMetricsAndUpdateBucketCapacityInfo');
+const S3UtilsMongoClient = require('../utils/S3UtilsMongoClient');
+
+const log = new Logger('s3utils:DataReport');
+
+function stop() {
+    log.info('stopping execution');
+    process.exit(0);
+}
+
+function main() {
+    const mongoClient = new S3UtilsMongoClient(createMongoParams(log));
+    mongoClient.setup(err => {
+        if (err) {
+            log.error('error connecting to mongodb', {
+                error: err,
+            });
+            process.exit(1);
+        }
+        collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, log, err => {
+            if (err) {
+                log.error('error collecting bucket metrics and updating bucket capacity info', {
+                    error: err,
+                });
+                mongoClient.close(() => process.exit(1));
+            }
+            mongoClient.close(() => stop());
+        });
+    });
+}
+
+main();
+
+process.on('SIGINT', stop);
+process.on('SIGHUP', stop);
+process.on('SIGQUIT', stop);
+process.on('SIGTERM', stop);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.12",
+  "version": "1.13.13",
   "engines": {
     "node": ">= 16"
   },
@@ -28,7 +28,7 @@
   "dependencies": {
     "@senx/warp10": "^1.1.2",
     "JSONStream": "^1.3.5",
-    "arsenal": "git+https://github.com/scality/arsenal#8.1.59",
+    "arsenal": "git+https://github.com/scality/arsenal#8.1.78",
     "async": "^2.6.4",
     "aws-sdk": "^2.1005.0",
     "bucketclient": "git+https://github.com/scality/bucketclient#8.1.5",

--- a/tests/functional/collectBucketMetricsAndUpdateBucketCapacityInfo.js
+++ b/tests/functional/collectBucketMetricsAndUpdateBucketCapacityInfo.js
@@ -1,0 +1,211 @@
+const async = require('async');
+const werelogs = require('werelogs');
+const assert = require('assert');
+const S3UtilsMongoClient = require('../../utils/S3UtilsMongoClient');
+const { testBucketMD } = require('../constants');
+const { collectBucketMetricsAndUpdateBucketCapacityInfo } = require('../../DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo');
+
+const logger = new werelogs.Logger('collectBucketMetricsAndUpdateBucketCapacityInfo::Test::Functional');
+const { MONGODB_REPLICASET } = process.env;
+const dbName = 'collectBucketMetricsAndUpdateBucketCapacityInfoTest';
+
+
+describe('collectBucketMetricsAndUpdateBucketCapacityInfo', () => {
+    const oldEnv = process.env;
+    let client;
+    let testBucketCapacities;
+
+    const testBucketName = 'test-bucket';
+
+    beforeAll(done => {
+        process.env = oldEnv;
+        process.env.MONGODB_DATABASE = dbName;
+
+        const opts = {
+            replicaSetHosts: MONGODB_REPLICASET,
+            writeConcern: 'majority',
+            replicaSet: 'rs0',
+            readPreference: 'primary',
+            database: dbName,
+            replicationGroupId: 'RG001',
+            logger,
+        };
+        client = new S3UtilsMongoClient(opts);
+        async.series([
+            next => client.setup(next),
+        ], done);
+    });
+
+    afterAll(done => {
+        async.series([
+            next => client.db.dropDatabase(next),
+            next => client.close(next),
+        ], done);
+    });
+
+    beforeEach(done => {
+        testBucketCapacities = {
+            VeeamSOSApi: {
+                SystemInfo: {
+                    ProtocolCapabilities: {
+                        CapacityInfo: true,
+                    },
+                },
+                CapacityInfo: {
+                    Capacity: 0,
+                    Available: 0,
+                    Used: 0,
+                },
+            },
+        };
+        client.updateCountItems({
+            dataMetrics: {
+                bucket: {
+                    [testBucketName]: {
+                        usedCapacity: { current: 10, nonCurrent: 10 },
+                        objectCount: { current: 10, nonCurrent: 10 },
+                    },
+                },
+            },
+        }, logger, done);
+    });
+
+    afterEach(done => client.deleteBucket(testBucketName, logger, done));
+
+    test('should not update bucket CapacityInfo if bucket doesn\'t have _capabilities attribute', done => {
+        testBucketCapacities.VeeamSOSApi.SystemInfo.ProtocolCapabilities.CapacityInfo = false;
+        return async.series([
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                assert.equal(bucketInfo.getCapabilities(), null);
+                next();
+            }),
+        ], done);
+    });
+
+    test('should not update bucket CapacityInfo if bucket is SOSAPI Capacity disabled', done => {
+        testBucketCapacities.VeeamSOSApi.SystemInfo.ProtocolCapabilities.CapacityInfo = false;
+        return async.series([
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+                _capabilities: testBucketCapacities,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                const { Capacity, Available, Used } = bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo;
+                assert.strictEqual(Capacity, 0);
+                assert.strictEqual(Available, 0);
+                assert.strictEqual(Used, 0);
+                next();
+            }),
+        ], done);
+    });
+
+    test('should successfully collect bucketMetrics and update bucket CapacityInfo', done => {
+        testBucketCapacities.VeeamSOSApi.CapacityInfo.Capacity = 30;
+
+        return async.series([
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+                _capabilities: testBucketCapacities,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                const { Capacity, Available, Used } = bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo;
+                assert.strictEqual(Capacity, 30);
+                assert.strictEqual(Available, 10);
+                assert.strictEqual(Used, 20);
+                next();
+            }),
+        ], done);
+    });
+
+    test('should update bucket Capacity and Available -1 if Capacity value is not valid', done => {
+        testBucketCapacities.VeeamSOSApi.CapacityInfo.Capacity = 'not-a-number';
+
+        return async.series([
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+                _capabilities: testBucketCapacities,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                const { Capacity, Available, Used } = bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo;
+                assert.strictEqual(Capacity, -1);
+                assert.strictEqual(Available, -1);
+                assert.strictEqual(Used, 20);
+                next();
+            }),
+        ], done);
+    });
+
+    test('should update bucket Available -1 if Capacity value is smaller than Used', done => {
+        testBucketCapacities.VeeamSOSApi.CapacityInfo.Capacity = 10;
+
+        return async.series([
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+                _capabilities: testBucketCapacities,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                const { Capacity, Available, Used } = bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo;
+                assert.strictEqual(Capacity, 10);
+                assert.strictEqual(Available, -1);
+                assert.strictEqual(Used, 20);
+                next();
+            }),
+        ], done);
+    });
+
+    test('should update bucket Used and Available -1 if bucket metrics are not retrievable', done => {
+        testBucketCapacities.VeeamSOSApi.CapacityInfo.Capacity = 30;
+
+        return async.series([
+            next => client.updateCountItems({
+                dataMetrics: {
+                    bucket: {},
+                },
+            }, logger, next),
+            next => client.createBucket(testBucketName, {
+                ...testBucketMD,
+                _capabilities: testBucketCapacities,
+            }, logger, next),
+            next => collectBucketMetricsAndUpdateBucketCapacityInfo(client, logger, err => {
+                assert.equal(err, null);
+                next();
+            }),
+            next => client.getBucketAttributes(testBucketName, logger, (err, bucketInfo) => {
+                assert.equal(err, null);
+                const { Capacity, Available, Used } = bucketInfo.getCapabilities().VeeamSOSApi.CapacityInfo;
+                assert.strictEqual(Capacity, 30);
+                assert.strictEqual(Available, -1);
+                assert.strictEqual(Used, -1);
+                next();
+            }),
+        ], done);
+    });
+});

--- a/tests/unit/DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo.js
+++ b/tests/unit/DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo.js
@@ -1,0 +1,380 @@
+const { BucketInfo } = require('arsenal').models;
+const werelogs = require('werelogs');
+
+const { testBucketMD } = require('../../constants');
+const {
+    isSOSCapacityInfoEnabled,
+    isValidBucketStorageMetrics,
+    isValidCapacityValue,
+    collectBucketMetricsAndUpdateBucketCapacityInfo,
+} = require('../../../DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo');
+const createMongoParams = require('../../../utils/createMongoParams');
+const S3UtilsMongoClient = require('../../../utils/S3UtilsMongoClient');
+
+const logger = new werelogs.Logger('collectBucketMetricsAndUpdateBucketCapacityInfo', 'debug', 'debug');
+
+describe('DataReport::collectBucketMetricsAndUpdateBucketCapacityInfo', () => {
+    describe('isSOSCapacityInfoEnabled', () => {
+        test('should return false if _capacities property doesn\'t exist in bucket', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj(testBucketMD));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi property doesn\'t exist in bucket', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {},
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo property doesn\'t exist in bucket', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {},
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities property doesn\'t exist in bucket', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {},
+                    },
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities.CapacityInfo property doesn\'t exist in bucket', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {
+                            ProtocolCapabilities: {},
+                        },
+                    },
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities.CapacityInfo property is not boolean', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {
+                            ProtocolCapabilities: {
+                                CapacityInfo: 'true',
+                            },
+                        },
+                    },
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities.CapacityInfo property is false', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {
+                            ProtocolCapabilities: {
+                                CapacityInfo: false,
+                            },
+                        },
+                    },
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return false if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities.CapacityInfo property is true'
+            + 'and _capacities.VeeamSOSApi.CapacityInfo doesn\'t exist', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {
+                            ProtocolCapabilities: {
+                                CapacityInfo: false,
+                            },
+                        },
+                    },
+                },
+            }));
+            expect(enabled).toBeFalsy();
+        });
+
+        test('should return true if _capacities.VeeamSOSApi.SystemInfo.SystemInfo.ProtocolCapabilities.CapacityInfo property is true'
+            + 'and _capacities.VeeamSOSApi.CapacityInfo exists', () => {
+            const enabled = isSOSCapacityInfoEnabled(BucketInfo.fromObj({
+                ...testBucketMD,
+                _capabilities: {
+                    VeeamSOSApi: {
+                        SystemInfo: {
+                            ProtocolCapabilities: {
+                                CapacityInfo: true,
+                            },
+                        },
+                        CapacityInfo: {},
+                    },
+                },
+            }));
+            expect(enabled).toBeTruthy();
+        });
+    });
+
+    describe('isValidBucketStorageMetrics', () => {
+        test('should return false if bucket metrics is empty', () => {
+            const valid = isValidBucketStorageMetrics(null);
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity property doesn\'t exist', () => {
+            const valid = isValidBucketStorageMetrics({});
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.current property doesn\'t exist', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { nonCurrent: 0 },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.nonCurrent property doesn\'t exist', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: 0 },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.current value is negative', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: -1, nonCurrent: 0 },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.nonCurrent value is negative', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: 0, nonCurrent: -1 },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.current value is not a number', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: 'not-a-number', nonCurrent: 0 },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if usedCapacity.nonCurrent value is not a number', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: 0, nonCurrent: 'not-a-number' },
+            });
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return true if usedCapacity.current and usedCapacity.nonCurrent value are both valid', () => {
+            const valid = isValidBucketStorageMetrics({
+                usedCapacity: { current: 0, nonCurrent: 0 },
+            });
+            expect(valid).toBeTruthy();
+        });
+    });
+
+    describe('isValidCapacityValue', () => {
+        test('should return false if capacity is not a number', () => {
+            const valid = isValidCapacityValue('not-a-number');
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if capacity is not a integer', () => {
+            const valid = isValidCapacityValue(0.2);
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if capacity is negative', () => {
+            const valid = isValidCapacityValue(-1);
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return false if capacity is not a safe integer', () => {
+            const valid = isValidCapacityValue(2 ** 53);
+            expect(valid).toBeFalsy();
+        });
+
+        test('should return true if capacity is a valid integer', () => {
+            const valid = isValidCapacityValue(1);
+            expect(valid).toBeTruthy();
+        });
+    });
+
+    describe('collectBucketMetricsAndUpdateBucketCapacityInfo', () => {
+        let mongoClient;
+        beforeEach(done => {
+            mongoClient = new S3UtilsMongoClient(createMongoParams(logger));
+            mongoClient.setup = jest.fn();
+            mongoClient.readCountItems = jest.fn();
+            mongoClient.getBucketInfos = jest.fn();
+            mongoClient.updateBucketCapacityInfo = jest.fn();
+            mongoClient.setup.mockImplementation(cb => cb(null));
+            return mongoClient.setup(done);
+        });
+
+        afterEach(() => jest.resetAllMocks());
+
+        test('should not pass if mongo readCountItems() returns error', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(new Error('an error occurred during readCountItems')));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toEqual(new Error('an error occurred during readCountItems'));
+                done();
+            });
+        });
+
+        test('should finish directly if no dataMetrics from readCountItems', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {}));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toBeNull();
+                expect(mongoClient.getBucketInfos).toHaveBeenCalledTimes(0);
+                expect(mongoClient.updateBucketCapacityInfo).toHaveBeenCalledTimes(0);
+                done();
+            });
+        });
+
+        test('should not pass if mongo getBucketInfos() returns error', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {
+                    dataMetrics: {
+                        bucket: {},
+                    },
+                }));
+            mongoClient.getBucketInfos
+                .mockImplementation((log, cb) => cb(new Error('error getting bucket list')));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toEqual(new Error('error getting bucket list'));
+                done();
+            });
+        });
+
+        test('should not pass if mongo updateBucketCapacityInfo() returns error', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {
+                    dataMetrics: {
+                        bucket: {},
+                    },
+                }));
+            mongoClient.getBucketInfos
+                .mockImplementation((log, cb) => cb(null, {
+                    bucketInfos: [BucketInfo.fromObj({
+                        ...testBucketMD,
+                        _capabilities: {
+                            VeeamSOSApi: {
+                                SystemInfo: {
+                                    ProtocolCapabilities: {
+                                        CapacityInfo: true,
+                                    },
+                                },
+                                CapacityInfo: {},
+                            },
+                        },
+                    })],
+                }));
+            mongoClient.updateBucketCapacityInfo
+                .mockImplementation((bucketName, bucket, log, cb) => cb(new Error('an error occurred during put bucket CapacityInfo attributes')));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toEqual(new Error('an error occurred during put bucket CapacityInfo attributes'));
+                done();
+            });
+        });
+
+        test('should pass with empty bucket', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {
+                    dataMetrics: {
+                        bucket: {},
+                    },
+                }));
+            mongoClient.getBucketInfos
+                .mockImplementation((log, cb) => cb(null, {
+                    bucketInfos: [],
+                }));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toBeNull();
+                done();
+            });
+        });
+
+        test('should pass with SOSAPI disabled buckets', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {
+                    dataMetrics: {
+                        bucket: {
+                            [testBucketMD._name]: {
+                                usedCapacity: { current: 0, nonCurrent: 0 },
+                            },
+                        },
+                    },
+                }));
+            mongoClient.getBucketInfos
+                .mockImplementation((log, cb) => cb(null, {
+                    bucketInfos: [BucketInfo.fromObj({
+                        ...testBucketMD,
+                        _capabilities: {},
+                    })],
+                }));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toBeNull();
+                done();
+            });
+        });
+
+        test('should pass with SOSAPI enabled buckets and update bucket md', done => {
+            mongoClient.readCountItems
+                .mockImplementation((log, cb) => cb(null, {
+                    dataMetrics: {
+                        bucket: {
+                            [testBucketMD._name]: {
+                                usedCapacity: { current: 0, nonCurrent: 0 },
+                            },
+                        },
+                    },
+                }));
+            mongoClient.getBucketInfos
+                .mockImplementation((log, cb) => cb(null, {
+                    bucketInfos: [BucketInfo.fromObj({
+                        ...testBucketMD,
+                        _capabilities: {
+                            VeeamSOSApi: {
+                                SystemInfo: {
+                                    ProtocolCapabilities: {
+                                        CapacityInfo: true,
+                                    },
+                                },
+                                CapacityInfo: {},
+                            },
+                        },
+                    })],
+                }));
+            mongoClient.updateBucketCapacityInfo
+                .mockImplementation((bucketName, bucket, log, cb) => cb(null));
+            return collectBucketMetricsAndUpdateBucketCapacityInfo(mongoClient, logger, err => {
+                expect(err).toBeNull();
+                expect(mongoClient.updateBucketCapacityInfo).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
+});

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+    MaxParallelLimit: 10,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,16 +65,16 @@
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-cognito-identity@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.236.0.tgz#bec1a6625d1b34b0014a8ded15d70557643ee7e9"
-  integrity sha512-lWGuTVA+q3h1KS3nxTWeRGOfsuQ+GNwq5IxFJ8ko441mpwo5A2t6u25Z+G6t5Eh+q4EcoxMX64HYA+cu91lr7g==
+"@aws-sdk/client-cognito-identity@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.238.0.tgz#6a69b35adc0110d166b4ef90ff9fa8d22be71130"
+  integrity sha512-vjIVFzlkcUX9YT7pqg9NrvOTuqqsdYSesFgMLTCSWXBE5rPjWEK5ljIVOZtGn8MJQgwqS+Lqc8oB1vIfE+EaSA==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
-    "@aws-sdk/client-sts" "3.236.0"
+    "@aws-sdk/client-sts" "3.238.0"
     "@aws-sdk/config-resolver" "3.234.0"
-    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/credential-provider-node" "3.238.0"
     "@aws-sdk/fetch-http-handler" "3.226.0"
     "@aws-sdk/hash-node" "3.226.0"
     "@aws-sdk/invalid-dependency" "3.226.0"
@@ -107,10 +107,10 @@
     "@aws-sdk/util-utf8-node" "3.208.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso-oidc@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz#501cc3f69bdfc1b538b3b89d1166bc80dd86a461"
-  integrity sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==
+"@aws-sdk/client-sso-oidc@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz#95aa2e993b6bff2adc74d1821241f80f9ea5b283"
+  integrity sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
@@ -146,10 +146,10 @@
     "@aws-sdk/util-utf8-node" "3.208.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz#eba16f73abb9639bfdafeeb64d5c9771db2a4cc9"
-  integrity sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==
+"@aws-sdk/client-sso@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz#dcb4df1e97e6e8821f473e70eee81a8d4424664f"
+  integrity sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
@@ -185,15 +185,15 @@
     "@aws-sdk/util-utf8-node" "3.208.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sts@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz#8f3d793d627edf72ae80ffc50e7982b6cbcfd3f7"
-  integrity sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==
+"@aws-sdk/client-sts@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz#b814c2cf888cf99be199c25ede851dfcc8ae5ec6"
+  integrity sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
     "@aws-sdk/config-resolver" "3.234.0"
-    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/credential-provider-node" "3.238.0"
     "@aws-sdk/fetch-http-handler" "3.226.0"
     "@aws-sdk/hash-node" "3.226.0"
     "@aws-sdk/invalid-dependency" "3.226.0"
@@ -239,12 +239,12 @@
     "@aws-sdk/util-middleware" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-cognito-identity@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.236.0.tgz#7936ce9a7ceaeff9045d85b3e69af9865c467bfc"
-  integrity sha512-PDsUZ7gmSCwraDDYnmoSkmrA1tpmvDBDjNPUVe6E+/8tDw3SWiL2efGR6r8ajFh9m+6jF6B8Wy+YB3u3yjAjWQ==
+"@aws-sdk/credential-provider-cognito-identity@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.238.0.tgz#26622fce7f664fe92acf718a246c7fc4f7001f39"
+  integrity sha512-FGVXGtGn7t/XacBdCKgqzxJNvorjCIar+F0oRsGq8aH09L/H8uGZ7qXvYvi9I94Qv7ay0Dy/KpGcMB53zt41UA==
   dependencies:
-    "@aws-sdk/client-cognito-identity" "3.236.0"
+    "@aws-sdk/client-cognito-identity" "3.238.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
@@ -269,31 +269,31 @@
     "@aws-sdk/url-parser" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-ini@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz#10270be0de0cd34b1a82187248ade3779ff02005"
-  integrity sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==
+"@aws-sdk/credential-provider-ini@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz#ff21f2a52c9867c34814c1548e8d2bd5f5dfb15a"
+  integrity sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.226.0"
     "@aws-sdk/credential-provider-imds" "3.226.0"
     "@aws-sdk/credential-provider-process" "3.226.0"
-    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-sso" "3.238.0"
     "@aws-sdk/credential-provider-web-identity" "3.226.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/shared-ini-file-loader" "3.226.0"
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-node@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz#288f10f65c8b94d8f20f431e77febbe6c285ab42"
-  integrity sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==
+"@aws-sdk/credential-provider-node@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz#cccd15fc5f8babb843fab7ec3b09b36d40a02c61"
+  integrity sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.226.0"
     "@aws-sdk/credential-provider-imds" "3.226.0"
-    "@aws-sdk/credential-provider-ini" "3.236.0"
+    "@aws-sdk/credential-provider-ini" "3.238.0"
     "@aws-sdk/credential-provider-process" "3.226.0"
-    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-sso" "3.238.0"
     "@aws-sdk/credential-provider-web-identity" "3.226.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/shared-ini-file-loader" "3.226.0"
@@ -310,15 +310,15 @@
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-sso@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz#98deadb0b689546bd5e93fc73dc6d6c87fe1c562"
-  integrity sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==
+"@aws-sdk/credential-provider-sso@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz#3e99252faa3e8e8d86e2f0dc8e29813d96f570c2"
+  integrity sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==
   dependencies:
-    "@aws-sdk/client-sso" "3.236.0"
+    "@aws-sdk/client-sso" "3.238.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/shared-ini-file-loader" "3.226.0"
-    "@aws-sdk/token-providers" "3.236.0"
+    "@aws-sdk/token-providers" "3.238.0"
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
 
@@ -332,20 +332,20 @@
     tslib "^2.3.1"
 
 "@aws-sdk/credential-providers@^3.186.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.236.0.tgz#52c6f0e5baa1f0eab1f39171b47102806809d504"
-  integrity sha512-z7RU5E9xlk6KX16jJxByn8xa8mv8pPZoqAPkavCsFJS6pOYTtQJYYdjrUK/2EmOmbPpc62P6mqVP7qTVQKgafw==
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.238.0.tgz#20a34fe61aa2e9b8a321fa61328d3bb63b87bcba"
+  integrity sha512-wqj88z9UCbqxnd9XoaKrI+7oSN/13f1AP7cZWYKrzdvb3Ae5QmXmgMKXJdsQlWtPijchpPOQNGhd1rVogycgiA==
   dependencies:
-    "@aws-sdk/client-cognito-identity" "3.236.0"
-    "@aws-sdk/client-sso" "3.236.0"
-    "@aws-sdk/client-sts" "3.236.0"
-    "@aws-sdk/credential-provider-cognito-identity" "3.236.0"
+    "@aws-sdk/client-cognito-identity" "3.238.0"
+    "@aws-sdk/client-sso" "3.238.0"
+    "@aws-sdk/client-sts" "3.238.0"
+    "@aws-sdk/credential-provider-cognito-identity" "3.238.0"
     "@aws-sdk/credential-provider-env" "3.226.0"
     "@aws-sdk/credential-provider-imds" "3.226.0"
-    "@aws-sdk/credential-provider-ini" "3.236.0"
-    "@aws-sdk/credential-provider-node" "3.236.0"
+    "@aws-sdk/credential-provider-ini" "3.238.0"
+    "@aws-sdk/credential-provider-node" "3.238.0"
     "@aws-sdk/credential-provider-process" "3.226.0"
-    "@aws-sdk/credential-provider-sso" "3.236.0"
+    "@aws-sdk/credential-provider-sso" "3.238.0"
     "@aws-sdk/credential-provider-web-identity" "3.226.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/shared-ini-file-loader" "3.226.0"
@@ -585,12 +585,12 @@
     "@aws-sdk/types" "3.226.0"
     tslib "^2.3.1"
 
-"@aws-sdk/token-providers@3.236.0":
-  version "3.236.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz#c98ad2abad2a3686dbe849d680572f11ce965605"
-  integrity sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==
+"@aws-sdk/token-providers@3.238.0":
+  version "3.238.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz#825306e82f24276e6aaa4850f36bba87418ba485"
+  integrity sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==
   dependencies:
-    "@aws-sdk/client-sso-oidc" "3.236.0"
+    "@aws-sdk/client-sso-oidc" "3.238.0"
     "@aws-sdk/property-provider" "3.226.0"
     "@aws-sdk/shared-ini-file-loader" "3.226.0"
     "@aws-sdk/types" "3.226.0"
@@ -748,6 +748,174 @@
     "@aws-sdk/util-buffer-from" "3.208.0"
     tslib "^2.3.1"
 
+"@azure/abort-controller@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.1.0.tgz#788ee78457a55af8a1ad342acb182383d2119249"
+  integrity sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/core-auth@^1.3.0", "@azure/core-auth@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.4.0.tgz#6fa9661c1705857820dbc216df5ba5665ac36a9e"
+  integrity sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-client@^1.4.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.6.1.tgz#a1aad3f7c69b6e5d9dddb39fabaeba013eac9313"
+  integrity sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.9.1"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.0.0"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-http@^2.0.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-2.3.1.tgz#eed8a7d012ba8c576c557828f66af0fc4e52b23a"
+  integrity sha512-cur03BUwV0Tbv81bQBOLafFB02B6G++K6F2O3IMl8pSE2QlXm3cu11bfyBNlDUKi5U+xnB3GC63ae3athhkx6Q==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/core-util" "^1.1.1"
+    "@azure/logger" "^1.0.0"
+    "@types/node-fetch" "^2.5.0"
+    "@types/tunnel" "^0.0.3"
+    form-data "^4.0.0"
+    node-fetch "^2.6.7"
+    process "^0.11.10"
+    tough-cookie "^4.0.0"
+    tslib "^2.2.0"
+    tunnel "^0.0.6"
+    uuid "^8.3.0"
+    xml2js "^0.4.19"
+
+"@azure/core-lro@^2.2.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.4.0.tgz#e3fdff797b045ee753aab25c3d2ecc0aa3e0a539"
+  integrity sha512-F65+rYkll1dpw3RGm8/SSiSj+/QkMeYDanzS/QKlM1dmuneVyXbO46C88V1MRHluLGdMP6qfD3vDRYALn0z0tQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-paging@^1.1.1":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.4.0.tgz#b04a73ad18149733a848c3089a5e5ed144592338"
+  integrity sha512-tabFtZTg8D9XqZKEfNUOGh63SuYeOxmvH4GDcOJN+R1bZWZ1FZskctgY9Pmuwzhn+0Xvq9rmimK9hsvtLkeBsw==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.9.1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.0.tgz#12c6d1601c5a598b8ccf37bb7c5daf421f7f7ea9"
+  integrity sha512-m6c4iAalfaf6sytOOQhLKFprEHSkSjQuRgkW7MTMnAN+GENDDL4XZJp7WKFnq9VpKUE+ggq+rp5xX9GI93lumw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-tracing" "^1.0.1"
+    "@azure/core-util" "^1.0.0"
+    "@azure/logger" "^1.0.0"
+    form-data "^4.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    tslib "^2.2.0"
+    uuid "^8.3.0"
+
+"@azure/core-tracing@1.0.0-preview.13":
+  version "1.0.0-preview.13"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz#55883d40ae2042f6f1e12b17dd0c0d34c536d644"
+  integrity sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==
+  dependencies:
+    "@opentelemetry/api" "^1.0.1"
+    tslib "^2.2.0"
+
+"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.1.tgz#352a38cbea438c4a83c86b314f48017d70ba9503"
+  integrity sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/core-util@^1.0.0", "@azure/core-util@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.1.1.tgz#8f87b3dd468795df0f0849d9f096c3e7b29452c1"
+  integrity sha512-A4TBYVQCtHOigFb2ETiiKFDocBoI1Zk2Ui1KpI42aJSIDexF7DHQFpnjonltXAIU/ceH+1fsZAWWgvX6/AKzog==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/identity@^3.1.1":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-3.1.2.tgz#35bbd3ac0499bac80408318727c82453842cce3a"
+  integrity sha512-UCuxhM3q3ODH62oOChEOS57uMc/CFTtoO7NyrDv0nx9IIfbiAaEVztDLXkpVWLw90Dw+t39MDL+I1MQLOWLT9g==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-client" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.1.0"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.0.0"
+    "@azure/logger" "^1.0.0"
+    "@azure/msal-browser" "^2.32.0"
+    "@azure/msal-common" "^9.0.0"
+    "@azure/msal-node" "^1.14.4"
+    events "^3.0.0"
+    jws "^4.0.0"
+    open "^8.0.0"
+    stoppable "^1.1.0"
+    tslib "^2.2.0"
+    uuid "^8.3.0"
+
+"@azure/logger@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.0.3.tgz#6e36704aa51be7d4a1bae24731ea580836293c96"
+  integrity sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/msal-browser@^2.32.0":
+  version "2.32.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.32.1.tgz#785670d5bd066690e313ba32cd4638a473675598"
+  integrity sha512-2G3B12ZEIpiimi6/Yqq7KLk4ud1zZWoHvVd2kJ2VthN1HjMsZjdMUxeHkwMWaQ6RzO6mv9rZiuKmRX64xkXW9g==
+  dependencies:
+    "@azure/msal-common" "^9.0.1"
+
+"@azure/msal-common@^9.0.0", "@azure/msal-common@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-9.0.1.tgz#a89c3e156a60d5952aed17b80d3f69e40385daa0"
+  integrity sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ==
+
+"@azure/msal-node@^1.14.4":
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.14.5.tgz#4045075f944a62e94e0b6d1e8fab4f21e3ad711e"
+  integrity sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==
+  dependencies:
+    "@azure/msal-common" "^9.0.1"
+    jsonwebtoken "^8.5.1"
+    uuid "^8.3.0"
+
+"@azure/storage-blob@^12.12.0":
+  version "12.12.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.12.0.tgz#25e277c885692d5adcd8c2a949789b2837a74c59"
+  integrity sha512-o/Mf6lkyYG/eBW4/hXB9864RxVNmAkcKHjsGR6Inlp5hupa3exjSyH2KjO3tLO//YGA+tS+17hM2bxRl9Sn16g==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-http" "^2.0.0"
+    "@azure/core-lro" "^2.2.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    events "^3.0.0"
+    tslib "^2.2.0"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -826,6 +994,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@opentelemetry/api@^1.0.1":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.3.0.tgz#27c6f776ac3c1c616651e506a89f438a0ed6a055"
+  integrity sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==
+
 "@senx/warp10@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@senx/warp10/-/warp10-1.1.2.tgz#b12ff40a203bf52b560a944e62ea4e992658119f"
@@ -869,6 +1042,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
 "@types/async@^3.2.12":
   version "3.2.15"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.15.tgz#26d4768fdda0e466f18d6c9918ca28cc89a4e1fe"
@@ -884,6 +1062,14 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/node-fetch@^2.5.0":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "18.11.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.17.tgz#5c009e1d9c38f4a2a9d45c0b0c493fe6cdb4bcb5"
@@ -893,6 +1079,13 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
   integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
+
+"@types/tunnel@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.3.tgz#f109e730b072b3136347561fc558c9358bb8c6e9"
+  integrity sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/utf8@^3.0.1":
   version "3.0.1"
@@ -1329,10 +1522,12 @@ arrify@^1.0.1:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.1.59":
-  version "8.1.59"
-  resolved "git+https://github.com/scality/arsenal#56c1ba5c215630ad2ea7d542b9ff0c7032843ee0"
+"arsenal@git+https://github.com/scality/arsenal#8.1.78":
+  version "8.1.78"
+  resolved "git+https://github.com/scality/arsenal#c460338163bcc9decde7c18d2835beeef53273e6"
   dependencies:
+    "@azure/identity" "^3.1.1"
+    "@azure/storage-blob" "^12.12.0"
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"
     JSONStream "^1.0.0"
@@ -1340,7 +1535,6 @@ arrify@^1.0.1:
     ajv "6.12.3"
     async "~2.6.4"
     aws-sdk "^2.1005.0"
-    azure-storage "~2.10.7"
     backo "^1.1.0"
     base-x "3.0.8"
     base62 "2.0.1"
@@ -1348,7 +1542,8 @@ arrify@^1.0.1:
     debug "~4.1.0"
     diskusage "^1.1.1"
     fcntl "github:scality/node-fcntl#0.2.0"
-    hdclient scality/hdclient#1.1.0
+    hdclient scality/hdclient#1.1.5
+    httpagent scality/httpagent#1.0.6
     https-proxy-agent "^2.2.0"
     ioredis "^4.28.5"
     ipaddr.js "1.9.1"
@@ -1361,10 +1556,10 @@ arrify@^1.0.1:
     simple-glob "^0.2.0"
     socket.io "2.4.1"
     socket.io-client "2.4.0"
-    sproxydclient "github:scality/sproxydclient#8.0.4"
+    sproxydclient scality/sproxydclient#8.0.7
     utf8 "3.0.0"
     uuid "^3.0.1"
-    werelogs scality/werelogs#8.1.0
+    werelogs scality/werelogs#8.1.2
     xml2js "~0.4.23"
   optionalDependencies:
     ioctl "^2.0.2"
@@ -1864,6 +2059,11 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -2126,6 +2326,13 @@ combined-stream@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -2403,6 +2610,11 @@ deferred-leveldown@~5.3.0:
     abstract-leveldown "~6.2.1"
     inherits "^2.0.3"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2525,6 +2737,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2951,6 +3170,11 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
+events@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
@@ -3284,6 +3508,24 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.2"
@@ -3657,6 +3899,13 @@ hdclient@scality/hdclient#1.1.0:
   dependencies:
     werelogs scality/werelogs#GA7.2.0.5
 
+hdclient@scality/hdclient#1.1.5:
+  version "1.1.5"
+  resolved "https://codeload.github.com/scality/hdclient/tar.gz/0260d7ddc898bd0abdd6567c73fb9ded86cb8874"
+  dependencies:
+    httpagent "github:scality/httpagent#1.0.6"
+    werelogs "github:scality/werelogs#8.1.2"
+
 heapdump@^0.3.15:
   version "0.3.15"
   resolved "https://registry.yarnpkg.com/heapdump/-/heapdump-0.3.15.tgz#631a8a2585588ea64778d8ec80a64c6c025f6a08"
@@ -3709,6 +3958,15 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3721,6 +3979,19 @@ http-signature@~1.2.0:
 "httpagent@git+https://github.com/scality/httpagent#1.0.6":
   version "1.0.6"
   resolved "git+https://github.com/scality/httpagent#66e97ab93532d79dbddcf6c4ea4df849b84c33c9"
+  dependencies:
+    agentkeepalive "^4.2.1"
+
+"httpagent@github:scality/httpagent#1.0.5":
+  version "1.0.5"
+  resolved "https://codeload.github.com/scality/httpagent/tar.gz/ec4e28f05001eaa6528daa174dbeab9e1df40ff6"
+  dependencies:
+    agentkeepalive "^4.2.1"
+
+"httpagent@github:scality/httpagent#1.0.6", httpagent@scality/httpagent#1.0.6:
+  version "1.0.6"
+  uid "66e97ab93532d79dbddcf6c4ea4df849b84c33c9"
+  resolved "https://codeload.github.com/scality/httpagent/tar.gz/66e97ab93532d79dbddcf6c4ea4df849b84c33c9"
   dependencies:
     agentkeepalive "^4.2.1"
 
@@ -4043,6 +4314,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -4260,6 +4536,13 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -4822,6 +5105,22 @@ jsonparse@~1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.2.0.tgz#5c0c5685107160e72fe7489bddea0b44c2bc67bd"
   integrity sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@1.4.2, jsprim@^1.2.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
@@ -4831,6 +5130,40 @@ jsprim@1.4.2, jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.4.0"
     verror "1.10.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwa@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.0.tgz#a7e9c3f29dae94027ebcaf49975c9345593410fc"
+  integrity sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.0.tgz#2d4e8cf6a318ffaa12615e9dec7e86e6c97310f4"
+  integrity sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==
+  dependencies:
+    jwa "^2.0.0"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5141,15 +5474,50 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
 lodash.isarguments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
   integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5738,6 +6106,13 @@ new-find-package-json@^2.0.0:
   dependencies:
     debug "^4.3.4"
 
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -6009,6 +6384,15 @@ once@^1.3.0, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+open@^8.0.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 opencollective-postinstall@^2.0.0:
   version "2.0.3"
@@ -6330,6 +6714,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 prom-client@10.2.3:
   version "10.2.3"
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.3.tgz#a51bf21c239c954a6c5be4b1361fdd380218bb41"
@@ -6390,6 +6779,11 @@ psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
 pull-cat@^1.1.9:
   version "1.1.11"
@@ -6470,6 +6864,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2, queue-microtask@^1.2.3:
   version "1.2.3"
@@ -6726,6 +7125,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6872,6 +7276,11 @@ sax@>=0.6.0, sax@^1.2.4:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
@@ -7229,6 +7638,14 @@ sprintf-js@~1.0.2:
     async "^3.2.0"
     werelogs scality/werelogs#8.1.0
 
+sproxydclient@scality/sproxydclient#8.0.7:
+  version "8.0.7"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/46049c28d2487c8e4ea4c7dde2be2fc90dbcc9ec"
+  dependencies:
+    async "^3.2.0"
+    httpagent "github:scality/httpagent#1.0.5"
+    werelogs scality/werelogs#8.1.2
+
 sshpk@^1.7.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.1.tgz#b79a089a732e346c6e0714830f36285cd38191a2"
@@ -7278,6 +7695,11 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stoppable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
+  integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
 stream-to-pull-stream@^1.7.1:
   version "1.7.3"
@@ -7581,6 +8003,16 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
+tough-cookie@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -7602,6 +8034,11 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -7628,7 +8065,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^2.3.1, tslib@^2.4.1:
+tslib@^2.2.0, tslib@^2.3.1, tslib@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
@@ -7646,6 +8083,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -7765,6 +8207,11 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -7789,6 +8236,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url@0.10.3:
   version "0.10.3"
@@ -7841,7 +8296,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^8.3.1, uuid@^8.3.2:
+uuid@^8.3.0, uuid@^8.3.1, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -7910,6 +8365,11 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -7926,18 +8386,18 @@ webidl-conversions@^7.0.0:
   dependencies:
     safe-json-stringify "1.0.3"
 
-werelogs@scality/werelogs#8.1.0:
-  version "8.1.0"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
-  dependencies:
-    safe-json-stringify "1.0.3"
-
-werelogs@scality/werelogs#8.1.2:
+"werelogs@github:scality/werelogs#8.1.2", werelogs@scality/werelogs#8.1.2:
   version "8.1.2"
   resolved "https://codeload.github.com/scality/werelogs/tar.gz/c9952528699978e4b09164c67922b4fbcfd4654f"
   dependencies:
     fast-safe-stringify "^2.1.1"
     safe-json-stringify "^1.2.0"
+
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
+  dependencies:
+    safe-json-stringify "1.0.3"
 
 werelogs@scality/werelogs#GA7.2.0.5:
   version "7.2.0"
@@ -7964,6 +8424,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"
@@ -8089,20 +8557,20 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
-xml2js@~0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.8.tgz#9b81690931631ff09d1957549faf54f4f980b3c2"
-  integrity sha512-ZHZBIAO55GHCn2jBYByVPHvHS+o3j8/a/qmpEe6kxO3cTnTCWC3Htq9RYJ5G4XMwMMClD2QkXA9SNdPadLyn3Q==
-  dependencies:
-    sax "0.5.x"
-
-xml2js@~0.4.23:
+xml2js@^0.4.19, xml2js@~0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
+
+xml2js@~0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.8.tgz#9b81690931631ff09d1957549faf54f4f980b3c2"
+  integrity sha512-ZHZBIAO55GHCn2jBYByVPHvHS+o3j8/a/qmpEe6kxO3cTnTCWC3Htq9RYJ5G4XMwMMClD2QkXA9SNdPadLyn3Q==
+  dependencies:
+    sax "0.5.x"
 
 xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
this PR is based on [this PR](https://github.com/scality/s3utils/pull/276) to reuse the MongoClientInterface inherited class

this PR mainly implemented the script for the cronjob designed [here](https://github.com/scality/citadel/blob/development/1.0/docs/design/veeam-sosapi.md#cron-job)

the script does the following things:
- collects bucket storage metrics from `INFOSTORE` collection (which is updated by `countitems` cronjob hourly)
- read `Capacity` field from bucketMD (`Capacity` field is put into bucketMD by `capacity.xml` objectPut operation)
- check the validity of the metrics retrieved above
  - if valid, write back to buketMD `Avaible`, `Used` fields after some calculation
  - if not valid, write back `-1` 