### PR TITLE
S3UTILS-162: bump project version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.14.7",
+  "version": "1.15.0",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
This PR aims just to bump the project version to the right one : 1.15.0 instead of 1.14.7 that has been merged in this PR : https://github.com/scality/s3utils/pull/312

