### PR TITLE
ObjectRepair: fix exception with HTTP error responses

### DIFF
--- a/ObjectRepair/DuplicateKeysIngestion.js
+++ b/ObjectRepair/DuplicateKeysIngestion.js
@@ -1,5 +1,6 @@
 const { waterfall } = require('async');
 const { Logger } = require('werelogs');
+const { errors } = require('arsenal');
 const { httpRequest } = require('../repairDuplicateVersionsSuite');
 const { SproxydKeysProcessor } = require('./DuplicateKeysWindow');
 const { ProxyLoggerCreator, AggregateLogger } = require('./Logging');
@@ -73,10 +74,26 @@ class RaftJournalReader {
                 log.error('unable to fetch cseq', { err, requestUrl });
                 return cb(err);
             }
+            if (res.statusCode === 416) {
+                // RAFT session is empty: start at 1
+                this.cseq = 1;
+            } else {
+                if (res.statusCode !== 200) {
+                    log.error(
+                        'unable to fetch cseq: error HTTP status code returned',
+                        { statusCode: res.statusCode },
+                    );
+                    return cb(errors.InternalError);
+                }
 
-            const body = JSON.parse(res.body);
-
-            this._setCseq(body);
+                try {
+                    const body = JSON.parse(res.body);
+                    this._setCseq(body);
+                } catch (err) {
+                    log.error('unable to fetch cseq: invalid JSON in response body');
+                    return cb(errors.InternalError);
+                }
+            }
 
             // make sure begin is at least 1 since Raft Journal logs are 1-indexed
             this.begin = Math.max(1, this.cseq - this.lookBack);
@@ -134,7 +151,12 @@ class RaftJournalReader {
                 return cb(new Error(`GET ${requestUrl} returned empty body at ${this.begin}`));
             }
 
-            const body = JSON.parse(res.body);
+            let body;
+            try {
+                body = JSON.parse(res.body);
+            } catch (err) {
+                return cb(new Error(`GET ${requestUrl}: invalid JSON in response body`));
+            }
             // FIXME this special case should be taken care of once S3C-3928 is fixed
             if (body.log.length === 0) {
                 return cb(new RangeError(`GET ${requestUrl} found no new records at ${this.begin}`));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "engines": {
     "node": ">= 16"
   },

--- a/tests/unit/SproxydKeysScan/DuplicateKeysIngestionTest.js
+++ b/tests/unit/SproxydKeysScan/DuplicateKeysIngestionTest.js
@@ -39,35 +39,36 @@ describe('RaftJournalReader', () => {
     describe('::setBegin', () => {
         const reader = setupJournalReader();
 
-        beforeEach(() => {
-            reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
-        });
-
         afterEach(() => {
             reader._httpRequest.mockReset();
         });
 
-        test('when begin is undefined, begin = latest cseq - lookBack', () => {
+        test('when begin is undefined, begin = latest cseq - lookBack', done => {
+            reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
             reader.begin = undefined;
             reader.lookBack = 5;
 
             reader.setBegin(err => {
                 expect(err).toBe(undefined);
                 expect(reader.begin).toEqual(reader.cseq - reader.lookBack);
+                done();
             });
         });
 
-        test('begin is at minimum 1, even with lookback > latest cseq', () => {
+        test('begin is at minimum 1, even with lookback > latest cseq', done => {
+            reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
             reader.begin = undefined;
             reader.lookBack = Infinity;
 
             reader.setBegin(err => {
                 expect(err).toBe(undefined);
                 expect(reader.begin).toEqual(1);
+                done();
             });
         });
 
-        test('if begin is set from a previous call, use the existing begin and ignore lookBack', () => {
+        test('if begin is set from a previous call, use the existing begin and ignore lookBack', done => {
+            reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
             reader.begin = 3;
             reader.lookBack = Infinity;
 
@@ -75,6 +76,7 @@ describe('RaftJournalReader', () => {
                 expect(err).toBe(undefined);
                 expect(reader._httpRequest).not.toHaveBeenCalled();
                 expect(reader.begin).toEqual(3);
+                done();
             });
         });
     });
@@ -96,7 +98,7 @@ describe('RaftJournalReader', () => {
             expect(body).toBe(undefined);
         };
 
-        test('should correctly read mocked data', () => {
+        test('should correctly read mocked data', done => {
             reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
             reader.getBatch((err, body) => {
                 expect(reader._httpRequest).toHaveBeenCalled();
@@ -109,35 +111,40 @@ describe('RaftJournalReader', () => {
                 expect(err).toBe(null);
                 expect(body).not.toBe(null);
                 expect(body.log).not.toBe(null);
+                done();
             });
         });
 
-        test('should return error with a non-200 status code', () => {
+        test('should return error with a non-200 status code', done => {
             reader._httpRequest = mockHttpRequest(null, getMockResponse(500));
             reader.getBatch((err, body) => {
                 returnedError(err, body);
+                done();
             });
         });
 
-        test('should return error with a missing body', () => {
+        test('should return error with a missing body', done => {
             reader._httpRequest = mockHttpRequest(null, { statusCode: 200 });
             reader.getBatch((err, body) => {
                 returnedError(err, body);
+                done();
             });
         });
 
-        test('should return error with null response', () => {
+        test('should return error with null response', done => {
             reader._httpRequest = mockHttpRequest(null, null);
             reader.getBatch((err, body) => {
                 returnedError(err, body);
+                done();
             });
         });
 
         // FIXME this special case should be taken care of once S3C-3928 is fixed
-        test('should return error with response containing empty log', () => {
+        test('should return error with response containing empty log', done => {
             reader._httpRequest = mockHttpRequest(null, getEmptyRsMockResponse());
             reader.getBatch((err, body) => {
                 returnedError(err, body);
+                done();
             });
         });
     });
@@ -211,7 +218,7 @@ describe('RaftJournalReader', () => {
         reader._httpRequest = mockHttpRequest(null, getMockResponse(200));
         afterEach(() => reader._httpRequest.mockReset());
 
-        test('inserts correct sproxyd key data into SproxydKeyProcessor', () => {
+        test('inserts correct sproxyd key data into SproxydKeyProcessor', done => {
             expect(reader.begin).toEqual(1);
             reader.runOnce((err, timeout) => {
                 expect(err).toBe(null);
@@ -219,6 +226,7 @@ describe('RaftJournalReader', () => {
                 expect(reader._httpRequest).toHaveBeenCalled();
                 expect(reader.processor.insert).toHaveBeenCalled();
                 expect(reader.begin).toBeGreaterThan(1);
+                done();
             });
         });
 
@@ -229,19 +237,21 @@ describe('RaftJournalReader', () => {
             expect(reader.processor.insert).not.toHaveBeenCalled();
         };
 
-        test('should set a timeout of 5000 milliseconds when there is any error during ingestion', () => {
+        test('should set a timeout of 5000 milliseconds when there is any error during ingestion', done => {
             reader._httpRequest = mockHttpRequest(null, getMockResponse(500));
             reader.processor.insert.mockReset();
             reader.runOnce((err, timeout) => {
                 waitsFiveSeconds(err, timeout);
+                done();
             });
         });
 
-        test('should set a timeout of 5000 milliseconds when there is no new data from raft journal', () => {
+        test('should set a timeout of 5000 milliseconds when there is no new data from raft journal', done => {
             reader._httpRequest = mockHttpRequest(null, null);
             reader.processor.insert.mockReset();
             reader.runOnce((err, timeout) => {
                 waitsFiveSeconds(err, timeout);
+                done();
             });
         });
     });

--- a/tests/unit/SproxydKeysScan/DuplicateKeysIngestionTest.js
+++ b/tests/unit/SproxydKeysScan/DuplicateKeysIngestionTest.js
@@ -1,13 +1,18 @@
 const fs = require('fs');
+const { errors } = require('arsenal');
 const { RaftJournalReader } = require('../../../ObjectRepair/DuplicateKeysIngestion');
 const { subscribers } = require('../../../ObjectRepair/SproxydKeysSubscribers');
 
 function getMockResponse(mockStatusCode) {
-    const mockBody = fs.readFileSync(`${__dirname}/RaftJournalTestData.json`, 'utf8');
     const mockResponse = {
-        body: mockBody,
         statusCode: mockStatusCode,
     };
+    if (Math.floor(mockStatusCode / 100) === 2) {
+        const mockBody = fs.readFileSync(`${__dirname}/RaftJournalTestData.json`, 'utf8');
+        mockResponse.body = mockBody;
+    } else {
+        mockResponse.body = '';
+    }
     return mockResponse;
 }
 
@@ -79,6 +84,50 @@ describe('RaftJournalReader', () => {
                 done();
             });
         });
+
+        test('when begin is undefined and route returns an unexpected error', done => {
+            reader._httpRequest = mockHttpRequest(new Error('OOPS'), undefined);
+            reader.begin = undefined;
+
+            reader.setBegin(err => {
+                expect(err).toEqual(new Error('OOPS'));
+                done();
+            });
+        });
+
+        test('when begin is undefined and route returns a 416 HTTP status with empty response body', done => {
+            reader._httpRequest = mockHttpRequest(null, getMockResponse(416));
+            reader.begin = undefined;
+
+            reader.setBegin(err => {
+                expect(err).toBe(undefined);
+                expect(reader.begin).toEqual(1);
+                done();
+            });
+        });
+
+        test('when begin is undefined and route returns a 500 HTTP status with empty response body', done => {
+            reader._httpRequest = mockHttpRequest(null, getMockResponse(500));
+            reader.begin = undefined;
+
+            reader.setBegin(err => {
+                expect(err).toEqual(errors.InternalError);
+                done();
+            });
+        });
+
+        test('when begin is undefined and route returns a 200 OK HTTP status with invalid JSON in response body', done => {
+            reader._httpRequest = mockHttpRequest(null, {
+                statusCode: 200,
+                body: '{BADJSON}',
+            });
+            reader.begin = undefined;
+
+            reader.setBegin(err => {
+                expect(err).toEqual(errors.InternalError);
+                done();
+            });
+        });
     });
     describe('::getBatch', () => {
         const reader = setupJournalReader(getMockResponse(200));
@@ -142,6 +191,17 @@ describe('RaftJournalReader', () => {
         // FIXME this special case should be taken care of once S3C-3928 is fixed
         test('should return error with response containing empty log', done => {
             reader._httpRequest = mockHttpRequest(null, getEmptyRsMockResponse());
+            reader.getBatch((err, body) => {
+                returnedError(err, body);
+                done();
+            });
+        });
+
+        test('should return error with response containing invalid JSON', done => {
+            reader._httpRequest = mockHttpRequest(null, {
+                statusCode: 200,
+                body: '{BADJSON}',
+            });
             reader.getBatch((err, body) => {
                 returnedError(err, body);
                 done();


### PR DESCRIPTION
Fix exceptions `SyntaxError: Unexpected end of JSON input` in ObjectRepair when trying to fetch the RAFT oplog returns an HTTP error status with an empty body. Also do not crash if the returned JSON is invalid, although this is unlikely to happen.

issue: S3UTILS-192
