### PR TITLE
Feature/s3 utils 161/monitoring dahsboards implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           oras push ghcr.io/${{ github.repository }}/${{ env.PROJECT_NAME }}-dashboards:${{ inputs.tag }} \
             count-items-cronjob/alerts.yaml:application/prometheus-alerts+yaml \
-            update-bucket-capacity-info-cronjob/alerts.yaml:application/prometheus-alerts+yaml
+            update-bucket-capacity-info-cronjob/alerts.yaml:application/prometheus-alerts+yaml \
+            count-items-cronjob/dashboard.json:application/prometheus-dashboard+json 
         working-directory: monitoring
 
       - name: Build and push

--- a/monitoring/count-items-cronjob/dashboard.json
+++ b/monitoring/count-items-cronjob/dashboard.json
@@ -1,0 +1,379 @@
+{
+  "__inputs": [
+    {
+      "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus",
+      "type": "datasource"
+    },
+    {
+      "description": "",
+      "label": "Loki",
+      "name": "DS_LOKI",
+      "pluginId": "loki",
+      "pluginName": "Loki",
+      "type": "datasource"
+    },
+    {
+      "description": "Namespace associated with the Zenko instance",
+      "label": "namespace",
+      "name": "namespace",
+      "type": "constant",
+      "value": "zenko"
+    },
+    {
+      "description": "Name of the S3utils job, used to filter the metrics.",
+      "label": "job",
+      "name": "job",
+      "type": "constant",
+      "value": "artesca-data-ops-count-items-metrics"
+    },
+    {
+      "description": "Prefix of the cronjob pod name, used to filter only the cronjob instances.",
+      "label": "pod",
+      "name": "pod",
+      "type": "constant",
+      "value": "artesca-data-ops-count-items"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 1,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
+      "title": "Count items metrics",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 180000,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": ""
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "hideTimeOverride": false,
+      "id": 2,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "rate(s3_countitems_total_objects_count{namespace=\"${namespace}\", job=~\"${job}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{status}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Rate of the S3 objects processed",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 3,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum by(le) (increase(s3_countitems_bucket_merge_duration_seconds_bucket{namespace=\"${namespace}\", job=\"${job}\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Consolidation duration",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 180000,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": ""
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "hideTimeOverride": false,
+      "id": 4,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "rate(s3_countitems_total_buckets_count{namespace=\"${namespace}\", job=~\"${job}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{status}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Rate of the S3 buckets processed",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "rows": [],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [
+    "S3Utils"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "S3Utils service",
+  "uid": null,
+  "version": 0
+}

--- a/monitoring/count-items-cronjob/dashboard.py
+++ b/monitoring/count-items-cronjob/dashboard.py
@@ -1,0 +1,119 @@
+from grafanalib.core import (
+    ConstantInput,
+    DataSourceInput,
+    Heatmap,
+    HeatmapColor,
+    HIDE_VARIABLE,
+    RowPanel,
+    Stat,
+    Template,
+    Templating,
+    Threshold,
+    YAxis,
+)
+from grafanalib import formatunits as UNITS
+from scalgrafanalib import (
+    layout,
+    BarGauge,
+    Dashboard,
+    GaugePanel,
+    PieChart,
+    Tooltip,
+    Target,
+    TimeSeries
+)
+
+objectProcessingSpeed = TimeSeries(
+    title="Rate of the S3 objects processed",
+    dataSource="${DS_PROMETHEUS}",
+    lineInterpolation="smooth",
+    spanNulls=3*60*1000,
+    unit="",
+    targets=[
+        Target(
+            expr='rate(s3_countitems_total_objects_count{namespace="${namespace}", job=~"${job}"}[$__rate_interval])',
+            legendFormat="{{status}}",
+        ),
+    ],
+)
+
+bucketProcessingSpeed = TimeSeries(
+    title="Rate of the S3 buckets processed",
+    dataSource="${DS_PROMETHEUS}",
+    lineInterpolation="smooth",
+    spanNulls=3*60*1000,
+    unit="",
+    targets=[
+        Target(
+            expr='rate(s3_countitems_total_buckets_count{namespace="${namespace}", job=~"${job}"}[$__rate_interval])',
+            legendFormat="{{status}}",
+        ),
+    ],
+)
+
+consolidationDuration = Heatmap(
+    title="Consolidation duration",
+    dataSource="${DS_PROMETHEUS}",
+    dataFormat="tsbuckets",
+    maxDataPoints=25,
+    tooltip=Tooltip(show=True, showHistogram=True),
+    yAxis=YAxis(format=UNITS.SECONDS),
+    color=HeatmapColor(mode="opacity"),
+    targets=[Target(
+        expr='sum by(le) (increase(s3_countitems_bucket_merge_duration_seconds_bucket{namespace="${namespace}", job="${job}"}[$__rate_interval]))',
+        format="heatmap",
+        legendFormat="{{le}}",
+    )],
+)
+
+dashboard = (
+    Dashboard(
+        title="S3Utils service",
+        editable=True,
+        refresh="30s",
+        tags=["S3Utils"],
+        timezone="",
+        inputs=[
+            DataSourceInput(
+                name="DS_PROMETHEUS",
+                label="Prometheus",
+                pluginId="prometheus",
+                pluginName="Prometheus",
+            ),
+            DataSourceInput(
+                name="DS_LOKI",
+                label="Loki",
+                pluginId="loki",
+                pluginName="Loki"
+            ),
+            ConstantInput(
+                name="namespace",
+                label="namespace",
+                description="Namespace associated with the Zenko instance",
+                value="zenko",
+            ),
+            ConstantInput(
+                name="job",
+                label="job",
+                description="Name of the S3utils job, used to filter the "
+                            "metrics.",
+                value="artesca-data-ops-count-items-metrics",
+            ),
+            ConstantInput(
+                name="pod",
+                label="pod",
+                description="Prefix of the cronjob pod name, used to filter "
+                            "only the cronjob instances.",
+                value="artesca-data-ops-count-items",
+            ),
+        ],
+        panels=layout.column([
+            RowPanel(title="Count items metrics"),
+            layout.row([objectProcessingSpeed, consolidationDuration, bucketProcessingSpeed], height=8),
+        ]),
+    )
+    .auto_panel_ids()
+    .verify_datasources()
+)
+
+


### PR DESCRIPTION
![image](https://github.com/scality/s3utils/assets/144012792/60a41ef7-11c7-466c-9d2e-349cc2b2f54d)
This PR aims to introduced count-items specific dashboards : 
- Rate of the s3 objects processed => shows the speed of objects processing 
- Rate of the s3 buckets processed => shows the speed of buckets processing 
- Data consolidation => heatmap showing the duration of the data consolidation 

Linked issue : https://scality.atlassian.net/browse/S3UTILS-161