### PR TITLE
remove UpdateBucketCapacityJobTakingTooLong alert

### DIFF
--- a/monitoring/update-bucket-capacity-info-cronjob/alerts.test.yaml
+++ b/monitoring/update-bucket-capacity-info-cronjob/alerts.test.yaml
@@ -3,33 +3,6 @@ rule_files:
   - alerts.rendered.yaml
 
 tests:
-  - name: Update Bucket Capacity Info CronJob Test Taking Too Long
-    interval: 1m
-    input_series:
-      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-1", namespace="zenko"}'
-        values: '0x9'
-      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-1", namespace="zenko"}'
-        values: '_x4 240x5'
-      - series: 'kube_job_status_start_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-2", namespace="zenko"}'
-        values: '_x4 240x5'
-      - series: 'kube_job_status_completion_time{job="kube-state-metrics", job_name="artesca-data-ops-update-bucket-capacity-info-2", namespace="zenko"}'
-        values: '_x9 '
-    alert_rule_test:
-      - alertname: UpdateBucketCapacityJobTakingTooLong
-        eval_time: 4m
-        exp_alerts: []
-      - alertname: UpdateBucketCapacityJobTakingTooLong
-        eval_time: 9m
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              job_name: artesca-data-ops-update-bucket-capacity-info-1
-            exp_annotations:
-              description: |
-                Job artesca-data-ops-update-bucket-capacity-info is taking more than 240s to complete.
-                This may cause bucket capacity to be out of date and Veeam SOSAPI avalability as risk.
-              summary: update-bucket-capacity-info cronjob takes too long to finish
-
   - name: Update Bucket Capacity Info CronJob Test No Success in 10m
     interval: 1m
     input_series:

--- a/monitoring/update-bucket-capacity-info-cronjob/alerts.yaml
+++ b/monitoring/update-bucket-capacity-info-cronjob/alerts.yaml
@@ -16,21 +16,6 @@ x-inputs:
 groups:
   - name: update-bucket-capacity-info-cronjob/alerts.rules
     rules:
-      - alert: UpdateBucketCapacityJobTakingTooLong
-        expr: |
-          time() -
-          (sum by(job_name) (kube_job_status_failed{job_name=~"${update_bucket_capacity_info_cronjob}.*"})
-          > sum by(job_name) (kube_job_status_completion_time{job_name=~"${update_bucket_capacity_info_cronjob}.*"})
-          or sum by(job_name) (kube_job_status_completion_time{job_name=~"${update_bucket_capacity_info_cronjob}.*"}))
-          > ${update_bucket_capacity_info_job_duration_threshold}
-        labels:
-          severity: warning
-        annotations:
-          description: |
-            Job ${update_bucket_capacity_info_cronjob} is taking more than ${update_bucket_capacity_info_job_duration_threshold}s to complete.
-            This may cause bucket capacity to be out of date and Veeam SOSAPI avalability as risk.
-          summary: update-bucket-capacity-info cronjob takes too long to finish
-
       - alert: NoSuccessfulUpdateBucketCapacityJobRunIn10m
         expr: |
           time() 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.13.24",
+  "version": "1.13.25",
   "engines": {
     "node": ">= 16"
   },

--- a/tests/unit/CompareRaftMembers/BucketStream.js
+++ b/tests/unit/CompareRaftMembers/BucketStream.js
@@ -4,7 +4,6 @@ const { versioning } = require('arsenal');
 
 const BucketStream = require('../../../CompareRaftMembers/BucketStream');
 
-const HTTP_TEST_PORT = 9090;
 const TEST_BUCKET_FILTERED_CONTENTS_LENGTH = 3210;
 const DUMMY_VERSION_ID = '987654321 FOOBAR42.42';
 const VERSIONED_RANGE = [1210, 1310];
@@ -183,7 +182,7 @@ describe('BucketStream', () => {
             }
             throw new Error(`unexpected request path ${url.pathname}`);
         });
-        httpServer.listen(HTTP_TEST_PORT);
+        httpServer.listen(0);
     });
     afterAll(done => {
         httpServer.close(done);
@@ -230,7 +229,7 @@ describe('BucketStream', () => {
         test(testCase.desc, done => {
             const bucketStream = new BucketStream({
                 bucketdHost: 'localhost',
-                bucketdPort: HTTP_TEST_PORT,
+                bucketdPort: httpServer.address().port,
                 bucketName: 'test-bucket',
                 marker: testCase.marker,
                 lastKey: testCase.lastKey,
@@ -274,7 +273,7 @@ describe('BucketStream', () => {
     test('listing should continue when all keys in a page are ignored', done => {
         const bucketStream = new BucketStream({
             bucketdHost: 'localhost',
-            bucketdPort: HTTP_TEST_PORT,
+            bucketdPort: httpServer.address().port,
             bucketName: 'bucket-with-replay-keys',
             retryDelayMs: 50,
             maxRetryDelayMs: 1000,

--- a/tests/unit/CompareRaftMembers/DiffStreamOplogFilter.js
+++ b/tests/unit/CompareRaftMembers/DiffStreamOplogFilter.js
@@ -5,8 +5,6 @@ const { shuffle } = require('arsenal');
 
 const DiffStreamOplogFilter = require('../../../CompareRaftMembers/DiffStreamOplogFilter');
 
-const HTTP_TEST_PORT = 9090;
-
 class MockRaftOplogStream extends stream.Readable {
     constructor(entriesToEmit, refreshPeriodMs) {
         super({ objectMode: true });
@@ -71,7 +69,7 @@ describe('DiffStreamOplogFilter', () => {
             }
             throw new Error(`unexpected request path ${url.pathname}`);
         });
-        httpServer.listen(HTTP_TEST_PORT);
+        httpServer.listen(0);
         httpServer.once('listening', done);
     });
     afterAll(done => {
@@ -81,7 +79,7 @@ describe('DiffStreamOplogFilter', () => {
     test('filtering test with mocks', done => {
         const oplogFilter = new DiffStreamOplogFilter({
             bucketdHost: 'localhost',
-            bucketdPort: HTTP_TEST_PORT,
+            bucketdPort: httpServer.address().port,
             maxBufferedEntries: 5,
             excludeFromCseqs: {
                 1: 10,
@@ -204,7 +202,7 @@ describe('DiffStreamOplogFilter', () => {
     test('should handle an empty input stream', done => {
         const oplogFilter = new DiffStreamOplogFilter({
             bucketdHost: 'localhost',
-            bucketdPort: HTTP_TEST_PORT,
+            bucketdPort: httpServer.address().port,
             maxBufferedEntries: 5,
             excludeFromCseqs: {},
         });
@@ -224,7 +222,7 @@ describe('DiffStreamOplogFilter', () => {
     test('should emit a stream error if failing to fetch RSID after retries', done => {
         const oplogFilter = new DiffStreamOplogFilter({
             bucketdHost: 'localhost',
-            bucketdPort: HTTP_TEST_PORT,
+            bucketdPort: httpServer.address().port,
             maxBufferedEntries: 5,
             excludeFromCseqs: {
                 1: 10,

--- a/tests/unit/CompareRaftMembers/RaftOplogStream.js
+++ b/tests/unit/CompareRaftMembers/RaftOplogStream.js
@@ -2,7 +2,6 @@ const http = require('http');
 
 const RaftOplogStream = require('../../../CompareRaftMembers/RaftOplogStream');
 
-const HTTP_TEST_PORT = 9090;
 const TEST_OPLOG_NB_RECORDS = 123;
 const DUMMY_VERSION_ID = '987654321 FOOBAR42.42';
 
@@ -82,7 +81,7 @@ describe('RaftOplogStream', () => {
             }
             throw new Error(`unexpected request path ${url.pathname}`);
         });
-        httpServer.listen(HTTP_TEST_PORT);
+        httpServer.listen(0);
         httpServer.on('listening', done);
     });
     afterAll(done => {
@@ -108,7 +107,7 @@ describe('RaftOplogStream', () => {
         test(testCase.desc, done => {
             const oplogStream = new RaftOplogStream({
                 bucketdHost: 'localhost',
-                bucketdPort: HTTP_TEST_PORT,
+                bucketdPort: httpServer.address().port,
                 raftSessionId: 1,
                 startSeq: testCase.startSeq,
                 refreshPeriodMs: 100,
@@ -163,7 +162,7 @@ describe('RaftOplogStream', () => {
         const oplogStream = new RaftOplogStream({
             bucketdHost: 'localhost',
             // change port to get connection errors
-            bucketdPort: HTTP_TEST_PORT + 1,
+            bucketdPort: httpServer.address().port + 1,
             raftSessionId: 1,
             startSeq: 42,
             retryDelayMs: 10,


### PR DESCRIPTION
UpdateBucketCapacityJobTakingTooLong creates noise and is not useful as what we truly want to monitor is having multiple jobs failing in series.

NoSuccessfulUpdateBucketCapacityJobRunIn10m already tests that as jobs are only run one at a time and at a 4 minute interval.

Issue: S3UTILS-150