### PR TITLE
S3UTILS-135: increase alert thresholds to 1 day

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -20,7 +20,7 @@ jobs:
           alert_file_path: monitoring/count-items-cronjob/alerts.yaml
           test_file_path: monitoring/count-items-cronjob/alerts.test.yaml
           alert_inputs: >-
-            namespace=zenko,count_items_cronjob=artesca-data-ops-count-items,count_items_job_duration_threshold=3600
+            namespace=zenko,count_items_cronjob=artesca-data-ops-count-items,count_items_job_duration_threshold=86400
           github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Render and test update-bucket-capacity-info-cronjob

--- a/monitoring/count-items-cronjob/alerts.test.yaml
+++ b/monitoring/count-items-cronjob/alerts.test.yaml
@@ -8,26 +8,26 @@ tests:
     interval: 1m
     input_series:
       - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-1", namespace="zenko"}'
-        values: '0x121'
+        values: '0x3000'
       - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-1", namespace="zenko"}'
-        values: '_x60 3600x61'
+        values: '_x1440 86400x1560'
       - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-2", namespace="zenko"}'
-        values: '_x60 3600x61'
+        values: '_x1440 86400x1560'
       - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-count-items-2", namespace="zenko"}'
-        values: '_x121'
+        values: '_x3000'
     alert_rule_test:
       - alertname: CountItemsJobTakingTooLong
-        eval_time: 60m
+        eval_time: 1440m
         exp_alerts: []
       - alertname: CountItemsJobTakingTooLong
-        eval_time: 121m
+        eval_time: 3000m
         exp_alerts:
           - exp_labels:
               severity: warning
               job_name: artesca-data-ops-count-items-1
             exp_annotations:
               description: |
-                Job artesca-data-ops-count-items is taking more than 3600s to complete.
+                Job artesca-data-ops-count-items is taking more than 86400s to complete.
                 This means that consumption information will be delayed
                 and the reported metrics might not be accurate anymore.
               summary: count-items cronjob takes too long to finish

--- a/monitoring/count-items-cronjob/alerts.yaml
+++ b/monitoring/count-items-cronjob/alerts.yaml
@@ -7,7 +7,7 @@ x-inputs:
     value: artesca-data-ops-count-items
   - name: count_items_job_duration_threshold
     type: config
-    value: 3600
+    value: 86400
 
 groups:
   - name: count-items-cronjob/alerts.rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.21",
+  "version": "1.13.22",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
Based on [discussion](https://scality.atlassian.net/browse/ARTESCA-8036?focusedCommentId=348344), the cronjob for countItems must have it’s alert threshold increased.