### PR TITLE
S3UTILS-211: split coverage directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "description": "Awesome scripts to use when working with S3 at scale",
   "scripts": {
     "lint": "eslint $(git ls-files '*.js')",
-    "test:unit": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js --coverage --testPathPattern='tests/unit/[\\w/-]+\\.[tj]s'",
-    "test:functional": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js  --coverage --testPathPattern='tests/functional/[\\w/-]+\\.[tj]s'"
+    "test:unit": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js --coverage --coverageDirectory=coverage/unit --testPathPattern='tests/unit/[\\w/-]+\\.[tj]s'",
+    "test:functional": "LOCATION_CONFIG_FILE='tests/conf/locationConfig.json' yarn jest --verbose --logHeapUsage --projects jest.config.js --coverage --coverageDirectory=coverage/functional --testPathPattern='tests/functional/[\\w/-]+\\.[tj]s'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With the way the CI is set, executing the ft tests after the unit tests erase the coverage knowledge of the unit tests. Now keeping them in separate folders so we can upload the full picture to codecov.