### PR TITLE
S3UTILS-146: Recover from specific listing parsing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "engines": {
     "node": ">= 16"
   },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node-uuid": "^1.4.8",
     "vaultclient": "scality/vaultclient#8.2.6",
     "werelogs": "scality/werelogs#8.1.2",
+    "xml2js": "^0.6.2",
     "zenkoclient": "scality/zenkoclient#1.2.1"
   },
   "resolutions": {

--- a/tests/unit/utils/safeList.js
+++ b/tests/unit/utils/safeList.js
@@ -1,0 +1,311 @@
+const xml2js = require('xml2js');
+const { recoverListing } = require('../../../utils/safeList');
+
+
+describe('test safeListObjectVersions', () => {
+    const testCases = [
+        {
+            description: 'should parse valid empty response',
+            response: {
+                ListVersionsResult: {
+                    Name: 'my-bucket',
+                    IsTruncated: false,
+                    MaxKeys: 1000,
+                },
+            },
+            expectedData: {
+                Name: 'my-bucket',
+                IsTruncated: false,
+                MaxKeys: 1000,
+                Versions: [],
+                DeleteMarkers: [],
+                CommonPrefixes: [],
+            },
+        },
+        {
+            description: 'should return error for invalid empty response',
+            response: {},
+            expectedError: new Error('im an original error'),
+        },
+        {
+            description: 'should parse truncated response',
+            response: {
+                ListVersionsResult: {
+                    Name: 'my-bucket',
+                    IsTruncated: true,
+                    MaxKeys: 1000,
+                    NextKeyMarker: 'my-next-key-marker',
+                    NextVersionIdMarker: 'my-next-version-id-marker',
+                    Version: [
+                        {
+                            Key: 'my-key',
+                            VersionId: 'my-version-id',
+                            IsLatest: true,
+                            LastModified: '2021-01-01T00:00:00.000Z',
+                            ETag: 'my-etag',
+                            Size: 123,
+                            StorageClass: 'STANDARD',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    DeleteMarker: [
+                        {
+                            Key: 'my-deleted-key',
+                            VersionId: 'my-deleted-version-id',
+                            IsLatest: true,
+                            LastModified: '2021-01-01T00:00:00.000Z',
+                            ETag: 'my-etag',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    CommonPrefix: [
+                        {
+                            Prefix: 'my-prefix',
+                        },
+                    ],
+                },
+            },
+            expectedData: {
+                Name: 'my-bucket',
+                IsTruncated: true,
+                MaxKeys: 1000,
+                NextKeyMarker: 'my-next-key-marker',
+                NextVersionIdMarker: 'my-next-version-id-marker',
+                Versions: [
+                    {
+                        Key: 'my-key',
+                        VersionId: 'my-version-id',
+                        IsLatest: true,
+                        LastModified: new Date('2021-01-01T00:00:00.000Z'),
+                        ETag: 'my-etag',
+                        Size: 123,
+                        StorageClass: 'STANDARD',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                DeleteMarkers: [
+                    {
+                        Key: 'my-deleted-key',
+                        VersionId: 'my-deleted-version-id',
+                        IsLatest: true,
+                        LastModified: new Date('2021-01-01T00:00:00.000Z'),
+                        ETag: 'my-etag',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                CommonPrefixes: [
+                    {
+                        Prefix: 'my-prefix',
+                    },
+                ],
+            },
+        },
+        {
+            description: 'should recover bad last-modified date',
+            response: {
+                ListVersionsResult: {
+                    Name: 'my-bucket',
+                    IsTruncated: true,
+                    MaxKeys: 1000,
+                    NextKeyMarker: 'my-next-key-marker',
+                    NextVersionIdMarker: 'my-next-version-id-marker',
+                    Version: [
+                        {
+                            Key: 'my-key',
+                            VersionId: 'my-version-id',
+                            IsLatest: true,
+                            LastModified: 'undefined',
+                            ETag: 'my-etag',
+                            Size: 123,
+                            StorageClass: 'STANDARD',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    DeleteMarker: [
+                        // LastModified is missing
+                        {
+                            Key: 'my-deleted-key',
+                            VersionId: 'my-deleted-version-id',
+                            IsLatest: true,
+                            ETag: 'my-etag',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    CommonPrefix: [],
+                },
+
+            },
+            expectedData: {
+                Name: 'my-bucket',
+                IsTruncated: true,
+                MaxKeys: 1000,
+                NextKeyMarker: 'my-next-key-marker',
+                NextVersionIdMarker: 'my-next-version-id-marker',
+                Versions: [
+                    {
+                        Key: 'my-key',
+                        VersionId: 'my-version-id',
+                        IsLatest: true,
+                        LastModified: 'undefined',
+                        ETag: 'my-etag',
+                        Size: 123,
+                        StorageClass: 'STANDARD',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                DeleteMarkers: [
+                    {
+                        Key: 'my-deleted-key',
+                        VersionId: 'my-deleted-version-id',
+                        IsLatest: true,
+                        ETag: 'my-etag',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                CommonPrefixes: [],
+            },
+        },
+        {
+            description: 'should recover bad content-length',
+            response: {
+                ListVersionsResult: {
+                    Name: 'my-bucket',
+                    IsTruncated: true,
+                    MaxKeys: 1000,
+                    NextKeyMarker: 'my-next-key-marker',
+                    NextVersionIdMarker: 'my-next-version-id-marker',
+                    Version: [
+                        {
+                            Key: 'my-key',
+                            VersionId: 'my-version-id',
+                            IsLatest: true,
+                            LastModified: '2021-01-01T00:00:00.000Z',
+                            ETag: 'my-etag',
+                            Size: 'foobar',
+                            StorageClass: 'STANDARD',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    DeleteMarker: [
+                        {
+                            Key: 'my-deleted-key',
+                            VersionId: 'my-deleted-version-id',
+                            IsLatest: true,
+                            LastModified: '2021-01-01T00:00:00.000Z',
+                            ETag: 'my-etag',
+                            Owner: {
+                                ID: 'my-id',
+                                DisplayName: 'my-display-name',
+                            },
+                        },
+                    ],
+                    CommonPrefix: [],
+                },
+            },
+            expectedData: {
+                Name: 'my-bucket',
+                IsTruncated: true,
+                MaxKeys: 1000,
+                NextKeyMarker: 'my-next-key-marker',
+                NextVersionIdMarker: 'my-next-version-id-marker',
+                Versions: [
+                    {
+                        Key: 'my-key',
+                        VersionId: 'my-version-id',
+                        IsLatest: true,
+                        LastModified: new Date('2021-01-01T00:00:00.000Z'),
+                        ETag: 'my-etag',
+                        Size: 'foobar',
+                        StorageClass: 'STANDARD',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                DeleteMarkers: [
+                    {
+                        Key: 'my-deleted-key',
+                        VersionId: 'my-deleted-version-id',
+                        IsLatest: true,
+                        LastModified: new Date('2021-01-01T00:00:00.000Z'),
+                        ETag: 'my-etag',
+                        Owner: {
+                            ID: 'my-id',
+                            DisplayName: 'my-display-name',
+                        },
+                    },
+                ],
+                CommonPrefixes: [],
+            },
+        },
+        {
+            description: 'should pass through original error is response is not recoverable',
+            response: {},
+            expectedError: new Error('im an original error'),
+        },
+    ];
+
+
+    testCases.forEach(testCase => {
+        it(testCase.description, done => {
+            const xmlBuilder = new xml2js.Builder();
+            const body = Buffer.from(xmlBuilder.buildObject(testCase.response));
+            const resp = {
+                httpResponse: {
+                    body,
+                },
+                error: testCase.expectedError || null,
+            };
+
+            recoverListing(resp, (err, data) => {
+                expect(err).toStrictEqual(testCase.expectedError || null);
+                expect(data).toStrictEqual(testCase.expectedData);
+                done();
+            });
+        });
+    });
+
+    it('should pass through original error if the XML fails to parse', done => {
+        const error = new Error('im an original error');
+        const resp = {
+            httpResponse: {
+                body: Buffer.from('im not xml'),
+            },
+            error,
+        };
+
+        recoverListing(resp, (err, data) => {
+            expect(err).toStrictEqual(error);
+            expect(data).toStrictEqual(undefined);
+            done();
+        });
+    });
+});

--- a/utils/safeList.js
+++ b/utils/safeList.js
@@ -1,0 +1,286 @@
+const xml2js = require('xml2js');
+
+const recoverableErrors = new Set([
+    'TimestampParserError',
+]);
+
+const NO_VALUE = Symbol('noValue');
+
+/**
+ * @typedef {Object} ExtractResult
+ * @property {any} value - extracted value
+ * @property {Error|undefined} error - error if any
+ */
+
+/**
+ * @typedef {function} Extractor
+ * @param {string} key - key to extract
+ * @param {object} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+
+/**
+ * extractKeys - extract keys from data using the provided extractors
+ *
+ * @param {object} data - data to extract keys from
+ * @param {object<string, Extractor>} keys - Mapping of keys to extractors
+ * @returns {ExtractResult} - extracted values
+ */
+function extractKeys(data, keys) {
+    const extracted = {};
+    for (const [key, extractor] of Object.entries(keys)) {
+        const { value, error } = extractor(key, data);
+        if (error) {
+            return { error };
+        }
+        if (value !== NO_VALUE) {
+            extracted[key] = value;
+        }
+    }
+    return { value: extracted };
+}
+
+/**
+ * safeExtract - extract a value from data
+ * @param {string} key - key to extract
+ * @param {any} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+function safeExtract(key, data) {
+    if (Array.isArray(data[key]) && data[key].length > 0) {
+        return { value: data[key][0] };
+    }
+    return { value: NO_VALUE };
+}
+
+/**
+ * safeExtractInt - extract a value from data and parse it as an int
+ * If the value cannot be parsed as an int, the raw string value will be returned.
+ *
+ * @param {string} key - key to extract
+ * @param {any} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+function safeExtractInt(key, data) {
+    if (Array.isArray(data[key]) && data[key].length > 0) {
+        const parsed = parseInt(data[key][0], 10);
+        if (!Number.isNaN(parsed)) {
+            return { value: parsed };
+        }
+        return { value: data[key][0] };
+    }
+
+    return { value: NO_VALUE };
+}
+
+/**
+ * safeExtractDate - extract a value from data and parse it as a ISO8601 date
+ * If the value cannot be parsed as a date, the raw string value will be returned.
+ *
+ * @param {string} key - key to extract
+ * @param {any} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+function safeExtractDate(key, data) {
+    if (Array.isArray(data[key]) && data[key].length > 0) {
+        const parsed = new Date(data[key][0]);
+        if (Number.isNaN(parsed.getTime())) {
+            return { value: data[key][0] };
+        }
+        return { value: parsed };
+    }
+    return { value: NO_VALUE };
+}
+
+/**
+ * safeExtractBool - extract a value from data and parse it as a boolean
+ * Any value other than the string 'true' will be parsed as false.
+ *
+ * @param {string} key - key to extract
+ * @param {any} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+function safeExtractBool(key, data) {
+    if (Array.isArray(data[key]) && data[key].length > 0) {
+        return { value: data[key][0] === 'true' };
+    }
+    return { value: NO_VALUE };
+}
+
+/**
+ * safeExtractArray - extract an array of values from the array found at key
+ *
+ * @param {string} key - key containing the array to extract
+ * @param {any} data - data to extract from
+ * @param {object<string, Extractor>} arrKeys - Mapping of keys to extractors
+ * @returns {ExtractResult} - extracted value
+ */
+function safeExtractArray(key, data, arrKeys) {
+    const arr = [];
+    if (Array.isArray(data[key])) {
+        for (const item of data[key]) {
+            const { value, error } = extractKeys(item, arrKeys);
+            if (error) {
+                return { error };
+            }
+            arr.push(value);
+        }
+    }
+    return { value: arr };
+}
+
+const ownerKeys = {
+    ID: safeExtract,
+    DisplayName: safeExtract,
+};
+
+/**
+ * safeExtractOwner - extract an owner object from data
+ * @param {string} key - key to extract
+ * @param {any} data - data to extract from
+ * @returns {ExtractResult} - extracted value
+ */
+function extractOwner(key, data) {
+    if (!Array.isArray(data[key]) || data[key].length === 0) {
+        return { value: NO_VALUE };
+    }
+
+    const { value, error } = extractKeys(data[key][0], ownerKeys);
+    if (error) {
+        return { error };
+    }
+    return { value };
+}
+
+const listingKeys = {
+    Name: safeExtract,
+    Prefix: safeExtract,
+    KeyMarker: safeExtract,
+    VersionIdMarker: safeExtract,
+    NextKeyMarker: safeExtract,
+    NextVersionIdMarker: safeExtract,
+    Delimiter: safeExtract,
+    MaxKeys: safeExtractInt,
+    IsTruncated: safeExtractBool,
+    EncodingType: safeExtract,
+    RequestCharged: safeExtract,
+};
+
+const versionKeys = {
+    Key: safeExtract,
+    VersionId: safeExtract,
+    IsLatest: safeExtractBool,
+    LastModified: safeExtractDate,
+    ETag: safeExtract,
+    Size: safeExtractInt,
+    StorageClass: safeExtract,
+    Owner: extractOwner,
+};
+
+const deleteMarkerKeys = {
+    Key: safeExtract,
+    VersionId: safeExtract,
+    IsLatest: safeExtractBool,
+    LastModified: safeExtractDate,
+    ETag: safeExtract,
+    Owner: extractOwner,
+    StorageClass: safeExtract,
+};
+
+const commonPrefixKeys = {
+    Prefix: safeExtract,
+};
+
+
+/**
+ * recoverListing - parse an xml listing response in a safe manner
+ * @param {object} resp - response from complete event of listObjectVersions
+ * @param {object|undefined} resp.httpResponse - http response from S3 (if any)
+ * @param {Error|undefined} resp.error - error from S3 (if any)
+ * @param {function} cb - callback
+ * @returns {undefined}
+ */
+function recoverListing(resp, cb) {
+    const parser = new xml2js.Parser();
+    parser.parseString(resp.httpResponse.body, (err, data) => {
+        if (err) {
+            // if there is an error parsing the xml, return the original error
+            return cb(resp.error);
+        }
+
+        if (!data.ListVersionsResult) {
+            // if no listing data is present, return the original error
+            return cb(resp.error);
+        }
+
+        const { value, error } = extractKeys(data.ListVersionsResult, listingKeys);
+        if (error) {
+            return cb(error);
+        }
+
+        const { value: versions, error: verErr } = safeExtractArray(
+            'Version',
+            data.ListVersionsResult,
+            versionKeys,
+        );
+        if (verErr) {
+            return cb(verErr);
+        }
+
+        const { value: deleteMarkers, error: delErr } = safeExtractArray(
+            'DeleteMarker',
+            data.ListVersionsResult,
+            deleteMarkerKeys,
+        );
+        if (delErr) {
+            return cb(delErr);
+        }
+
+        const { value: commonPrefixes, error: comErr } = safeExtractArray(
+            'CommonPrefix',
+            data.ListVersionsResult,
+            commonPrefixKeys,
+        );
+        if (comErr) {
+            return cb(comErr);
+        }
+
+        value.Versions = versions;
+        value.DeleteMarkers = deleteMarkers;
+        value.CommonPrefixes = commonPrefixes;
+        return cb(null, value);
+    });
+}
+
+/**
+ *  safeListObjectVersions - listObjectVersions with error recovery
+ *
+ * This function is a wrapper around listObjectVersions that will attempt to
+ * recover from certain format errors by parsing the XML response and returning the
+ * data in the same format as listObjectVersions.
+ *
+ * Values that fail to parse will be returned as the raw string value present in the xml.
+ *
+ * @param {AWS.S3} s3 - S3 client instance
+ * @param {object} params - listObjectVersions params
+ * @param {function} cb - callback
+ * @returns {undefined}
+ */
+function safeListObjectVersions(s3, params, cb) {
+    const req = s3.listObjectVersions(params);
+    req.on('complete', resp => {
+        if (resp.error) {
+            if (recoverableErrors.has(resp.error.code)) {
+                return recoverListing(resp, cb);
+            }
+            return cb(resp.error);
+        }
+        return cb(null, resp.data);
+    });
+    req.send();
+}
+
+module.exports = {
+    safeListObjectVersions,
+    recoverListing,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8708,6 +8708,14 @@ xml2js@^0.4.19, xml2js@~0.4.23:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xml2js@~0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.8.tgz#9b81690931631ff09d1957549faf54f4f980b3c2"


### PR DESCRIPTION
Adds a util function that will attempt to reparse a listing response to recover from specific errors.
If a value fails to parse (only timestamps and ints presently) then the original string value is returned.

