### PR TITLE
Bugfix/s3 utils 164/count items termination error

### DIFF
--- a/CountItems/masterProcess.js
+++ b/CountItems/masterProcess.js
@@ -55,7 +55,7 @@ const countMaster = new CountMaster({
 const metricServer = new WebServer(8003, log).onRequest((req, res) => monitoring.metricsHandler(
     () => {
         if (waitingForPromScraping === true) {
-            countMaster.stop(null, () => process.exit(1));
+            countMaster.stop(null, () => process.exit(0));
         }
     },
     req,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.14.9",
+  "version": "1.14.10",
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
This PR fixes the exit with error when the scrapping occurs before the timeout 
Linked issue : https://scality.atlassian.net/browse/S3UTILS-164