### PR TITLE
Fix CrrExistingObjects skipping versions when listing

### DIFF
--- a/CrrExistingObjects/metadataUtils.js
+++ b/CrrExistingObjects/metadataUtils.js
@@ -11,10 +11,6 @@ const nonVersionedObjId = versionIdUtils.getInfVid(REPLICATION_GROUP_ID);
 
 function _processVersions(list) {
     /* eslint-disable no-param-reassign */
-    list.NextVersionIdMarker = list.NextVersionIdMarker
-        ? versionIdUtils.encode(list.NextVersionIdMarker)
-        : list.NextVersionIdMarker;
-
     list.Versions.forEach(v => {
         v.VersionId = v.VersionId
             ? versionIdUtils.encode(v.VersionId) : v.VersionId;


### PR DESCRIPTION
The listing function from metadata expects `versionIdMarker` to equal the non encoded versionId of the next version to list. However, currently we give it the encoded versionId, which causes the listing algo to skip some versions, as the versionId is used to skip all previous versions until `versionIdMarker` is reached ([see here](https://github.com/scality/Arsenal/blob/5a6069f7fdf75ca571e51ae75b4d1b28512515cd/lib/algos/list/delimiterVersions.ts#L441-L444)). Using the encoded versionId in the check results in unpredictable behaviour that can skip multiple versions from the listing.

Issue: S3UTILS-185