### PR TITLE
S3UTILS-210: include all files in coverage report

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,12 @@ module.exports = {
     moduleFileExtensions: ['js', 'jsx', 'json', 'node'],
     setupFiles: ['<rootDir>/tests/conf/envSetup.js'],
     testMatch: ['**/tests/**/*.js?(x)'],
+    collectCoverageFrom: [
+        '**/*.js',
+        '!**/node_modules/**',
+        '!**/tests/**',
+        '!**/coverage/**',
+        '!jest.config.js',
+    ],
 };
 


### PR DESCRIPTION
In [codecov report](https://app.codecov.io/github/scality/s3utils/tree/development%2F1.16) only the files that have some coverage are showing up. But those not covered are not included.

Re-configuring jest to include them in the mix.