### PR TITLE
S3UTILS-208 Reset object replication configuration

### DIFF
--- a/CRR/ReplicationStatusUpdater.js
+++ b/CRR/ReplicationStatusUpdater.js
@@ -30,6 +30,7 @@ class ReplicationStatusUpdater {
      * @param {string} [params.keyMarker] - (Optional) Key marker for resuming object listing.
      * @param {string} [params.versionIdMarker] - (Optional) Version ID marker for resuming object listing.
      * @param {boolean} [params.currentVersionOnly] - (Optional) Whether to process only the current version of objects.
+     * @param {boolean} [params.forceUsingConfiguration] - (Optional) Force reset replication target to bucket's configuration.
      */
     constructor(params, log) {
         const {
@@ -48,6 +49,7 @@ class ReplicationStatusUpdater {
             keyMarker,
             versionIdMarker,
             currentVersionOnly,
+            forceUsingConfiguration,
         } = params;
 
         // inputs
@@ -66,6 +68,7 @@ class ReplicationStatusUpdater {
         this.inputKeyMarker = keyMarker;
         this.inputVersionIdMarker = versionIdMarker;
         this.currentVersionOnly = currentVersionOnly;
+        this.forceUsingConfiguration = forceUsingConfiguration;
         this.log = log;
 
         this._setupClients();
@@ -188,9 +191,10 @@ class ReplicationStatusUpdater {
                 // This is particularly important if the object was created before
                 // enabling replication on the bucket.
                 let replicationInfo = objMD.getReplicationInfo();
+                const { Rules, Role } = repConfig;
+                const destination = Rules[0].Destination.Bucket;
+                
                 if (!replicationInfo || !replicationInfo.status) {
-                    const { Rules, Role } = repConfig;
-                    const destination = Rules[0].Destination.Bucket;
                     // set replication properties
                     const ops = objMD.getContentLength() === 0 ? ['METADATA']
                         : ['METADATA', 'DATA'];
@@ -204,6 +208,12 @@ class ReplicationStatusUpdater {
                         storageType: '',
                     };
                     objMD.setReplicationInfo(replicationInfo);
+                }
+
+                // Force reset object's replication configuration to match bucket's configuration
+                if (this.forceUsingConfiguration) {
+                    objMD.setReplicationTargetBucket(destination);
+                    objMD.setReplicationRoles(Role);
                 }
                 // Update replication info with site specific info
                 if (!objMD.getReplicationSiteStatus(storageClass)) {

--- a/crrExistingObjects.js
+++ b/crrExistingObjects.js
@@ -15,6 +15,7 @@ const { SITE_NAME } = process.env;
 let { STORAGE_TYPE } = process.env;
 let { TARGET_REPLICATION_STATUS } = process.env;
 const { TARGET_PREFIX } = process.env;
+const FORCE_USING_CONFIGURATION = process.env.FORCE_USING_CONFIGURATION === 'true' || process.env.FORCE_USING_CONFIGURATION === '1' || false;
 const WORKERS = (process.env.WORKERS
     && Number.parseInt(process.env.WORKERS, 10)) || 10;
 const MAX_UPDATES = (process.env.MAX_UPDATES
@@ -92,6 +93,7 @@ const replicationStatusUpdater = new ReplicationStatusUpdater({
     keyMarker: KEY_MARKER,
     versionIdMarker: VERSION_ID_MARKER,
     currentVersionOnly: CURRENT_VERSION_ONLY,
+    forceUsingConfiguration: FORCE_USING_CONFIGURATION,
 }, log);
 
 replicationStatusUpdater.run(err => {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@senx/warp10": "^2.0.3",
     "@smithy/util-retry": "^4.0.7",
     "JSONStream": "^1.3.5",
-    "arsenal": "git+https://github.com/scality/arsenal#8.2.26",
+    "arsenal": "git+https://github.com/scality/arsenal#8.2.36",
     "async": "^3.2.6",
     "aws-sdk": "^2.1691.0",
     "bucketclient": "scality/bucketclient#8.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "engines": {
     "node": ">= 22"
   },

--- a/tests/unit/CRR/ReplicationStatusUpdater.js
+++ b/tests/unit/CRR/ReplicationStatusUpdater.js
@@ -7,15 +7,14 @@ const {
     listVersionsRes,
     listVersionWithMarkerRes,
     getMetadataRes,
+    objectMd,
 } = require('../../utils/crr');
 
 const logger = new werelogs.Logger('ReplicationStatusUpdater::tests', 'debug', 'debug');
 
 describe('ReplicationStatusUpdater', () => {
-    let crr;
-
-    beforeEach(() => {
-        crr = initializeCrrWithMocks({
+    it('should process bucket for CRR', done => {
+        const crr = initializeCrrWithMocks({
             buckets: ['bucket0'],
             workers: 10,
             replicationStatusToProcess: ['NEW'],
@@ -23,9 +22,7 @@ describe('ReplicationStatusUpdater', () => {
             listingLimit: 10,
             siteName: 'aws-location',
         }, logger);
-    });
 
-    it('should process bucket for CRR', done => {
         crr.run(err => {
             assert.ifError(err);
 
@@ -66,7 +63,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: '',
@@ -88,7 +85,7 @@ describe('ReplicationStatusUpdater', () => {
     });
 
     it('should process bucket for CRR with multiple objects', done => {
-        crr = initializeCrrWithMocks({
+        const crr = initializeCrrWithMocks({
             buckets: ['bucket0'],
             workers: 10,
             replicationStatusToProcess: ['NEW'],
@@ -159,7 +156,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -188,7 +185,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -206,7 +203,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -223,7 +220,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -241,7 +238,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -258,7 +255,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'aws_s3',
@@ -281,7 +278,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'azure-location,aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'azure,aws_s3',
@@ -302,7 +299,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'azure-location,aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'azure,aws_s3',
@@ -325,7 +322,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'azure-location,azure-location-2',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'azure,azure',
@@ -350,7 +347,7 @@ describe('ReplicationStatusUpdater', () => {
                     },
                 ],
                 content: ['METADATA', 'DATA'],
-                destination: 'arn:aws:s3:::sourcebucket',
+                destination: 'arn:aws:s3:::destination',
                 storageClass: 'azure-location,azure-location-2,aws-location',
                 role: 'arn:aws:iam::root:role/s3-replication-role',
                 storageType: 'azure,azure,aws_s3',
@@ -359,6 +356,14 @@ describe('ReplicationStatusUpdater', () => {
         },
     ].forEach(params => {
         it(`should trigger replication ${params.description}`, done => {
+            const crr = initializeCrrWithMocks({
+                buckets: ['bucket0'],
+                workers: 10,
+                replicationStatusToProcess: ['NEW'],
+                targetPrefix: 'toto',
+                listingLimit: 10,
+                siteName: 'aws-location',
+            }, logger);
             crr.bb.getMetadata = jest.fn((p, cb) => {
                 const objectMd = JSON.parse(getMetadataRes.Body);
                 objectMd.replicationInfo = params.replicationInfo;
@@ -573,6 +578,63 @@ describe('ReplicationStatusUpdater with specifics', () => {
                 })
             }));
 
+            done();
+        });
+    });
+});
+
+describe('ReplicationStatusUpdater with forceUsingConfiguration', () => {
+    it('should overwrite replication destination and role when forceUsingConfiguration is true', done => {
+        // Deep copy objectMd from utils to avoid affecting the original
+        const objectMdWithOldReplication = JSON.parse(JSON.stringify(objectMd));
+        
+        // Only modify the replicationInfo part
+        objectMdWithOldReplication.replicationInfo = {
+            status: 'COMPLETED',
+            backends: [
+                {
+                    site: 'sf',
+                    status: 'COMPLETED',
+                    dataStoreVersionId: '',
+                },
+            ],
+            content: ['DATA', 'METADATA'],
+            destination: 'arn:aws:s3:::destination2',
+            storageClass: 'sf',
+            role: 'arn:aws:iam::123456789012:role/src-resource,arn:aws:iam::123456789012:role/dest-resource',
+            storageType: '',
+            dataStoreVersionId: '',
+        };
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+            forceUsingConfiguration: true,
+        }, logger);
+
+        // Override getMetadata to return object with old replication info
+        crr.bb.getMetadata = jest.fn((params, cb) => cb(null, {
+            Body: JSON.stringify(objectMdWithOldReplication),
+        }));
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.bb.putMetadata).toHaveBeenCalledTimes(1);
+            
+            // Verify that putMetadata was called with updated destination and role from bucket config
+            const putMetadataCall = crr.bb.putMetadata.mock.calls[0][0];
+            const updatedMetadata = JSON.parse(putMetadataCall.Body);
+            
+            // Check that replicationInfo contains the bucket configuration values
+            expect(updatedMetadata.replicationInfo.destination).toBe('arn:aws:s3:::destination');
+            expect(updatedMetadata.replicationInfo.role).toBe('arn:aws:iam::root:role/s3-replication-role');
+            
+            assert.strictEqual(crr._nProcessed, 1);
+            assert.strictEqual(crr._nSkipped, 0);
+            assert.strictEqual(crr._nUpdated, 1);
+            assert.strictEqual(crr._nErrors, 0);
             done();
         });
     });

--- a/tests/unit/CRR/crrExistingObjects.js
+++ b/tests/unit/CRR/crrExistingObjects.js
@@ -76,6 +76,7 @@ describe('crrExistingObjects', () => {
         process.env.VERSION_ID_MARKER = 'testVersionIdMarker';
         process.env.DEBUG = '0';
         process.env.CURRENT_VERSION_ONLY = 'true';
+        process.env.FORCE_USING_CONFIGURATION = 'true';
 
         require('../../../crrExistingObjects');
 
@@ -98,6 +99,7 @@ describe('crrExistingObjects', () => {
             keyMarker: 'testKeyMarker',
             versionIdMarker: 'testVersionIdMarker',
             currentVersionOnly: true,
+            forceUsingConfiguration: true,
         }, expect.anything());
 
         expect(mockFatal).not.toHaveBeenCalled();
@@ -134,6 +136,7 @@ describe('crrExistingObjects', () => {
             keyMarker: undefined,
             versionIdMarker: undefined,
             currentVersionOnly: false,
+            forceUsingConfiguration: false,
         }, expect.anything());
 
         expect(mockFatal).not.toHaveBeenCalled();

--- a/tests/utils/crr.js
+++ b/tests/utils/crr.js
@@ -97,7 +97,7 @@ const getBucketReplicationRes = {
                 Prefix: '',
                 Status: 'Enabled',
                 Destination: {
-                    Bucket: 'arn:aws:s3:::sourcebucket',
+                    Bucket: 'arn:aws:s3:::destination',
                     StorageClass: 'aws-location',
                 },
             },
@@ -204,4 +204,5 @@ module.exports = {
     getBucketReplicationRes,
     getMetadataRes,
     putMetadataRes,
+    objectMd,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,6 +615,15 @@
   dependencies:
     tslib "^2.6.2"
 
+"@azure/core-auth@^1.10.0":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.10.1.tgz#68a17fa861ebd14f6fd314055798355ef6bedf1b"
+  integrity sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-util" "^1.13.0"
+    tslib "^2.6.2"
+
 "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.8.0", "@azure/core-auth@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.9.0.tgz#ac725b03fabe3c892371065ee9e2041bee0fd1ac"
@@ -622,6 +631,19 @@
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-util" "^1.11.0"
+    tslib "^2.6.2"
+
+"@azure/core-client@^1.10.0", "@azure/core-client@^1.9.3":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.10.1.tgz#83d78f97d647ab22e6811a7a68bb4223e7a1d019"
+  integrity sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-rest-pipeline" "^1.22.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
     tslib "^2.6.2"
 
 "@azure/core-client@^1.3.0", "@azure/core-client@^1.6.2", "@azure/core-client@^1.9.2":
@@ -646,6 +668,15 @@
     "@azure/core-client" "^1.3.0"
     "@azure/core-rest-pipeline" "^1.20.0"
 
+"@azure/core-http-compat@^2.2.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-http-compat/-/core-http-compat-2.3.1.tgz#2182e39a31c062800d4e3ad69bcf0109d87713dc"
+  integrity sha512-az9BkXND3/d5VgdRRQVkiJb2gOmDU8Qcq4GvjtBmDICNiQ9udFmDk4ZpSB5Qq1OmtDJGlQAfBaS4palFsazQ5g==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-client" "^1.10.0"
+    "@azure/core-rest-pipeline" "^1.22.0"
+
 "@azure/core-lro@^2.2.0":
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.7.2.tgz#787105027a20e45c77651a98b01a4d3b01b75a08"
@@ -656,7 +687,7 @@
     "@azure/logger" "^1.0.0"
     tslib "^2.6.2"
 
-"@azure/core-paging@^1.1.1":
+"@azure/core-paging@^1.1.1", "@azure/core-paging@^1.6.2":
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.6.2.tgz#40d3860dc2df7f291d66350b2cfd9171526433e7"
   integrity sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==
@@ -676,10 +707,30 @@
     "@typespec/ts-http-runtime" "^0.2.2"
     tslib "^2.6.2"
 
+"@azure/core-rest-pipeline@^1.19.1", "@azure/core-rest-pipeline@^1.22.0":
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.1.tgz#f47bc02ff9a79f62e6a32aa375420b1b86dcbccd"
+  integrity sha512-UVZlVLfLyz6g3Hy7GNDpooMQonUygH7ghdiSASOOHy97fKj/mPLqgDX7aidOijn+sCMU+WU8NjlPlNTgnvbcGA==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
 "@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1", "@azure/core-tracing@^1.1.2":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.2.0.tgz#7be5d53c3522d639cf19042cbcdb19f71bc35ab2"
   integrity sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-tracing@^1.2.0", "@azure/core-tracing@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.3.1.tgz#e971045c901ea9c110616b0e1db272507781d5f6"
+  integrity sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==
   dependencies:
     tslib "^2.6.2"
 
@@ -692,6 +743,15 @@
     "@typespec/ts-http-runtime" "^0.2.2"
     tslib "^2.6.2"
 
+"@azure/core-util@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.13.1.tgz#6dff2ff6d3c9c6430c6f4d3b3e65de531f10bafe"
+  integrity sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
 "@azure/core-xml@^1.4.3":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@azure/core-xml/-/core-xml-1.4.5.tgz#6ebffa860799cb657f0ca63a5992d359d4aa4b2d"
@@ -700,10 +760,18 @@
     fast-xml-parser "^5.0.7"
     tslib "^2.8.1"
 
-"@azure/identity@^4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-4.10.2.tgz#6609ce398824ff0bb53f1ad1043a9f1cc93e56b8"
-  integrity sha512-Uth4vz0j+fkXCkbvutChUj03PDCokjbC6Wk9JT8hHEUtpy/EurNKAseb3+gO6Zi9VYBvwt61pgbzn1ovk942Qg==
+"@azure/core-xml@^1.4.5":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-xml/-/core-xml-1.5.0.tgz#cd82d511d7bcc548d206f5627c39724c5d5a4434"
+  integrity sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==
+  dependencies:
+    fast-xml-parser "^5.0.7"
+    tslib "^2.8.1"
+
+"@azure/identity@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-4.13.0.tgz#b2be63646964ab59e0dc0eadca8e4f562fc31f96"
+  integrity sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==
   dependencies:
     "@azure/abort-controller" "^2.0.0"
     "@azure/core-auth" "^1.9.0"
@@ -742,6 +810,14 @@
     "@typespec/ts-http-runtime" "^0.2.2"
     tslib "^2.6.2"
 
+"@azure/logger@^1.1.4", "@azure/logger@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.3.0.tgz#5501cf85d4f52630602a8cc75df76568c969a827"
+  integrity sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==
+  dependencies:
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
 "@azure/msal-browser@^4.2.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-4.13.0.tgz#a8777fab55544433581b52dd7f86e3de1532dde6"
@@ -763,7 +839,7 @@
     jsonwebtoken "^9.0.0"
     uuid "^8.3.0"
 
-"@azure/storage-blob@^12.25.0", "@azure/storage-blob@^12.27.0":
+"@azure/storage-blob@^12.25.0":
   version "12.27.0"
   resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.27.0.tgz#3062930411173a28468bd380e0ad2c6328d7288a"
   integrity sha512-IQjj9RIzAKatmNca3D6bT0qJ+Pkox1WZGOg2esJF2YLHb45pQKOwGPIAV+w3rfgkj7zV3RMxpn/c6iftzSOZJQ==
@@ -781,6 +857,41 @@
     "@azure/logger" "^1.0.0"
     events "^3.0.0"
     tslib "^2.2.0"
+
+"@azure/storage-blob@^12.28.0":
+  version "12.29.1"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.29.1.tgz#d9588b3f56f3621f92936fa3e7f268e00a34548a"
+  integrity sha512-7ktyY0rfTM0vo7HvtK6E3UvYnI9qfd6Oz6z/+92VhGRveWng3kJwMKeUpqmW/NmwcDNbxHpSlldG+vsUnRFnBg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-client" "^1.9.3"
+    "@azure/core-http-compat" "^2.2.0"
+    "@azure/core-lro" "^2.2.0"
+    "@azure/core-paging" "^1.6.2"
+    "@azure/core-rest-pipeline" "^1.19.1"
+    "@azure/core-tracing" "^1.2.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/core-xml" "^1.4.5"
+    "@azure/logger" "^1.1.4"
+    "@azure/storage-common" "^12.1.1"
+    events "^3.0.0"
+    tslib "^2.8.1"
+
+"@azure/storage-common@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@azure/storage-common/-/storage-common-12.1.1.tgz#cd0768188f7cf8ea7202d584067ad5f3eba89744"
+  integrity sha512-eIOH1pqFwI6UmVNnDQvmFeSg0XppuzDLFeUNO/Xht7ODAzRLgGDh7h550pSxoA+lPDxBl1+D2m/KG3jWzCUjTg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-http-compat" "^2.2.0"
+    "@azure/core-rest-pipeline" "^1.19.1"
+    "@azure/core-tracing" "^1.2.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/logger" "^1.1.4"
+    events "^3.3.0"
+    tslib "^2.8.1"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
@@ -1126,10 +1237,37 @@
     "@eslint/core" "^0.14.0"
     levn "^0.4.1"
 
+"@hapi/address@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-5.1.1.tgz#e9925fc1b65f5cc3fbea821f2b980e4652e84cb6"
+  integrity sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==
+  dependencies:
+    "@hapi/hoek" "^11.0.2"
+
+"@hapi/formula@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-3.0.2.tgz#81b538060ee079481c906f599906d163c4badeaf"
+  integrity sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==
+
+"@hapi/hoek@^11.0.2", "@hapi/hoek@^11.0.7":
+  version "11.0.7"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-11.0.7.tgz#56a920793e0a42d10e530da9a64cc0d3919c4002"
+  integrity sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
   integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/pinpoint@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.1.tgz#32077e715655fc00ab8df74b6b416114287d6513"
+  integrity sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==
+
+"@hapi/tlds@^1.1.1":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@hapi/tlds/-/tlds-1.1.4.tgz#df4a7b59082b54ba4f3b7b38f781e2ac3cbc359a"
+  integrity sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==
 
 "@hapi/topo@^5.1.0":
   version "5.1.0"
@@ -1137,6 +1275,13 @@
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@hapi/topo@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-6.0.2.tgz#f219c1c60da8430228af4c1f2e40c32a0d84bbb4"
+  integrity sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==
+  dependencies:
+    "@hapi/hoek" "^11.0.2"
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -1165,6 +1310,11 @@
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
+
+"@ioredis/commands@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.4.0.tgz#9f657d51cdd5d2fdb8889592aa4a355546151f25"
+  integrity sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==
 
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
@@ -1439,6 +1589,13 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz#09506f29cc2a99d9d7b951caa7fffc87e522a6d3"
   integrity sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
+"@mongodb-js/saslprep@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.3.2.tgz#51e5cad2f24b8759702d9cc185da0a3ef3784bad"
+  integrity sha512-QgA5AySqB27cGTXBFmnpifAi7HxoGUeezwo6p9dI03MuDB6Pp33zgclqVb6oVK3j6I9Vesg0+oojW2XxB59SGg==
   dependencies:
     sparse-bitfield "^3.0.3"
 
@@ -2246,6 +2403,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
   integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
 
+"@standard-schema/spec@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
 "@types/async@^3.2.24":
   version "3.2.24"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.24.tgz#3a96351047575bbcf2340541b2d955a35339608f"
@@ -2443,6 +2605,15 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@typespec/ts-http-runtime/-/ts-http-runtime-0.2.2.tgz#a0c7458ed99aae6d7eb22efc17a839cec0b4a1b3"
   integrity sha512-Gz/Sm64+Sq/vklJu1tt9t+4R2lvnud8NbTD/ZfpZtMiUX7YeVpCA8j6NSW8ptwcoLL+NmYANwqP8DV0q/bwl2w==
+  dependencies:
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.0"
+    tslib "^2.6.2"
+
+"@typespec/ts-http-runtime@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz#2fa94050f25b4d85d0bc8b9d97874b8d347a9173"
+  integrity sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==
   dependencies:
     http-proxy-agent "^7.0.0"
     https-proxy-agent "^7.0.0"
@@ -2734,12 +2905,12 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.2.26":
-  version "8.2.26"
-  resolved "git+https://github.com/scality/arsenal#80bb045e77ed9a5205af105820dc23b8351d3258"
+"arsenal@git+https://github.com/scality/arsenal#8.2.36":
+  version "8.2.36"
+  resolved "git+https://github.com/scality/arsenal#cd72c49fdfe47440680142ece0b268e35c3e1691"
   dependencies:
-    "@azure/identity" "^4.10.2"
-    "@azure/storage-blob" "^12.27.0"
+    "@azure/identity" "^4.13.0"
+    "@azure/storage-blob" "^12.28.0"
     "@js-sdsl/ordered-set" "^4.4.2"
     "@scality/hdclient" "^1.3.1"
     JSONStream "^1.3.5"
@@ -2750,16 +2921,16 @@ arraybuffer.prototype.slice@^1.0.4:
     backo "^1.1.0"
     base-x "3.0.8"
     base62 "^2.0.2"
-    debug "^4.4.1"
+    debug "^4.4.3"
     fcntl "github:scality/node-fcntl#0.3.0"
     httpagent scality/httpagent#1.1.0
     https-proxy-agent "^7.0.6"
-    ioredis "^5.6.1"
+    ioredis "^5.8.1"
     ipaddr.js "^2.2.0"
-    joi "^17.13.3"
+    joi "^18.0.1"
     level "~5.0.1"
     level-sublevel "~6.6.5"
-    mongodb "^6.17.0"
+    mongodb "^6.20.0"
     node-forge "^1.3.1"
     prom-client "^15.1.3"
     simple-glob "^0.2.0"
@@ -3354,7 +3525,7 @@ dayjs@^1.11.10:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.0, debug@^4.4.1:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -3367,6 +3538,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
   version "4.3.7"
@@ -3882,7 +4060,7 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -4496,12 +4674,27 @@ ioctl@2.0.2, ioctl@^2.0.2:
     bindings "^1.5.0"
     nan "^2.14.0"
 
-ioredis@^5.4.1, ioredis@^5.6.1:
+ioredis@^5.4.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.6.1.tgz#1ed7dc9131081e77342503425afceaf7357ae599"
   integrity sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==
   dependencies:
     "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
+ioredis@^5.8.1:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.8.2.tgz#c7a228a26cf36f17a5a8011148836877780e2e14"
+  integrity sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==
+  dependencies:
+    "@ioredis/commands" "1.4.0"
     cluster-key-slot "^1.1.0"
     debug "^4.3.4"
     denque "^2.1.0"
@@ -5239,6 +5432,19 @@ joi@^17.13.3:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
+joi@^18.0.1:
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-18.0.1.tgz#1e1885d035cc6ca1624e81bf22112e7c1ee38e1b"
+  integrity sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==
+  dependencies:
+    "@hapi/address" "^5.1.1"
+    "@hapi/formula" "^3.0.2"
+    "@hapi/hoek" "^11.0.7"
+    "@hapi/pinpoint" "^2.0.1"
+    "@hapi/tlds" "^1.1.1"
+    "@hapi/topo" "^6.0.2"
+    "@standard-schema/spec" "^1.0.0"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5903,7 +6109,7 @@ module-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-error/-/module-error-1.0.2.tgz#8d1a48897ca883f47a45816d4fb3e3c6ba404d86"
   integrity sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==
 
-mongodb-connection-string-url@^3.0.0:
+mongodb-connection-string-url@^3.0.0, mongodb-connection-string-url@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz#e223089dfa0a5fa9bf505f8aedcbc67b077b33e7"
   integrity sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==
@@ -5954,6 +6160,15 @@ mongodb@^6.17.0:
     "@mongodb-js/saslprep" "^1.1.9"
     bson "^6.10.4"
     mongodb-connection-string-url "^3.0.0"
+
+mongodb@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.20.0.tgz#5212dcf512719385287aa4574265352eefb01d8e"
+  integrity sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^6.10.4"
+    mongodb-connection-string-url "^3.0.2"
 
 ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
@@ -7029,7 +7244,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7082,7 +7306,14 @@ string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7602,7 +7833,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Adds a new `FORCE_USING_CONFIGURATION` environment variable to the CRR existing objects processing tool. 
When enabled, this option allows custumers to force-update existing object replication configurations to match the current bucket replication configuration.


**Context**

When an object is created, its replication destination bucket and the IAM role used for replication are hardcoded in its object metadata under the `replicationInfo` field.
This design makes sure that each object is replicated according to the exact bucket replication configuration in effect at the time of its creation. 

Later changes of the bucket replication configuration only affect newly created objects.

However, in the case of CRR existing objects processing (where objects are re-queued for replication or re-replication) the current bucket replication configuration might have changed since the objects were originally created. Customers may want these reprocessed objects to follow the updated bucket replication configuration rather than the old one stored in their metadata.