### PR TITLE
S3UTILS-211: Install and configure workbench for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,18 @@ jobs:
         with:
           node-version: '22'
           cache: 'yarn'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Boot workbench
+        uses: scality/workbench@v0.8.0
+        with:
+          environment-dir: workbench/env
       - run: sudo apt-get update -q
       # Ubuntu 24.04 doesn't have libssl1.1 which is needed by mongo-memory-server
       - name: install libssl1.1

--- a/workbench/env/default/values.yaml
+++ b/workbench/env/default/values.yaml
@@ -1,0 +1,56 @@
+global:
+  log_level: info
+
+features:
+  scuba:
+    enabled: false
+    enable_service_user: true
+
+  bucket_notifications:
+    enabled: false
+    destinationAuth:
+      type: none
+      username: admin
+      password: admin123
+
+  cross_region_replication:
+    enabled: true
+
+  utapi:
+    enabled: false
+
+  migration:
+    enabled: false
+
+cloudserver:
+  image: ghcr.io/scality/cloudserver:9.2.6
+
+vault:
+  image: ghcr.io/scality/vault:7.83.0
+
+backbeat:
+  image: ghcr.io/scality/backbeat:9.0.21-federation
+
+s3_metadata:
+  image: ghcr.io/scality/metadata:8.22.0-standalone
+
+scuba:
+  image: ghcr.io/scality/scuba:1.1.17-nodesvc-base
+
+scuba_metadata:
+  image: ghcr.io/scality/metadata:8.22.0-standalone
+
+kafka:
+  image: bitnami/kafka:3.9.0
+
+zookeeper:
+  image: bitnami/zookeeper:3.9.4
+
+redis:
+  image: redis:8
+
+utapi:
+  image: ghcr.io/scality/utapi:7.70.9
+
+migration_tools:
+  image: ghcr.io/scality/metadata-migration:1.4.0-svc-base


### PR DESCRIPTION
Splitting up the work to ease review of #359. 

Setting up workbench in the CI environment for later use the in the functional tests of s3utils.