### PR TITLE
crrExistingObjects: support only triggering current versions

### DIFF
--- a/CRR/ReplicationStatusUpdater.js
+++ b/CRR/ReplicationStatusUpdater.js
@@ -1,7 +1,6 @@
 const {
     doWhilst, eachSeries, eachLimit, waterfall, series,
 } = require('async');
-const werelogs = require('werelogs');
 const { ObjectMD } = require('arsenal').models;
 
 const { setupClients } = require('./clients');
@@ -44,6 +43,7 @@ class ReplicationStatusUpdater {
             maxScanned,
             keyMarker,
             versionIdMarker,
+            currentVersionOnly,
         } = params;
 
         // inputs
@@ -61,6 +61,7 @@ class ReplicationStatusUpdater {
         this.maxScanned = maxScanned;
         this.inputKeyMarker = keyMarker;
         this.inputVersionIdMarker = versionIdMarker;
+        this.currentVersionOnly = currentVersionOnly;
         this.log = log;
 
         this._setupClients();
@@ -305,7 +306,12 @@ class ReplicationStatusUpdater {
                     this.log.warn(`missing SITE_NAME environment variable, triggering replication to the ${storageClass} storage class`);
                 }
                 return eachLimit(versions, this.workers, (i, apply) => {
-                    const { Key, VersionId } = i;
+                    const { Key, VersionId, IsLatest } = i;
+                    if (this.currentVersionOnly && !IsLatest) {
+                        ++this._nSkipped;
+                        apply();
+                        return;
+                    }
                     this._markObjectPending(bucket, Key, VersionId, storageClass, repConfig, apply);
                 }, next);
             },

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -23,6 +23,7 @@ const MAX_SCANNED = (process.env.MAX_SCANNED
     && Number.parseInt(process.env.MAX_SCANNED, 10));
 const { KEY_MARKER } = process.env;
 const { VERSION_ID_MARKER } = process.env;
+const CURRENT_VERSION_ONLY = process.env.CURRENT_VERSION_ONLY === 'true' || process.env.CURRENT_VERSION_ONLY === '1' || false;
 
 const {
     ACCESS_KEY,
@@ -56,6 +57,11 @@ if (!STORAGE_TYPE) {
 if (!TARGET_REPLICATION_STATUS) {
     TARGET_REPLICATION_STATUS = 'NEW';
 }
+if (CURRENT_VERSION_ONLY) {
+    log.info('CURRENT_VERSION_ONLY is enabled, only latest versions will be processed');
+} else {
+    log.info('CURRENT_VERSION_ONLY is disabled, all versions will be processed');
+}
 
 const replicationStatusToProcess = TARGET_REPLICATION_STATUS.split(',');
 replicationStatusToProcess.forEach(state => {
@@ -85,6 +91,7 @@ const replicationStatusUpdater = new ReplicationStatusUpdater({
     maxScanned: MAX_SCANNED,
     keyMarker: KEY_MARKER,
     versionIdMarker: VERSION_ID_MARKER,
+    currentVersionOnly: CURRENT_VERSION_ONLY,
 }, log);
 
 replicationStatusUpdater.run(err => {

--- a/tests/unit/CRR/ReplicationStatusUpdater.js
+++ b/tests/unit/CRR/ReplicationStatusUpdater.js
@@ -1,17 +1,12 @@
-const AWS = require('aws-sdk');
 const werelogs = require('werelogs');
 const assert = require('assert');
 
-const BackbeatClient = require('../../../BackbeatClient');
-const ReplicationStatusUpdater = require('../../../CRR/ReplicationStatusUpdater');
 const {
     initializeCrrWithMocks,
     listVersionRes,
     listVersionsRes,
     listVersionWithMarkerRes,
-    getBucketReplicationRes,
     getMetadataRes,
-    putMetadataRes,
 } = require('../../utils/crr');
 
 const logger = new werelogs.Logger('ReplicationStatusUpdater::tests', 'debug', 'debug');
@@ -530,6 +525,177 @@ describe('ReplicationStatusUpdater with specifics', () => {
                 VersionIdMarker: 'vid1',
             }, expect.any(Function));
 
+            done();
+        });
+    });
+});
+
+describe('ReplicationStatusUpdater with currentVersionOnly', () => {
+    it('should process only latest versions when currentVersionOnly is true', done => {
+        const listVersionsWithMixedLatest = {
+            IsTruncated: false,
+            Versions: [
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key0',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItW',
+                    IsLatest: true,
+                    LastModified: '2024-01-05T13:11:31.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key0',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItV',
+                    IsLatest: false,
+                    LastModified: '2024-01-05T13:11:30.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key1',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItU',
+                    IsLatest: true,
+                    LastModified: '2024-01-05T13:11:32.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key1',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItT',
+                    IsLatest: false,
+                    LastModified: '2024-01-05T13:11:31.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+            ],
+            DeleteMarkers: [],
+            Name: 'bucket0',
+            MaxKeys: 1000,
+            CommonPrefixes: [],
+        };
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+            currentVersionOnly: true,
+        }, logger);
+
+        crr.s3.listObjectVersions = jest.fn((params, cb) => cb(null, listVersionsWithMixedLatest));
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.s3.listObjectVersions).toHaveBeenCalledTimes(1);
+            expect(crr.s3.getBucketReplication).toHaveBeenCalledTimes(1);
+
+            expect(crr.bb.getMetadata).toHaveBeenCalledTimes(2);
+            expect(crr.bb.getMetadata).toHaveBeenNthCalledWith(1, {
+                Bucket: 'bucket0',
+                Key: 'key0',
+                VersionId: 'aJdO148N3LjN00000000001I4j3QKItW',
+            }, expect.any(Function));
+            expect(crr.bb.getMetadata).toHaveBeenNthCalledWith(2, {
+                Bucket: 'bucket0',
+                Key: 'key1',
+                VersionId: 'aJdO148N3LjN00000000001I4j3QKItU',
+            }, expect.any(Function));
+
+            expect(crr.bb.putMetadata).toHaveBeenCalledTimes(2);
+
+            assert.strictEqual(crr._nProcessed, 2);
+            assert.strictEqual(crr._nSkipped, 2);
+            assert.strictEqual(crr._nUpdated, 2);
+            assert.strictEqual(crr._nErrors, 0);
+            done();
+        });
+    });
+
+    it('should process all versions when currentVersionOnly is false', done => {
+        const listVersionsWithMixedLatest = {
+            IsTruncated: false,
+            Versions: [
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key0',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItW',
+                    IsLatest: true,
+                    LastModified: '2024-01-05T13:11:31.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+                {
+                    ETag: '"dabcc341ecab339daf766e1cddd5d1bb"',
+                    ChecksumAlgorithm: [],
+                    Size: 3263,
+                    StorageClass: 'STANDARD',
+                    Key: 'key0',
+                    VersionId: 'aJdO148N3LjN00000000001I4j3QKItV',
+                    IsLatest: false,
+                    LastModified: '2024-01-05T13:11:30.861Z',
+                    Owner: {
+                        DisplayName: 'bart',
+                        ID: '0',
+                    },
+                },
+            ],
+            DeleteMarkers: [],
+            Name: 'bucket0',
+            MaxKeys: 1000,
+            CommonPrefixes: [],
+        };
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+            currentVersionOnly: false,
+        }, logger);
+
+        crr.s3.listObjectVersions = jest.fn((params, cb) => cb(null, listVersionsWithMixedLatest));
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.s3.listObjectVersions).toHaveBeenCalledTimes(1);
+            expect(crr.s3.getBucketReplication).toHaveBeenCalledTimes(1);
+
+            expect(crr.bb.getMetadata).toHaveBeenCalledTimes(2);
+            expect(crr.bb.putMetadata).toHaveBeenCalledTimes(2);
+
+            assert.strictEqual(crr._nProcessed, 2);
+            assert.strictEqual(crr._nSkipped, 0);
+            assert.strictEqual(crr._nUpdated, 2);
+            assert.strictEqual(crr._nErrors, 0);
             done();
         });
     });

--- a/tests/unit/CRR/crrExistingObjects.js
+++ b/tests/unit/CRR/crrExistingObjects.js
@@ -75,6 +75,7 @@ describe('crrExistingObjects', () => {
         process.env.KEY_MARKER = 'testKeyMarker';
         process.env.VERSION_ID_MARKER = 'testVersionIdMarker';
         process.env.DEBUG = '0';
+        process.env.CURRENT_VERSION_ONLY = 'true';
 
         require('../../../crrExistingObjects');
 
@@ -96,6 +97,7 @@ describe('crrExistingObjects', () => {
             maxScanned: 1000,
             keyMarker: 'testKeyMarker',
             versionIdMarker: 'testVersionIdMarker',
+            currentVersionOnly: true,
         }, expect.anything());
 
         expect(mockFatal).not.toHaveBeenCalled();
@@ -131,6 +133,7 @@ describe('crrExistingObjects', () => {
             maxScanned: undefined,
             keyMarker: undefined,
             versionIdMarker: undefined,
+            currentVersionOnly: false,
         }, expect.anything());
 
         expect(mockFatal).not.toHaveBeenCalled();
@@ -182,5 +185,29 @@ describe('crrExistingObjects', () => {
 
         expect(mockFatal).toHaveBeenCalledWith('SECRET_KEY not defined');
         expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    test('should handle currentVersionOnly with value "1" as true', () => {
+        process.argv[2] = 'bucket1';
+
+        process.env.ACCESS_KEY = 'testAccessKey';
+        process.env.SECRET_KEY = 'testSecretKey';
+        process.env.ENDPOINT = 'http://fake.endpoint';
+        process.env.CURRENT_VERSION_ONLY = '1';
+
+        require('../../../crrExistingObjects');
+
+        const ReplicationStatusUpdater = require('../../../CRR/ReplicationStatusUpdater');
+
+        expect(ReplicationStatusUpdater).toHaveBeenCalledWith(
+            expect.objectContaining({
+                currentVersionOnly: true,
+            }),
+            expect.anything(),
+        );
+        expect(mockFatal).not.toHaveBeenCalled();
+        expect(mockError).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockCrrRun).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
This is needed when using multiple-backend replication, as triggering
all versions may result in an ordering missmatch between versions on
both sites. This is due to the parallel execution of PUTs to the destination,
there is no guarantee the order of versions in source will be respected,
the latest version PUT in destination becomes the master.

More context [available here](https://scality.atlassian.net/browse/S3UTILS-183?focusedCommentId=423762).

Issue: S3UTILS-183