### PR TITLE
Improvement/s3 utils 127 2nd implementation storage metrics

### DIFF
--- a/CountItems/CountMaster.js
+++ b/CountItems/CountMaster.js
@@ -46,7 +46,7 @@ class CountMaster {
                 return next();
             }),
             next => this.manager.start(next),
-            next => this.client.updateCountItems(this.manager.store, this._log, next),
+            next => this.client.updateStorageConsumptionMetrics(this.manager.store, this.manager.dataMetrics, this._log, next),
         ], err => {
             if (err) {
                 this.log.error('error occurred in count items job', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.17",
+  "version": "1.13.18",
   "engines": {
     "node": ">= 16"
   },

--- a/tests/conf/locationConfig.json
+++ b/tests/conf/locationConfig.json
@@ -1,4 +1,47 @@
 {
+    "us-east-1": {
+        "type": "file",
+        "objectId": "us-east-1",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "completed": {
+        "type": "file",
+        "objectId": "completed",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "completed-1": {
+        "type": "file",
+        "objectId": "completed-1",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "completed-2": {
+        "type": "file",
+        "objectId": "completed-2",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "completed-3": {
+        "type": "file",
+        "objectId": "completed-3",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "cold-location": {
+        "type": "dmf",
+        "objectId": "cold-location",
+        "legacyAwsBehavior": true,
+        "isCold": true,
+        "details": {}
+    },
+    "rep-loc-1": {
+        "type": "file",
+        "objectId": "rep-loc-1",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
     "primary-location": {
         "type": "file",
         "objectId": "primary-location",
@@ -13,7 +56,7 @@
     },
     "secondary-location-2": {
         "type": "file",
-        "objectId": "secondary-location-1",
+        "objectId": "secondary-location-2",
         "legacyAwsBehavior": true,
         "details": {}
     }

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -11,7 +11,7 @@ module.exports = {
         _name: 'test-bucket',
         _owner: 'test-owner',
         _ownerDisplayName: 'test-name',
-        _creationDate: new Date().toJSON(),
+        _creationDate: new Date(1678284806000).toString(),
         _mdBucketModelVersion: 10,
         _transient: false,
         _deleted: false,
@@ -26,4 +26,6 @@ module.exports = {
         _isNFS: null,
         ingestion: null,
     },
+    testAccountCanonicalId: 'd1d40abd2bd8250962f7f5774af1bbbeaec9b77a0853749d41ec46f142e66fe4',
+    testBucketCreationDate: 1678284806000,
 };

--- a/tests/functional/collectBucketMetricsAndUpdateBucketCapacityInfo.js
+++ b/tests/functional/collectBucketMetricsAndUpdateBucketCapacityInfo.js
@@ -2,7 +2,7 @@ const async = require('async');
 const werelogs = require('werelogs');
 const assert = require('assert');
 const S3UtilsMongoClient = require('../../utils/S3UtilsMongoClient');
-const { testBucketMD } = require('../constants');
+const { testBucketMD, testBucketCreationDate } = require('../constants');
 const { collectBucketMetricsAndUpdateBucketCapacityInfo } = require('../../DataReport/collectBucketMetricsAndUpdateBucketCapacityInfo');
 
 const logger = new werelogs.Logger('collectBucketMetricsAndUpdateBucketCapacityInfo::Test::Functional');
@@ -58,13 +58,11 @@ describe('collectBucketMetricsAndUpdateBucketCapacityInfo', () => {
                 },
             },
         };
-        client.updateCountItems({
-            dataMetrics: {
-                bucket: {
-                    [testBucketName]: {
-                        usedCapacity: { current: 10, nonCurrent: 10 },
-                        objectCount: { current: 10, nonCurrent: 10 },
-                    },
+        client.updateStorageConsumptionMetrics({}, {
+            bucket: {
+                [`${testBucketName}_${testBucketCreationDate}`]: {
+                    usedCapacity: { current: 10, nonCurrent: 10 },
+                    objectCount: { current: 10, nonCurrent: 10 },
                 },
             },
         }, logger, done);
@@ -185,11 +183,7 @@ describe('collectBucketMetricsAndUpdateBucketCapacityInfo', () => {
         testBucketCapacities.VeeamSOSApi.CapacityInfo.Capacity = 30;
 
         return async.series([
-            next => client.updateCountItems({
-                dataMetrics: {
-                    bucket: {},
-                },
-            }, logger, next),
+            next => client.updateStorageConsumptionMetrics({}, { bucket: {} }, logger, next),
             next => client.createBucket(testBucketName, {
                 ...testBucketMD,
                 _capabilities: testBucketCapacities,

--- a/tests/functional/countItems.js
+++ b/tests/functional/countItems.js
@@ -8,13 +8,13 @@ const CountMaster = require('../../CountItems/CountMaster');
 const CountManager = require('../../CountItems/CountManager');
 const createMongoParams = require('../../utils/createMongoParams');
 const createWorkers = require('../../CountItems/utils/createWorkers');
-const { testBucketMD } = require('../constants');
+const { testBucketMD, testAccountCanonicalId, testBucketCreationDate } = require('../constants');
 
 const logger = new werelogs.Logger('CountItems::Test::Functional');
 const { MONGODB_REPLICASET } = process.env;
 const dbName = 'countItemsTest';
 
-const expectedResults = {
+const expectedCountItems = {
     objects: 90,
     versions: 60,
     buckets: 9,
@@ -27,62 +27,70 @@ const expectedResults = {
         },
     },
     stalled: 0,
-    dataMetrics: {
-        account: {
-            [testBucketMD._ownerDisplayName]: {
+};
+const expectedDataMetrics = {
+    [`account_${testAccountCanonicalId}`]: {
+        objectCount: { current: 90, deleteMarker: 0, nonCurrent: 60 },
+        usedCapacity: { current: 9000, nonCurrent: 6000 },
+        locations: {
+            'secondary-location-1': {
+                objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 },
+                usedCapacity: { current: 3000, nonCurrent: 3000 },
+            },
+            'secondary-location-2': {
+                objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 },
+                usedCapacity: { current: 3000, nonCurrent: 3000 },
+            },
+            'us-east-1': {
                 objectCount: { current: 90, deleteMarker: 0, nonCurrent: 60 },
                 usedCapacity: { current: 9000, nonCurrent: 6000 },
             },
         },
-        bucket: {
-            'test-bucket-0': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
-                usedCapacity: { current: 1000, nonCurrent: 0 },
-            },
-            'test-bucket-1': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
-                usedCapacity: { current: 1000, nonCurrent: 0 },
-            },
-            'test-bucket-2': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
-                usedCapacity: { current: 1000, nonCurrent: 0 },
-            },
-            'test-bucket-3': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-            'test-bucket-4': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-            'test-bucket-5': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-            'test-bucket-6': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-            'test-bucket-7': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-            'test-bucket-8': {
-                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                usedCapacity: { current: 1000, nonCurrent: 1000 },
-            },
-        },
-        location: {
-            'secondary-location-1': {
-                objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 }, usedCapacity: { current: 3000, nonCurrent: 3000 },
-            },
-            'secondary-location-2': {
-                objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 }, usedCapacity: { current: 3000, nonCurrent: 3000 },
-            },
-            'us-east-1': {
-                objectCount: { current: 90, deleteMarker: 0, nonCurrent: 60 }, usedCapacity: { current: 9000, nonCurrent: 6000 },
-            },
-        },
+    },
+    [`bucket_test-bucket-0_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
+        usedCapacity: { current: 1000, nonCurrent: 0 },
+    },
+    [`bucket_test-bucket-1_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
+        usedCapacity: { current: 1000, nonCurrent: 0 },
+    },
+    [`bucket_test-bucket-2_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 0 },
+        usedCapacity: { current: 1000, nonCurrent: 0 },
+    },
+    [`bucket_test-bucket-3_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    [`bucket_test-bucket-4_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    [`bucket_test-bucket-5_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    [`bucket_test-bucket-6_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    [`bucket_test-bucket-7_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    [`bucket_test-bucket-8_${testBucketCreationDate}`]: {
+        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+        usedCapacity: { current: 1000, nonCurrent: 1000 },
+    },
+    'location_secondary-location-1': {
+        objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 }, usedCapacity: { current: 3000, nonCurrent: 3000 },
+    },
+    'location_secondary-location-2': {
+        objectCount: { current: 30, deleteMarker: 0, nonCurrent: 30 }, usedCapacity: { current: 3000, nonCurrent: 3000 },
+    },
+    'location_us-east-1': {
+        objectCount: { current: 90, deleteMarker: 0, nonCurrent: 60 }, usedCapacity: { current: 9000, nonCurrent: 6000 },
     },
 };
 
@@ -119,7 +127,7 @@ function populateMongo(client, callback) {
                 .setDataStoreName('us-east-1')
                 .setContentLength(100)
                 .setLastModified('2020-01-01T00:00:00.000Z')
-                .setOwnerDisplayName(testBucket.getOwnerDisplayName());
+                .setOwnerId(testAccountCanonicalId);
             if (testBucket.getVersioningConfiguration()
                 && testBucket.getVersioningConfiguration().Status === 'Enabled') {
                 objMD.setReplicationInfo({
@@ -219,11 +227,22 @@ describe('CountItems', () => {
                 }),
                 next => client.readCountItems(logger, (err, res) => {
                     expect(err).toBeFalsy();
-                    expect(res).toMatchObject(expectedResults);
+                    expect(res).toMatchObject(expectedCountItems);
                     expect(res.bucketList)
                         .toEqual(expect.arrayContaining(expectedBucketList));
                     return next();
                 }),
+                next => async.eachSeries(
+                    Object.keys(expectedDataMetrics),
+                    (entity, cb) => client.readStorageConsumptionMetrics(entity, logger, (err, res) => {
+                        expect(err).toBeFalsy();
+                        expect(res.usedCapacity).toMatchObject(expectedDataMetrics[entity].usedCapacity);
+                        expect(res.objectCount).toMatchObject(expectedDataMetrics[entity].objectCount);
+                        expect(res.measuredOn).not.toBeNull();
+                        return cb();
+                    }),
+                    () => next(),
+                ),
             ], () => countMaster.stop(null, done));
         },
     );

--- a/tests/mocks/mongoClient.js
+++ b/tests/mocks/mongoClient.js
@@ -7,5 +7,5 @@ module.exports = {
     _getIsTransient: jest.fn(),
     getObjectMDStats: jest.fn(),
     getBucketInfos: jest.fn(),
-    updateCountItems: jest.fn(),
+    updateStorageConsumptionMetrics: jest.fn(),
 };

--- a/tests/unit/CountItems/CountManager.js
+++ b/tests/unit/CountItems/CountManager.js
@@ -43,11 +43,6 @@ describe('CountItems::CountManager', () => {
                 byLocation: {},
             },
             stalled: 0,
-            dataMetrics: {
-                account: {},
-                bucket: {},
-                location: {},
-            },
         });
         m._consolidateData({
             versions: 10,
@@ -56,26 +51,6 @@ describe('CountItems::CountManager', () => {
             dataManaged: {
                 total: { curr: 100, prev: 100 },
                 locations: { location1: { curr: 100, prev: 100 } },
-            },
-            dataMetrics: {
-                account: {
-                    account1: {
-                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                        usedCapacity: { current: 100, nonCurrent: 100 },
-                    },
-                },
-                bucket: {
-                    bucket1: {
-                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                        usedCapacity: { current: 100, nonCurrent: 100 },
-                    },
-                },
-                location: {
-                    location1: {
-                        objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
-                        usedCapacity: { current: 100, nonCurrent: 100 },
-                    },
-                },
             },
         });
         expect(m.store).toEqual({
@@ -88,11 +63,33 @@ describe('CountItems::CountManager', () => {
                 byLocation: { location1: { curr: 100, prev: 100 } },
             },
             stalled: 10,
+        });
+    });
+
+    test('should update dataMetrics', () => {
+        const workers = createWorkers(1);
+        const m = new CountManager({
+            log: new DummyLogger(),
+            workers,
+            maxConcurrent: 1,
+        });
+        expect(m.dataMetrics).toEqual({
+            account: {},
+            bucket: {},
+            location: {},
+        });
+        m._consolidateData({
             dataMetrics: {
                 account: {
                     account1: {
                         objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
                         usedCapacity: { current: 100, nonCurrent: 100 },
+                        locations: {
+                            location1: {
+                                objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                                usedCapacity: { current: 100, nonCurrent: 100 },
+                            },
+                        },
                     },
                 },
                 bucket: {
@@ -106,6 +103,32 @@ describe('CountItems::CountManager', () => {
                         objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
                         usedCapacity: { current: 100, nonCurrent: 100 },
                     },
+                },
+            },
+        });
+        expect(m.dataMetrics).toEqual({
+            account: {
+                account1: {
+                    objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                    usedCapacity: { current: 100, nonCurrent: 100 },
+                    locations: {
+                        location1: {
+                            objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                            usedCapacity: { current: 100, nonCurrent: 100 },
+                        },
+                    },
+                },
+            },
+            bucket: {
+                bucket1: {
+                    objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                    usedCapacity: { current: 100, nonCurrent: 100 },
+                },
+            },
+            location: {
+                location1: {
+                    objectCount: { current: 10, deleteMarker: 0, nonCurrent: 10 },
+                    usedCapacity: { current: 100, nonCurrent: 100 },
                 },
             },
         });

--- a/utils/createMongoParams.js
+++ b/utils/createMongoParams.js
@@ -1,16 +1,8 @@
 const fs = require('fs');
+const getLocationConfig = require('./locationConfig');
 
 function getIsLocationTransientCb(log, locationConfigFile) {
-    if (!fs.existsSync(locationConfigFile)) {
-        log.info(
-            'location conf file missing, falling back to PENSIEVE coll',
-            { filename: locationConfigFile },
-        );
-        return null;
-    }
-
-    const buf = fs.readFileSync(locationConfigFile);
-    const locationConfig = JSON.parse(buf.toString());
+    const locationConfig = getLocationConfig(log, locationConfigFile);
 
     return function locationIsTransient(locationName, log, cb) {
         if (!locationConfig[locationName]) {

--- a/utils/locationConfig.js
+++ b/utils/locationConfig.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+function getLocationConfig(log, locationConfigFile) {
+    const locationConfiguration = locationConfigFile || process.env.LOCATION_CONFIG_FILE || 'conf/locationConfig.json';
+
+    if (!fs.existsSync(locationConfiguration)) {
+        return null;
+    }
+
+    const buf = fs.readFileSync(locationConfiguration);
+    let parsedConfig;
+    try {
+        parsedConfig = JSON.parse(buf.toString());
+    } catch (e) {
+        log.error('could not parse location config file', { error: e.message });
+        parsedConfig = null;
+    }
+    return parsedConfig;
+}
+
+module.exports = getLocationConfig;


### PR DESCRIPTION
the detailed [design](https://github.com/scality/citadel/pull/137) is defined here

the main changes are:
- add location metrics that is used by the account for each account
- split the whole single mongo document into one document per each account/location/bucket for scalability(because mongo has size limit for single document)
- because of the deleted and recreated entity will have stale metrics data issue, use a unique identifier(never be same) to represent each entity: account uses canonicalId, bucket uses bucketName_createionDate, location uses locationId(get from mounted locationConfig)