### PR TITLE
S3UTILS-133 compareFollowerDbs

### DIFF
--- a/CompareRaftMembers/KeyValueStreamDiff.js
+++ b/CompareRaftMembers/KeyValueStreamDiff.js
@@ -1,0 +1,113 @@
+const async = require('async');
+const stream = require('stream');
+
+const { jsutil } = require('arsenal');
+
+/**
+ * Output differences between two streams, where each stream emits
+ * { key: string, value: string } objects sorted by key.
+ *
+ * The output consists of entries of one of the following types:
+ *
+ * - [{ key, value }, null]: this key is present on stream #1 but not
+ *   on stream #2
+ *
+ * - [null, { key, value }]: this key is not present on stream #1 but
+ *   is present on stream #2
+ *
+ * - [{ key, value: "{value1}" }, { key, value: "{value2}" }]: this key
+ *   has a different value between stream #1 and stream #2: "value1"
+ *   is the value seen on stream #1 and "value2" the value seen on
+ *   stream #2.
+ *
+ * @class KeyValueStreamDiff
+ */
+class KeyValueStreamDiff extends stream.Readable {
+    /**
+     * @constructor
+     * @param {stream.Readable} stream1 - first stream to compare
+     * @param {stream.Readable} stream2 - second stream to compare
+     */
+    constructor(stream1, stream2) {
+        super({ objectMode: true });
+
+        this._streams = [stream1, stream2];
+        this._lastItems = [null, null];
+        this._eof = [false, false];
+        this._reading = false;
+
+        this._streams.forEach((stream, streamIndex) => {
+            stream
+                .on('data', data => {
+                    this._lastItems[streamIndex] = data;
+                    stream.pause();
+                    this._checkDiff();
+                })
+                .on('end', () => {
+                    this._eof[streamIndex] = true;
+                    this._checkDiff();
+                })
+                .on('error', err => {
+                    // eslint-disable-next-line no-console
+                    console.error(`error from stream #${streamIndex}: ${err.message}`);
+                    this.destroy(err);
+                });
+        });
+    }
+
+    _read() {
+        if (!this._reading) {
+            this._reading = true;
+            this._checkDiff();
+        }
+    }
+
+    _consumedItem(streamIndex) {
+        this._lastItems[streamIndex] = null;
+        this._streams[streamIndex].resume();
+    }
+
+    _pushDiff(item1, item2) {
+        this.push([item1, item2]);
+        this._reading = false;
+    }
+
+    _checkDiff() {
+        // bail out if:
+        // - consumer not actively reading
+        // - or at least one of the input streams is waiting for an item to read
+        if (!this._reading
+            || (!this._eof[0] && !this._lastItems[0])
+            || (!this._eof[1] && !this._lastItems[1])) {
+            return undefined;
+        }
+        // compute the difference between the last item read from each
+        // stream (or null if EOF was reached)
+        if (this._lastItems[0] && this._lastItems[1]) {
+            if (this._lastItems[0].key < this._lastItems[1].key) {
+                this._pushDiff(this._lastItems[0], null);
+                this._consumedItem(0);
+            } else if (this._lastItems[0].key > this._lastItems[1].key) {
+                this._pushDiff(null, this._lastItems[1]);
+                this._consumedItem(1);
+            } else {
+                if (this._lastItems[0].value !== this._lastItems[1].value) {
+                    this._pushDiff(this._lastItems[0], this._lastItems[1]);
+                }
+                this._consumedItem(0);
+                this._consumedItem(1);
+            }
+        } else if (this._lastItems[0]) {
+            this._pushDiff(this._lastItems[0], null);
+            this._consumedItem(0);
+        } else if (this._lastItems[1]) {
+            this._pushDiff(null, this._lastItems[1]);
+            this._consumedItem(1);
+        } else {
+            this.push(null);
+        }
+        return undefined;
+    }
+}
+
+module.exports = KeyValueStreamDiff;

--- a/CompareRaftMembers/compareFollowerDbs.js
+++ b/CompareRaftMembers/compareFollowerDbs.js
@@ -1,0 +1,272 @@
+/* eslint-disable no-console */
+
+const async = require('async');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+
+const { Logger } = require('werelogs');
+const Level = require('level');
+
+const DBListStream = require('./DBListStream');
+const DiffStreamOplogFilter = require('./DiffStreamOplogFilter');
+const KeyValueStreamDiff = require('./KeyValueStreamDiff');
+
+const DEFAULT_PARALLEL_SCANS = 4;
+const DEFAULT_LOG_PROGRESS_INTERVAL = 10;
+
+const USAGE = `
+compareFollowerDbs.js
+
+This tool compares offline Metadata leveldb databases of two different
+Metadata nodes, and outputs the differences to the file path given as
+the DIFF_OUTPUT_FILE environment variable.
+
+In this file, it outputs each key that differs as line-separated JSON
+entries, where each entry can be one of:
+
+- [{ key, value }, null]: this key is present on follower #1 but not
+  on follower #2
+
+- [null, { key, value }]: this key is not present on follower #1 but
+  is present on follower #2
+
+- [{ key, value: "{value1}" }, { key, value: "{value2}" }]: this key
+  has a different value between follower #1 and follower #2: "value1"
+  is the value seen on follower #1 and "value2" the value seen on
+  follower #2.
+
+Usage:
+    node compareFollowerDbs.js
+
+Mandatory environment variables:
+    DATABASES1: space-separated list of databases of follower #1 to
+    compare against follower #2
+    DATABASES2: space-separated list of databases of follower #2 to
+    compare against follower #1
+    DIFF_OUTPUT_FILE: file path where diff output will be stored
+
+Optional environment variables:
+    PARALLEL_SCANS: number of databases to scan in parallel (default ${DEFAULT_PARALLEL_SCANS})
+    EXCLUDE_FROM_CSEQS: mapping of raft sessions to filter on, where
+        keys are raft session IDs and values are the cseq value for that
+        raft session. Filtering will be based on all oplog records more
+        recent than the given "cseq" for the raft session. Input diff
+        entries not belonging to one of the declared raft sessions are
+        discarded from the output. The value must be in the following JSON
+        format:
+            {"rsId":cseq[,"rsId":cseq...]}
+        Example:
+            {"1":1234,"4":4567,"6":6789}
+        This configuration would cause diff entries which bucket/key
+        appear in either of the following to be discarded from the output:
+        - oplog of raft session 1 after cseq=1234
+        - or oplog of raft session 4 after cseq=4567
+        - or oplog of raft session 6 after cseq=6789
+        - or any other raft session's oplog at any cseq
+    BUCKETD_HOSTPORT: ip:port of bucketd endpoint, needed when EXCLUDE_FROM_CSEQS is set
+`;
+
+for (const envVar of [
+    'DATABASES1',
+    'DATABASES2',
+    'DIFF_OUTPUT_FILE',
+]) {
+    if (!process.env[envVar]) {
+        console.error(`ERROR: ${envVar} not defined`);
+        console.error(USAGE);
+        process.exit(1);
+    }
+}
+
+const {
+    DATABASES1,
+    DATABASES2,
+    DIFF_OUTPUT_FILE,
+} = process.env;
+
+const LOG_PROGRESS_INTERVAL = (
+    process.env.LOG_PROGRESS_INTERVAL
+        && Number.parseInt(process.env.LOG_PROGRESS_INTERVAL, 10))
+      || DEFAULT_LOG_PROGRESS_INTERVAL;
+
+const PARALLEL_SCANS = (
+    process.env.PARALLEL_SCANS
+        && Number.parseInt(process.env.PARALLEL_SCANS, 10))
+      || DEFAULT_PARALLEL_SCANS;
+
+const EXCLUDE_FROM_CSEQS = process.env.EXCLUDE_FROM_CSEQS
+      && JSON.parse(process.env.EXCLUDE_FROM_CSEQS);
+
+const DATABASE_LISTS = [
+    DATABASES1,
+    DATABASES2,
+].map(
+    databases => databases
+        .split(' ')
+        .filter(dbPath => {
+            const dbName = path.basename(dbPath);
+            return !['sdb', 'stdb', 'dbAttributes'].includes(dbName);
+        })
+        .sort(),
+);
+
+if (DATABASE_LISTS[0].length !== DATABASE_LISTS[1].length) {
+    console.error('ERROR: DATABASES1 and DATABASES2 must contain the same number of database paths');
+    process.exit(1);
+}
+
+const DATABASE_COMPARISON_PAIRS = [];
+for (let i = 0; i < DATABASE_LISTS[0].length; ++i) {
+    DATABASE_COMPARISON_PAIRS.push([
+        DATABASE_LISTS[0][i],
+        DATABASE_LISTS[1][i],
+    ]);
+}
+
+const DIFF_OUTPUT_STREAM = fs.createWriteStream(DIFF_OUTPUT_FILE, { flags: 'wx' });
+
+const log = new Logger('s3utils:CompareRaftMembers:compareFollowerDbs');
+
+const status = {
+    keysScanned: 0,
+    onlyOnFollower1: 0,
+    onlyOnFollower2: 0,
+    differingValue: 0,
+};
+
+function logProgress(message) {
+    log.info(message, status);
+}
+
+setInterval(
+    () => logProgress('progress update'),
+    LOG_PROGRESS_INTERVAL * 1000,
+);
+
+// Output a byte stream of newline-separated JSON entries from input
+// streamed objects + update metrics
+class JSONLStream extends stream.Transform {
+    constructor() {
+        super({ objectMode: true });
+    }
+
+    _transform(diffEntry, encoding, callback) {
+        if (diffEntry[0] === null) {
+            status.onlyOnFollower2 += 1;
+        } else if (diffEntry[1] === null) {
+            status.onlyOnFollower1 += 1;
+        } else {
+            status.differingValue += 1;
+        }
+        this.push(`${JSON.stringify(diffEntry)}\n`);
+        callback();
+    }
+
+    _flush(callback) {
+        this.push(null);
+        callback();
+    }
+}
+
+let diffStreamsSink;
+if (EXCLUDE_FROM_CSEQS) {
+    const { BUCKETD_HOSTPORT } = process.env;
+    if (!BUCKETD_HOSTPORT) {
+        console.error('ERROR: BUCKETD_HOSTPORT env var is required for EXCLUDE_FROM_CSEQS');
+        console.error(USAGE);
+        process.exit(1);
+    }
+    const [BUCKETD_HOST, BUCKETD_PORT] = BUCKETD_HOSTPORT.split(':');
+    if (!BUCKETD_PORT) {
+        console.error('ERROR: BUCKETD_HOSTPORT must be of form "ip:port"');
+        console.error(USAGE);
+        process.exit(1);
+    }
+    diffStreamsSink = new DiffStreamOplogFilter({
+        bucketdHost: BUCKETD_HOST,
+        bucketdPort: BUCKETD_PORT,
+        excludeFromCseqs: EXCLUDE_FROM_CSEQS,
+    });
+    diffStreamsSink
+        .pipe(new JSONLStream())
+        .pipe(DIFF_OUTPUT_STREAM);
+} else {
+    diffStreamsSink = new JSONLStream();
+    diffStreamsSink
+        .pipe(DIFF_OUTPUT_STREAM);
+}
+
+function compareDbs(dbPair, cb) {
+    log.info(
+        'starting comparison of pair of databases',
+        { db1: dbPair[0], db2: dbPair[1] },
+    );
+    const dbListStreams = dbPair.map(dbPath => {
+        const db = new Level(dbPath);
+        const dbRawStream = db.createReadStream();
+        const dbListStream = new DBListStream({ dbName: path.basename(dbPath) });
+        dbRawStream.pipe(dbListStream);
+        return dbListStream;
+    });
+    dbListStreams[0]
+        .on('data', () => {
+            status.keysScanned += 1;
+        });
+
+    const diffStream = new KeyValueStreamDiff(dbListStreams[0], dbListStreams[1]);
+    diffStream
+        .on('data', data => {
+            if (!diffStreamsSink.write(data)) {
+                diffStream.pause();
+                diffStreamsSink.once('drain', () => {
+                    diffStream.resume();
+                });
+            }
+        })
+        .on('end', () => {
+            log.info('completed scan of database pair', { db1: dbPair[0], db2: dbPair[1] });
+            cb();
+        })
+        .on('error', err => {
+            log.error(
+                'error from diff stream',
+                { db1: dbPair[0], db2: dbPair[1], error: err.message },
+            );
+            cb(err);
+        });
+}
+
+function main() {
+    log.info('starting scan');
+    async.series([
+        done => async.eachLimit(DATABASE_COMPARISON_PAIRS, PARALLEL_SCANS, compareDbs, done),
+        done => {
+            diffStreamsSink.end();
+            diffStreamsSink.on('finish', done);
+        },
+    ], err => {
+        if (err) {
+            logProgress('error during scan');
+            process.exit(1);
+        }
+        logProgress('completed scan');
+        DIFF_OUTPUT_STREAM.end();
+        DIFF_OUTPUT_STREAM.on('finish', () => {
+            process.exit(0);
+        });
+    });
+}
+
+main();
+
+function stop() {
+    log.info('stopping execution');
+    logProgress('last status');
+    process.exit(0);
+}
+
+process.on('SIGINT', stop);
+process.on('SIGHUP', stop);
+process.on('SIGQUIT', stop);
+process.on('SIGTERM', stop);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.22",
+  "version": "1.13.23",
   "engines": {
     "node": ">= 16"
   },

--- a/tests/unit/CompareRaftMembers/KeyValueStreamDiff.js
+++ b/tests/unit/CompareRaftMembers/KeyValueStreamDiff.js
@@ -1,0 +1,310 @@
+const async = require('async');
+const stream = require('stream');
+
+const KeyValueStreamDiff = require('../../../CompareRaftMembers/KeyValueStreamDiff');
+
+class MockKeyValueStream extends stream.Readable {
+    constructor(listingToSend) {
+        super({ objectMode: true });
+
+        this.listingToSend = listingToSend;
+    }
+
+    _read() {
+        process.nextTick(() => {
+            if (this.listingToSend.length === 0) {
+                this.push(null);
+            } else {
+                const item = this.listingToSend.shift();
+                this.push(item);
+            }
+        });
+    }
+}
+
+describe('KeyValueStreamDiff', () => {
+    describe('should output differences between streams of { key, value } items', () => {
+        [
+            {
+                desc: 'with empty streams',
+                streamEntries: [
+                    [],
+                    [],
+                ],
+                expectedOutput: [],
+            },
+            {
+                desc: 'with respectively zero and one entry in each stream',
+                streamEntries: [
+                    [],
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                ],
+                expectedOutput: [
+                    [
+                        null,
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                ],
+            },
+            {
+                // symmetric check of the previous one
+                desc: 'with respectively one and zero entry in each stream',
+                streamEntries: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                    [],
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                        null,
+                    ],
+                ],
+            },
+            {
+                desc: 'with a single identical entry in both streams',
+                streamEntries: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                ],
+                expectedOutput: [],
+            },
+            {
+                desc: 'with a single entry in each stream with a different key',
+                streamEntries: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                    [
+                        { key: 'bucket/key2', value: '{}' },
+                    ],
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                        null,
+                    ],
+                    [
+                        null,
+                        { key: 'bucket/key2', value: '{}' },
+                    ],
+                ],
+            },
+            {
+                desc: 'with a single entry with same key but different value in each stream',
+                streamEntries: [
+                    [
+                        { key: 'bucket/key1', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+            },
+            {
+                desc: 'with respectively one and two entries in each stream',
+                streamEntries: [
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                    ],
+                    [
+                        { key: 'bucket/key1', value: '{}' },
+                        { key: 'bucket/key2', value: '{"foo":"bar"}' },
+                    ],
+                ],
+                expectedOutput: [
+                    [
+                        null,
+                        { key: 'bucket/key2', value: '{"foo":"bar"}' },
+                    ],
+                ],
+            },
+            {
+                desc: 'with two identical entries in each stream',
+                streamEntries: [
+                    [
+                        { key: 'bucket1/key1', value: '{}' },
+                        { key: 'bucket2/key1', value: '{}' },
+                    ],
+                    [
+                        { key: 'bucket1/key1', value: '{}' },
+                        { key: 'bucket2/key1', value: '{}' },
+                    ],
+                ],
+                expectedOutput: [],
+            },
+            {
+                desc: 'with two different entries in each stream',
+                streamEntries: [
+                    [
+                        { key: 'bucket1/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket2/key1', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket1/key1', value: '{"foo":"qux"}' },
+                        { key: 'bucket2/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+                expectedOutput: [
+                    [
+                        { key: 'bucket1/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket1/key1', value: '{"foo":"qux"}' },
+                    ],
+                    [
+                        { key: 'bucket2/key1', value: '{"foo":"bar"}' },
+                        { key: 'bucket2/key1', value: '{"foo":"qux"}' },
+                    ],
+                ],
+            },
+            {
+                desc: 'with 7777 identical entries in both streams',
+                get streamEntries() {
+                    const streamEntries = [[], []];
+                    for (let s = 0; s < 2; ++s) {
+                        for (let i = 0; i < 7777; ++i) {
+                            const paddedI = `000000${i}`.slice(-6);
+                            streamEntries[s].push({
+                                key: `bucket/key-${paddedI}`,
+                                value: '{"foo":"bar"}',
+                            });
+                        }
+                    }
+                    return streamEntries;
+                },
+                expectedOutput: [],
+            },
+            {
+                desc: 'with respectively 7777 and zero entries in each stream',
+                get streamEntries() {
+                    const streamEntries = [[], []];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        streamEntries[0].push({
+                            key: `bucket/key-${paddedI}`,
+                            value: '{"foo":"bar"}',
+                        });
+                    }
+                    return streamEntries;
+                },
+                get expectedOutput() {
+                    const expectedDiff = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        expectedDiff.push([
+                            { key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' },
+                            null,
+                        ]);
+                    }
+                    return expectedDiff;
+                },
+            },
+            {
+                desc: 'with 7777 entries in each stream with a few differences',
+                get streamEntries() {
+                    const streamEntries = [[], []];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        let value1;
+                        if (i === 3333) {
+                            value1 = '{"foo":"qux"}';
+                        } else {
+                            value1 = '{"foo":"bar"}';
+                        }
+                        const value2 = '{"foo":"bar"}';
+                        if (i !== 2222) {
+                            streamEntries[0].push({
+                                key: `bucket/key-${paddedI}`,
+                                value: value1,
+                            });
+                        }
+                        if (i !== 4444) {
+                            streamEntries[1].push({
+                                key: `bucket/key-${paddedI}`,
+                                value: value2,
+                            });
+                        }
+                    }
+                    return streamEntries;
+                },
+                expectedOutput: [
+                    [
+                        null,
+                        { key: 'bucket/key-002222', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket/key-003333', value: '{"foo":"qux"}' },
+                        { key: 'bucket/key-003333', value: '{"foo":"bar"}' },
+                    ],
+                    [
+                        { key: 'bucket/key-004444', value: '{"foo":"bar"}' },
+                        null,
+                    ],
+                ],
+            },
+            {
+                desc: 'with respectively two and 7777 entries in each stream',
+                get streamEntries() {
+                    const streamEntries = [[], []];
+                    for (let i = 0; i < 7777; ++i) {
+                        const paddedI = `000000${i}`.slice(-6);
+                        if ([1234, 6667].includes(i)) {
+                            streamEntries[0].push({
+                                key: `bucket/key-${paddedI}`,
+                                value: '{"foo":"bar"}',
+                            });
+                        }
+                        streamEntries[1].push({
+                            key: `bucket/key-${paddedI}`,
+                            value: '{"foo":"bar"}',
+                        });
+                    }
+                    return streamEntries;
+                },
+                get expectedOutput() {
+                    const expectedDiff = [];
+                    for (let i = 0; i < 7777; ++i) {
+                        if (![1234, 6667].includes(i)) {
+                            const paddedI = `000000${i}`.slice(-6);
+                            expectedDiff.push([
+                                null,
+                                { key: `bucket/key-${paddedI}`, value: '{"foo":"bar"}' },
+                            ]);
+                        }
+                    }
+                    return expectedDiff;
+                },
+            },
+        ].forEach(testCase => {
+            const { expectedOutput } = testCase;
+            test(`${testCase.desc} yielding ${expectedOutput.length} diff entries`, done => {
+                const streams = testCase.streamEntries.map(
+                    streamEntries => new MockKeyValueStream(streamEntries),
+                );
+                const output = [];
+                const diffStream = new KeyValueStreamDiff(streams[0], streams[1]);
+                diffStream
+                    .on('data', data => {
+                        output.push(data);
+                    })
+                    .on('end', () => {
+                        expect(output).toEqual(expectedOutput);
+                        done();
+                    })
+                    .on('error', done);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add a new tool to compare follower databases offline, and report differences in a JSON output file in the same format than `followerDiff`.

It can be used in place of `followerDiff` to support frequent leader changes, however it has some drawbacks:

- it requires stopping the leader manually at least once

- it requires copying follower's databases so that the script can scan databases from two followers from the same location
