### PR TITLE
S3UTILS-212 [bf] change sync to async truth tests with async@v3

### DIFF
--- a/cleanupNoncurrentVersions.js
+++ b/cleanupNoncurrentVersions.js
@@ -593,7 +593,7 @@ function triggerDeletesOnBucket(bucketName, cb) {
                 return undefined;
             });
         },
-        () => {
+        async () => {
             if (nDeletesTriggered >= MAX_DELETES || nListed >= MAX_LISTED) {
                 return false;
             }

--- a/listFailedObjects.js
+++ b/listFailedObjects.js
@@ -103,7 +103,7 @@ function listBucket(bucket, cb) {
                 });
             },
         ),
-        () => {
+        async () => {
             if (!VersionIdMarker || !KeyMarker) {
                 log.debug(
                     'completed listing failed objects for bucket',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "engines": {
     "node": ">= 22"
   },

--- a/raftLogCheck.js
+++ b/raftLogCheck.js
@@ -214,7 +214,7 @@ async.waterfall([
     },
     (leaderHost, leaderPort, connected, _bseq, _vseq, next) => {
         let seq = _bseq;
-        async.until(() => {
+        async.until(async () => {
             log.debug('test', { seq, _vseq });
             return seq >= _vseq;
         }, cb => {

--- a/requeueFailedCRRCronJob.js
+++ b/requeueFailedCRRCronJob.js
@@ -228,7 +228,7 @@ function _requeueAll() {
             });
             failedReq.end();
         },
-        isTruncated => isTruncated && !stopRequest,
+        async isTruncated => isTruncated && !stopRequest,
         () => {
             requeueInProgress = false;
             if (stopRequest) {

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -549,7 +549,7 @@ function listBucket(bucket, cb) {
             _done => listBucketIter(bucket, _done),
             done
         ),
-        IsTruncated => IsTruncated,
+        async IsTruncated => IsTruncated,
         err => {
             status.bucketInProgress = null;
             status.KeyMarker = '';


### PR DESCRIPTION
A few places were missing an async truth test, that is mandatory since the bump to async@v3. It can result in the async loop being stuck in the affected scripts:

- cleanupNoncurrentVersions.js
- listFailedObjects.js
- raftLogCheck.js
- requeueFailedCRRCronJob.js
- verifyBucketSproxydKeys.js
