### PR TITLE
impr(S3UTILS-145): Add OLDER_THAN and VERBOSE options to bucketVersionStats.js

### DIFF
--- a/bucketVersionsStats.js
+++ b/bucketVersionsStats.js
@@ -49,8 +49,12 @@ Optional environment variables:
     HTTPS_CA_PATH: path to a CA certificate bundle used to authentify
     the S3 endpoint
     HTTPS_NO_VERIFY: set to 1 to disable S3 endpoint certificate check
-    OLDER_THAN: only count versions older than this date (format: YYYY-MM-DD or <number of seconds>s)
     VERBOSE: set to a non-empty value to enable logging of individual version info
+    OLDER_THAN: only count versions older than this date
+        set this as an ISO date, a number of days, or a number of seconds e.g.,
+        - setting to "2022-11-30T00:00:00Z" counts objects created/modified before Nov 30th 2022
+        - setting to "30 days" counts objects created/modified more than 30 days ago
+        - setting to "30 seconds" counts objects created/modified more than 30 seconds ago
 `;
 
 // We accept console statements for usage purpose
@@ -68,7 +72,7 @@ let _OLDER_THAN_TIMESTAMP;
 if (OLDER_THAN) {
     _OLDER_THAN_TIMESTAMP = parseOlderThan(OLDER_THAN);
     if (Number.isNaN(_OLDER_THAN_TIMESTAMP.getTime())) {
-        console.error('Invalid OLDER_THAN value, must be either a date in ISO 8601 format or a number of seconds suffixed with "s"');
+        console.error('OLDER_THAN is not valid');
         console.error(USAGE);
         process.exit(1);
     }

--- a/bucketVersionsStats.js
+++ b/bucketVersionsStats.js
@@ -6,6 +6,8 @@ const { doWhilst } = require('async');
 
 const { Logger } = require('werelogs');
 
+const parseOlderThan = require('./utils/parseOlderThan');
+
 const log = new Logger('s3utils::bucketVersionsStats');
 const { ENDPOINT } = process.env;
 const { ACCESS_KEY } = process.env;
@@ -64,17 +66,12 @@ const s3EndpointIsHttps = ENDPOINT.startsWith('https:');
 
 let _OLDER_THAN_TIMESTAMP;
 if (OLDER_THAN) {
-    if (OLDER_THAN.endsWith('s')) {
-        _OLDER_THAN_TIMESTAMP = Date.now() - Number.parseInt(OLDER_THAN, 10) * 1000;
-    } else {
-        _OLDER_THAN_TIMESTAMP = Date.parse(OLDER_THAN);
-    }
-    if (Number.isNaN(_OLDER_THAN_TIMESTAMP)) {
+    _OLDER_THAN_TIMESTAMP = parseOlderThan(OLDER_THAN);
+    if (Number.isNaN(_OLDER_THAN_TIMESTAMP.getTime())) {
         console.error('Invalid OLDER_THAN value, must be either a date in ISO 8601 format or a number of seconds suffixed with "s"');
         console.error(USAGE);
         process.exit(1);
     }
-    _OLDER_THAN_TIMESTAMP = new Date(_OLDER_THAN_TIMESTAMP);
 }
 
 /* eslint-enable no-console */

--- a/tests/unit/utils/parseOlderThan.js
+++ b/tests/unit/utils/parseOlderThan.js
@@ -24,4 +24,8 @@ describe('parseOlderThan', () => {
         const d = parseOlderThan('30 days');
         expect(d.toISOString()).toEqual('2022-06-14T00:00:00.000Z');
     });
+    test('as 30 seconds past the current date', () => {
+        const d = parseOlderThan('30 seconds');
+        expect(d.toISOString()).toEqual('2022-07-13T23:59:30.000Z');
+    });
 });

--- a/utils/parseOlderThan.js
+++ b/utils/parseOlderThan.js
@@ -16,6 +16,11 @@ function parseOlderThan(olderThan) {
         cutoff.setDate(cutoff.getDate() - numberOfDays);
         return cutoff;
     }
+    const numberOfSecsMatch = /^([0-9]+) seconds?$/.exec(olderThan);
+    if (numberOfSecsMatch) {
+        const numberOfMs = Number.parseInt(numberOfSecsMatch[1], 10) * 1000;
+        return new Date(Date.now() - numberOfMs);
+    }
     return new Date(olderThan);
 }
 


### PR DESCRIPTION
OLDER_THAN:
Limit counted versions to those with a last-modified older than the given timestamp. Can be given as an ISO 8601 timestamp or as a number of seconds suffixed with `s`.

VERBOSE:
Causes the tool to output a log line for each version counted.