### PR TITLE
impr(S3UTILS-147/S3UTILS-151):

### DIFF
--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -386,15 +386,17 @@ function fetchAndCheckObject(bucket, itemKey, cb) {
 }
 function hasMinimalMetadata(md) {
     if (!md) {
-        return false
+        return false;
     }
-    return md.hasOwnProperty('md-model-version')
-        && md.hasOwnProperty('owner-display-name')
-        && md.hasOwnProperty('owner-id')
-        && md.hasOwnProperty('content-length')
-        && md.hasOwnProperty('content-type') 
-        && md.hasOwnProperty('last-modified')
-        && md.hasOwnProperty('content-md5')
+    return (
+      md.hasOwnProperty("md-model-version") &&
+      md.hasOwnProperty("owner-display-name") &&
+      md.hasOwnProperty("owner-id") &&
+      md.hasOwnProperty("content-length") &&
+      md.hasOwnProperty("content-type") &&
+      md.hasOwnProperty("last-modified") &&
+      md.hasOwnProperty("content-md5")
+    );
 }
 function listBucketIter(bucket, cb) {
     const url = getBucketdURL(BUCKETD_HOSTPORT, {

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -428,7 +428,7 @@ function listBucketIter(bucket, cb) {
                 status.objectsErrors += 1;
                 return itemDone();
             }
-            if (md.isNull && !md.location && !md["md-model-version"] ) {
+            if (md.isNull && !md.location && !md['md-model-version'] ) {
                 log.error('Null Metadata JSON', {
                     object: objectUrl,
                     mdValue: item.value,

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -415,27 +415,26 @@ function listBucketIter(bucket, cb) {
             const vidSepPos = item.key.lastIndexOf('\0');
             const objectUrl = getObjectURL(bucket, item.key);
             let digestKey = item.key;
-
             let md;
             try {
                 md = JSON.parse(item.value);
-              } catch (e) {
+            } catch (e) {
                 log.error('Invalid Metadata JSON', {
                     object: objectUrl,
                     error: e.message,
                     mdValue: item.value,
                 });
                 status.objectsScanned += 1;
-                status.objectsErrors +=1;
+                status.objectsErrors += 1;
                 return itemDone();
-              }
+            }
             if (md.isNull) {
                 log.error('Null Metadata JSON', {
                     object: objectUrl,
                     mdValue: item.value,
                 });
                 status.objectsScanned += 1;
-                status.objectsErrors +=1;
+                status.objectsErrors += 1;
                 return itemDone();
             }
             if (vidSepPos === -1) {

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -428,7 +428,7 @@ function listBucketIter(bucket, cb) {
                 status.objectsErrors += 1;
                 return itemDone();
             }
-            if (md.isNull) {
+            if (md.isNull && !md.location && !md["md-model-version"] ) {
                 log.error('Null Metadata JSON', {
                     object: objectUrl,
                     mdValue: item.value,

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -389,9 +389,9 @@ function hasMinimalMetadata(md) {
         return false;
     }
     return (
-        md.hasOwnProperty('md-model-version') 
-        && md.hasOwnProperty('owner-display-name') 
-        && md.hasOwnProperty('owner-id') 
+        md.hasOwnProperty('md-model-version')
+        && md.hasOwnProperty('owner-display-name')
+        && md.hasOwnProperty('owner-id')
         && md.hasOwnProperty('content-length')
         && md.hasOwnProperty('content-type')
         && md.hasOwnProperty('last-modified')

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -428,7 +428,7 @@ function listBucketIter(bucket, cb) {
                 status.objectsErrors += 1;
                 return itemDone();
             }
-            if (md.isNull && !md.location && !md['md-model-version'] ) {
+            if (md.isNull && !md.location && !md['md-model-version']) {
                 log.error('Null Metadata JSON', {
                     object: objectUrl,
                     mdValue: item.value,

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -389,13 +389,13 @@ function hasMinimalMetadata(md) {
         return false;
     }
     return (
-      md.hasOwnProperty("md-model-version") &&
-      md.hasOwnProperty("owner-display-name") &&
-      md.hasOwnProperty("owner-id") &&
-      md.hasOwnProperty("content-length") &&
-      md.hasOwnProperty("content-type") &&
-      md.hasOwnProperty("last-modified") &&
-      md.hasOwnProperty("content-md5")
+        md.hasOwnProperty('md-model-version') 
+        && md.hasOwnProperty('owner-display-name') 
+        && md.hasOwnProperty('owner-id') 
+        && md.hasOwnProperty('content-length')
+        && md.hasOwnProperty('content-type')
+        && md.hasOwnProperty('last-modified')
+        && md.hasOwnProperty('content-md5')
     );
 }
 function listBucketIter(bucket, cb) {


### PR DESCRIPTION
we found corner cases where the MD answer was:
- not a correct - invalid -  JSON object
- not empty but Null

this should fix these two corner cases, so the scan of the SproxyD keys is not interrupted with an exception but it logs a specific error 