### PR TITLE
S3UTILS-214 improve codecov config and experience

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: tests
 on:
   push:
     branches-ignore:
-      - development/**
       - q/*/**
 
 concurrency:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,10 +1,18 @@
 ---
 
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
   notify:
-    wait_for_ci: yes
+    wait_for_ci: true
+    after_n_builds: 1
 
 parsers:
   javascript:
     enable_partials: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
Couple of things, we need to build on the default branch for codecov to have a base upon it will make comparisons when PRs are made.

Second is the condition upon codecov will send a check as a failure or not depending on how much coverage is added or removed on each new PR