### PR TITLE
S3UTILS-209 Prevent metadata ObjectMD field loss in CRRExistingObject

### DIFF
--- a/CRR/ReplicationStatusUpdater.js
+++ b/CRR/ReplicationStatusUpdater.js
@@ -167,22 +167,24 @@ class ReplicationStatusUpdater {
                 VersionId: versionId,
             }, next),
             (mdRes, next) => {
-                // NOTE: The Arsenal Object Metadata schema version 8.1 is being used for both Ring S3C and Artesca,
-                // it is acceptable because the 8.1 schema only adds extra properties to the 7.10 schema.
-                // This is beneficial because:
-                // - Forward compatibility: Having the 8.1 properties in place now ensures that
-                //   S3C is compatible with the 8.1 schema, which could be useful if we plan to upgrade
-                //   from 7.10 to 8.1 in the future.
-                // - No impact on current functionality: The extra properties from the 8.1
-                //   schema do not interfere with the current functionalities of the 7.10 environment,
-                //   so there is no harm in keeping them. S3C should ignore them without causing any issues.
-                // - Simple codebase: Not having to remove these properties simplifies the codebase of s3utils.
-                //   Less complexity and potential errors linked with conditionally removing metadata properties
-                //   based on the version.
-                // - Single schema approach: Keeping a single, unified schema approach in s3utils can make the
-                //   codebase easier to maintain and upgrade, as opposed to having multiple branches or versions of
-                //   the code for different schema versions.
-                objMD = new ObjectMD(JSON.parse(mdRes.Body));
+                const originalMD = JSON.parse(mdRes.Body);
+                const originalMDVersion = originalMD['md-model-version'];
+                objMD = new ObjectMD(originalMD);
+                const newMDVersion = objMD.getModelVersion();
+
+                // Prevent schema downgrade: do not write metadata if this model version
+                // is older than the object's original version, to avoid losing newer fields.
+                if (newMDVersion < originalMDVersion) {
+                    this.log.error('model version regression: newMDVersion < originalMDVersion', {
+                        bucket,
+                        key,
+                        versionId,
+                        newMDVersion,
+                        originalMDVersion,
+                    });
+                    return next(new Error('model version regression: refusing to overwrite newer metadata'));
+                }
+
                 if (!this._objectShouldBeUpdated(objMD, storageClass)) {
                     skip = true;
                     return process.nextTick(next);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "engines": {
     "node": ">= 22"
   },

--- a/tests/unit/CRR/ReplicationStatusUpdater.js
+++ b/tests/unit/CRR/ReplicationStatusUpdater.js
@@ -1,5 +1,6 @@
 const werelogs = require('werelogs');
 const assert = require('assert');
+const { models } = require('arsenal');
 
 const {
     initializeCrrWithMocks,
@@ -815,6 +816,90 @@ describe('ReplicationStatusUpdater with currentVersionOnly', () => {
             assert.strictEqual(crr._nProcessed, 2);
             assert.strictEqual(crr._nSkipped, 0);
             assert.strictEqual(crr._nUpdated, 2);
+            assert.strictEqual(crr._nErrors, 0);
+            done();
+        });
+    });
+});
+
+describe('ReplicationStatusUpdater model version guard', () => {
+    let getModelVersionSpy;
+
+    afterEach(() => {
+        if (getModelVersionSpy) {
+            getModelVersionSpy.mockRestore();
+            getModelVersionSpy = null;
+        }
+    });
+
+    it('should refuse to overwrite when new model version is lower than original', done => {
+        // Original object metadata version from test fixture is 3
+        // Force ObjectMD to report a lower version to trigger the guard
+        getModelVersionSpy = jest.spyOn(models.ObjectMD.prototype, 'getModelVersion')
+            .mockReturnValue(2);
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+        }, logger);
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.bb.putMetadata).not.toHaveBeenCalled();
+
+            assert.strictEqual(crr._nProcessed, 1);
+            assert.strictEqual(crr._nUpdated, 0);
+            assert.strictEqual(crr._nSkipped, 0);
+            assert.strictEqual(crr._nErrors, 1);
+            done();
+        });
+    });
+
+    it('should proceed when new model version equals original', done => {
+        // Match the test fixture version (3) to allow write
+        getModelVersionSpy = jest.spyOn(models.ObjectMD.prototype, 'getModelVersion')
+            .mockReturnValue(3);
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+        }, logger);
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.bb.putMetadata).toHaveBeenCalledTimes(1);
+
+            assert.strictEqual(crr._nProcessed, 1);
+            assert.strictEqual(crr._nUpdated, 1);
+            assert.strictEqual(crr._nSkipped, 0);
+            assert.strictEqual(crr._nErrors, 0);
+            done();
+        });
+    });
+
+    it('should proceed when new model version is higher than original', done => {
+        // Higher than the test fixture version (3)
+        getModelVersionSpy = jest.spyOn(models.ObjectMD.prototype, 'getModelVersion')
+            .mockReturnValue(4);
+
+        const crr = initializeCrrWithMocks({
+            buckets: ['bucket0'],
+            workers: 10,
+            replicationStatusToProcess: ['NEW'],
+        }, logger);
+
+        crr.run(err => {
+            assert.ifError(err);
+
+            expect(crr.bb.putMetadata).toHaveBeenCalledTimes(1);
+
+            assert.strictEqual(crr._nProcessed, 1);
+            assert.strictEqual(crr._nUpdated, 1);
+            assert.strictEqual(crr._nSkipped, 0);
             assert.strictEqual(crr._nErrors, 0);
             done();
         });


### PR DESCRIPTION
This change adds a safety check to make sure we never rewrite object metadata using an older ObjectMD version than the one already stored. 

If the new version is lower than the original one, the update is stopped.

This is a preventive safeguard, we have not seen this issue happening on customer environments so far.