### PR TITLE
Improvement/s3 utils 123 sosapi cronjob alerting

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,0 +1,33 @@
+name: Test alerts
+
+on:
+  push:
+    branches-ignore:
+      - development/**
+      - q/*/**
+
+jobs:
+  run-alert-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Render and test count-items-cronjob
+        uses: scality/action-prom-render-test@1.0.2
+        with:
+          alert_file_path: monitoring/count-items-cronjob/alerts.yaml
+          test_file_path: monitoring/count-items-cronjob/alerts.test.yaml
+          alert_inputs: >-
+            namespace=zenko,count_items_cronjob=artesca-data-ops-count-items,count_items_job_duration_threshold=3600
+          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+      - name: Render and test update-bucket-capacity-info-cronjob
+        uses: scality/action-prom-render-test@1.0.2
+        with:
+          alert_file_path: monitoring/update-bucket-capacity-info-cronjob/alerts.yaml
+          test_file_path: monitoring/update-bucket-capacity-info-cronjob/alerts.test.yaml
+          alert_inputs: >-
+            namespace=zenko,update_bucket_capacity_info_cronjob=artesca-data-ops-update-bucket-capacity-info,update_bucket_capacity_info_job_duration_threshold=240,update_bucket_capacity_info_success_job_existence_duration_threshold=600
+          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: build
+
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        required: false
+        type: string
+        default: s3utils-dev
+      tag:
+        required: false
+        type: string
+        default: "${{ github.sha }}"
+
+env:
+  REGISTRY_NAME: registry.scality.com
+  PROJECT_NAME: ${{ github.event.repository.name }}
+  NAMESPACE: ${{ inputs.namespace }}
+  TAG: ${{ inputs.tag }}
+
+jobs:
+  build:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.scality.com
+          username: ${{ secrets.REGISTRY_LOGIN }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push dashboards into the development namespace
+        run: |
+          oras push ${{ env.REGISTRY_NAME }}/${{ env.NAMESPACE }}/${{ env.PROJECT_NAME }}-dashboards:${{ env.TAG }} \
+            count-items-cronjob/alerts.yaml:application/prometheus-alerts+yaml \
+            update-bucket-capacity-info-cronjob/alerts.yaml:application/prometheus-alerts+yaml
+        working-directory: monitoring
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: "${{ env.REGISTRY_NAME }}/${{ env.NAMESPACE }}/${{ env.PROJECT_NAME }}:${{ env.TAG }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,36 +11,25 @@ on:
         default: 'false'
         required: false
 
+env:
+  REGISTRY_NAME: registry.scality.com
+  PROJECT_NAME: ${{ github.event.repository.name }}
+
 jobs:
-  release:
+  build:
+    name: Build and Push
+    uses: ./.github/workflows/build.yml
+    with:
+      namespace: s3utils
+      tag: ${{ github.event.inputs.tag }}
+    secrets: inherit
+
+  github-release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
+    needs:
+      - build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Registry
-        uses: docker/login-action@v1
-        with:
-          registry: registry.scality.com
-          username: ${{ secrets.REGISTRY_LOGIN }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: "registry.scality.com/s3utils/s3utils:${{ github.event.inputs.tag }}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,29 +35,10 @@ jobs:
           MONGODB_REPLICASET: "localhost:27018"
 
   build:
-    runs-on: ubuntu-latest
+    name: Build and Push
     needs:
       - tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Registry
-        uses: docker/login-action@v1
-        with:
-          registry: registry.scality.com
-          username: ${{ secrets.REGISTRY_LOGIN }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: "registry.scality.com/s3utils-dev/s3utils:${{ github.sha }}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      namespace: s3utils-dev

--- a/monitoring/count-items-cronjob/alerts.test.yaml
+++ b/monitoring/count-items-cronjob/alerts.test.yaml
@@ -1,0 +1,33 @@
+evaluation_interval: 1m
+rule_files:
+  - alerts.rendered.yaml
+
+tests:
+
+  - name: Count Items CronJob Tests
+    interval: 1m
+    input_series:
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-1", namespace="zenko"}'
+        values: '0x121'
+      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-1", namespace="zenko"}'
+        values: '_x60 3600x61'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-2", namespace="zenko"}'
+        values: '_x60 3600x61'
+      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-2", namespace="zenko"}'
+        values: '_x121'
+    alert_rule_test:
+      - alertname: CountItemsJobTakingTooLong
+        eval_time: 60m
+        exp_alerts: []
+      - alertname: CountItemsJobTakingTooLong
+        eval_time: 121m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job_name: artesca-data-ops-count-items-1
+            exp_annotations:
+              description: |
+                Job artesca-data-ops-count-items is taking more than 3600s to complete.
+                This means that consumption information will be delayed
+                and the reported metrics might not be accurate anymore.
+              summary: count-items cronjob takes too long to finish

--- a/monitoring/count-items-cronjob/alerts.yaml
+++ b/monitoring/count-items-cronjob/alerts.yaml
@@ -1,0 +1,29 @@
+x-inputs:
+  - name: namespace
+    type: constant
+    value: zenko
+  - name: count_items_cronjob
+    type: constant
+    value: artesca-data-ops-count-items
+  - name: count_items_job_duration_threshold
+    type: config
+    value: 3600
+
+groups:
+  - name: count-items-cronjob/alerts.rules
+    rules:
+      - alert: CountItemsJobTakingTooLong
+        Expr: |
+          time() -
+          (sum by(job_name) (kube_job_status_failed{job_name=~"${count_items_cronjob}.*"})
+          > sum by(job_name) (kube_job_status_completion_time{job_name=~"${count_items_cronjob}.*"})
+          or sum by(job_name) (kube_job_status_completion_time{job_name=~"${count_items_cronjob}.*"}))
+          > ${count_items_job_duration_threshold}
+        Labels:
+          severity: warning
+        Annotations:
+          description: |
+            Job ${count_items_cronjob} is taking more than ${count_items_job_duration_threshold}s to complete.
+            This means that consumption information will be delayed
+            and the reported metrics might not be accurate anymore.
+          summary: count-items cronjob takes too long to finish

--- a/monitoring/update-bucket-capacity-info-cronjob/alerts.test.yaml
+++ b/monitoring/update-bucket-capacity-info-cronjob/alerts.test.yaml
@@ -1,0 +1,53 @@
+evaluation_interval: 1m
+rule_files:
+  - alerts.rendered.yaml
+
+tests:
+  - name: Update Bucket Capacity Info CronJob Test Taking Too Long
+    interval: 1m
+    input_series:
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-1", namespace="zenko"}'
+        values: '0x9'
+      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-1", namespace="zenko"}'
+        values: '_x4 240x5'
+      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-2", namespace="zenko"}'
+        values: '_x4 240x5'
+      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-2", namespace="zenko"}'
+        values: '_x9 '
+    alert_rule_test:
+      - alertname: UpdateBucketCapacityJobTakingTooLong
+        eval_time: 4m
+        exp_alerts: []
+      - alertname: UpdateBucketCapacityJobTakingTooLong
+        eval_time: 9m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job_name: artesca-data-ops-update-bucket-capacity-info-1
+            exp_annotations:
+              description: |
+                Job artesca-data-ops-update-bucket-capacity-info is taking more than 240s to complete.
+                This may cause bucket capacity to be out of date and Veeam SOSAPI avalability as risk.
+              summary: update-bucket-capacity-info cronjob takes too long to finish
+
+  - name: Update Bucket Capacity Info CronJob Test No Success in 10m
+    interval: 1m
+    input_series:
+      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-1", namespace="zenko"}'
+        values: '0x11'
+    alert_rule_test:
+      - alertname: NoSuccessfulUpdateBucketCapacityJobRunIn10m
+        eval_time: 10m
+        exp_alerts: []
+      - alertname: NoSuccessfulUpdateBucketCapacityJobRunIn10m
+        eval_time: 11m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job_name: artesca-data-ops-update-bucket-capacity-info-1
+            exp_annotations:
+              description: |
+                No successful artesca-data-ops-update-bucket-capacity-info-1
+                job run in the last 600s, will cause bucket capacity to be out of date
+                and Veeam will process all buckets in non-SOSAPI mode.
+              summary: "No successful artesca-data-ops-update-bucket-capacity-info-1 job run, affecting Veeam SOSAPI"

--- a/monitoring/update-bucket-capacity-info-cronjob/alerts.yaml
+++ b/monitoring/update-bucket-capacity-info-cronjob/alerts.yaml
@@ -1,0 +1,46 @@
+# Variables which should be replaced. Similar to grafana dashboards' __inputs section
+x-inputs:
+  - name: namespace
+    type: constant
+    value: zenko
+  - name: update_bucket_capacity_info_cronjob
+    type: constant
+    value: artesca-data-ops-update-bucket-capacity-info
+  - name: update_bucket_capacity_info_job_duration_threshold
+    type: config
+    value: 240
+  - name: update_bucket_capacity_info_success_job_existence_duration_threshold
+    type: config
+    value: 600
+
+groups:
+  - name: update-bucket-capacity-info-cronjob/alerts.rules
+    rules:
+      - alert: UpdateBucketCapacityJobTakingTooLong
+        expr: |
+          time() -
+          (sum by(job_name) (kube_job_status_failed{job_name=~"${update_bucket_capacity_info_cronjob}.*"})
+          > sum by(job_name) (kube_job_status_completion_time{job_name=~"${update_bucket_capacity_info_cronjob}.*"})
+          or sum by(job_name) (kube_job_status_completion_time{job_name=~"${update_bucket_capacity_info_cronjob}.*"}))
+          > ${update_bucket_capacity_info_job_duration_threshold}
+        labels:
+          severity: warning
+        annotations:
+          description: |
+            Job ${update_bucket_capacity_info_cronjob} is taking more than ${update_bucket_capacity_info_job_duration_threshold}s to complete.
+            This may cause bucket capacity to be out of date and Veeam SOSAPI avalability as risk.
+          summary: update-bucket-capacity-info cronjob takes too long to finish
+
+      - alert: NoSuccessfulUpdateBucketCapacityJobRunIn10m
+        expr: |
+          time() 
+          - max by(job_name) (kube_job_status_completion_time{job_name=~"${update_bucket_capacity_info_cronjob}.*"} ) 
+          > ${update_bucket_capacity_info_success_job_existence_duration_threshold}
+        labels:
+          severity: critical
+        annotations:
+          description: |
+            No successful {{$labels.job_name}}
+            job run in the last ${update_bucket_capacity_info_success_job_existence_duration_threshold}s, will cause bucket capacity to be out of date
+            and Veeam will process all buckets in non-SOSAPI mode.
+          summary: "No successful {{$labels.job_name}} job run, affecting Veeam SOSAPI"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.15",
+  "version": "1.13.16",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
there are two cronjobs defined in s3utils
- count-items: counting object number and data size in the level of account/location/bucket hourly
- update-bucket-capacity-info: it's a feature of SOSAPI, it reads metrics generated by count-items and updates bucket metrics in each bucket's metadata every 4 mins

I added alerts for the two cronjobs accordingly
- for count-items cronjob: 
  - alert when job fails
  - alert when job takes too long(longer than cronjob interval)

- for update-bucket-capacity-info cronjob:
  - alert when job fails
  - alert when job takes too long(longer than cronjob inerval)
  - alert when no successful job runs in last 10m (10m is critical for Veeam to interact with Artesca bucket)