### PR TITLE
S3UTILS-207: [service-level-sidecar] Fix scuba metrics concatenation error + remove v1 format prefix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.15.12",
+  "version": "1.15.13",
   "engines": {
     "node": ">= 16"
   },

--- a/service-level-sidecar/bucketd.js
+++ b/service-level-sidecar/bucketd.js
@@ -52,7 +52,11 @@ async function* listBuckets(log) {
         log.debug('got list of buckets from bucketd', { length: res.length });
 
         yield res.map(data => {
-            const { key, value } = data;
+            const { value, key: rawKey } = data;
+            let key = rawKey;
+            if (key.startsWith('\x7fM')) {
+                key = key.slice(2);
+            }
             const [account, name] = key.split(mdKeySplitter);
             return {
                 account,

--- a/service-level-sidecar/report.js
+++ b/service-level-sidecar/report.js
@@ -73,8 +73,8 @@ async function getMetricsForBucket(sessionIds, timestamp, bucket, log) {
         return logResults
             .filter(result => result !== null)
             .reduce((acc, result) => ({
-                count: acc.count + result.value.metrics.objectsTotal,
-                bytes: acc.bytes + result.value.metrics.bytesTotal,
+                count: acc.count + parseInt(result.value.metrics.objectsTotal, 10),
+                bytes: acc.bytes + parseInt(result.value.metrics.bytesTotal, 10),
             }), { count: 0, bytes: 0 });
     }
     return warp10.getMetricsForBucket(timestamp, bucket.name, log);


### PR DESCRIPTION
Output before the concatenation fix:
```
{"account":[{"arn":"arn:aws:iam::662222158939:/scuba-account-local/","name":"scuba-account-local","obj_count":"001","bytes_stored":"000","bytes_stored_total":0}],"bucket":{"arn:aws:iam::662222158939:/scuba-account-local/":[{"name":"test-bucket","obj_count":"001","bytes_stored":"000","bytes_stored_total":0}]},"service":{"obj_count":"001","bytes_stored":"000","bytes_stored_total":0}}%
```
Output after the fix:
```
{"account":[{"arn":"arn:aws:iam::662222158939:/scuba-account-local/","name":"scuba-account-local","obj_count":1,"bytes_stored":0,"bytes_stored_total":0}],"bucket":{"arn:aws:iam::662222158939:/scuba-account-local/":[{"name":"test-bucket","obj_count":1,"bytes_stored":0,"bytes_stored_total":0}]},"service":{"obj_count":1,"bytes_stored":0,"bytes_stored_total":0}}%
```