### PR TITLE
Add tool to fix missing CRR replication permissions

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -59,10 +59,10 @@ gh pr diff <number> --repo <owner/repo>
 For each specific issue, post a comment on the exact file and line:
 
 ```bash
-gh api -X POST -H "Accept: application/vnd.github+json" "repos/<owner/repo>/pulls/<number>/comments" -f body=$'Your comment\n\n— Claude Code' -f path="path/to/file" -F line=<line_number> -f side="RIGHT" -f commit_id="<headRefOid>"
+gh api -X POST -H "Accept: application/vnd.github+json" "repos/<owner/repo>/pulls/<number>/comments" -f body="Your comment<br><br>— Claude Code" -f path="path/to/file" -F line=<line_number> -f side="RIGHT" -f commit_id="<headRefOid>"
 ```
 
-**The command must stay on a single bash line.** Use `$'...'` quoting for the `-f body=` value, with `\n` for line breaks. Never use `<br>` — it renders as literal text inside code blocks and suggestion blocks.
+**The command must stay on a single bash line.** Never use newlines in bash commands — use `<br>` for line breaks in comment bodies. Never put `<br>` inside code blocks or suggestion blocks — use `\n` within `$'...'` quoting only for content inside fenced code blocks.
 
 Each inline comment must:
 - Be short and direct — say what's wrong, why it's wrong, and how to fix it in 1-3 sentences
@@ -76,7 +76,7 @@ Each inline comment must:
   Only suggest when you can show the exact replacement. For architectural or design issues, just describe the problem.
   Example with a suggestion block:
   ```bash
-  gh api ... -f body=$'Missing the shared-guidelines update command.\n\n```suggestion\n/plugin update shared-guidelines@scality-agent-hub\n/plugin update scality-skills@scality-agent-hub\n```\n\n— Claude Code' ...
+  gh api ... -f body=$'Missing the shared-guidelines update command.<br><br>```suggestion\n/plugin update shared-guidelines@scality-agent-hub\n/plugin update scality-skills@scality-agent-hub\n```<br><br>— Claude Code' ...
   ```
 - Escape single quotes inside `$'...'` as `\'` (e.g., `don\'t`)
 - End with: `— Claude Code`
@@ -86,10 +86,10 @@ Use the line number from the **new version** of the file (the line number you'd 
 #### Part B: Summary comment
 
 ```bash
-gh pr comment <number> --repo <owner/repo> --body $'LGTM\n\nReview by Claude Code'
+gh pr comment <number> --repo <owner/repo> --body "LGTM<br><br>Review by Claude Code"
 ```
 
-**The command must stay on a single bash line.** Use `$'...'` quoting with `\n` for line breaks.
+**The command must stay on a single bash line.** Never use newlines in bash commands — use `<br>` for line breaks in comment bodies. Never put `<br>` inside code blocks or suggestion blocks.
 
 Do not describe or summarize the PR. For each issue, state the problem on one line, then list one or more suggestions below it:
 

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,3 +14,10 @@ jobs:
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
+        with:
+          # aws-sdk v2 is intentionally used as a devDependency because the
+          # fix-missing-replication-permissions script runs inside the vault
+          # container of older S3C versions (pre-9.5.2) where only v2 is
+          # available. This low-severity advisory is informational (no patch
+          # exists, v2 is end-of-life).
+          allow-ghsas: GHSA-j965-2qgj-vjmq

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/scality/s3utils#readme",
   "dependencies": {
-    "@aws-sdk/client-iam": "^3.962.0",
     "@aws-sdk/client-s3": "^3.873.0",
     "@aws-sdk/node-http-handler": "^3.374.0",
     "@scality/cloudserverclient": "^1.0.4",
@@ -55,6 +54,8 @@
     "string-width": "4.2.3"
   },
   "devDependencies": {
+    "@aws-sdk/client-iam": "^3.962.0",
+    "aws-sdk": "^2.1692.0",
     "@scality/eslint-config-scality": "scality/Guidelines#8.3.0",
     "@sinonjs/fake-timers": "^14.0.0",
     "eslint": "^9.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "engines": {
     "node": ">= 22"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/scality/s3utils#readme",
   "dependencies": {
+    "@aws-sdk/client-iam": "^3.962.0",
     "@aws-sdk/client-s3": "^3.873.0",
     "@aws-sdk/node-http-handler": "^3.374.0",
     "@scality/cloudserverclient": "^1.0.4",
@@ -54,7 +55,6 @@
     "string-width": "4.2.3"
   },
   "devDependencies": {
-    "@aws-sdk/client-iam": "^3.962.0",
     "@scality/eslint-config-scality": "scality/Guidelines#8.3.0",
     "@sinonjs/fake-timers": "^14.0.0",
     "eslint": "^9.14.0",

--- a/replicationAudit/README.md
+++ b/replicationAudit/README.md
@@ -1,12 +1,15 @@
 # TL;DR Complete Workflow Example
 
-Here's a complete example running the two scripts and audit the IAM policies used by CRR:
+Here's a complete example running the two scripts and audit the IAM policies used by CRR.
+
+Use the fix-missing-replication-permissions.js script (step 7) to correct any missing permissions found by the check script. If the fix script fails with "missing ownerDisplayName", re-run check-replication-permissions.js — this field was added in s3utils 1.17.5.
 
 From your local machine: copy scripts to the supervisor
 
 ```bash
 scp replicationAudit/list-buckets-with-replication.sh root@<supervisor-ip>:/root/
 scp replicationAudit/check-replication-permissions.js root@<supervisor-ip>:/root/
+scp replicationAudit/fix-missing-replication-permissions.js root@<supervisor-ip>:/root/
 ```
 
 Connect to the supervisor
@@ -26,6 +29,8 @@ ansible -i env/$ENV_DIR/inventory runners_s3[0] -m copy \
     -a 'src=/root/list-buckets-with-replication.sh dest=/root/'
 ansible -i env/$ENV_DIR/inventory runners_s3[0] -m copy \
     -a 'src=/root/check-replication-permissions.js dest={{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs'
+ansible -i env/$ENV_DIR/inventory runners_s3[0] -m copy \
+    -a 'src=/root/fix-missing-replication-permissions.js dest={{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs'
 
 # Step 2: Run list-buckets-with-replication.sh
 ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
@@ -50,19 +55,34 @@ ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
     -a 'cat {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/missing.json' \
     | grep -v CHANGED | tee /root/replicationAudit_missing.json
 
-# Step 6: Clean up remote files
+# Step 6: Fix missing permissions
+# Copy admin credentials and missing.json to vault container and run inside it
+ansible -i env/$ENV_DIR/inventory runners_s3[0] -m copy \
+    -a "src=/srv/scality/s3/s3-offline/federation/env/$ENV_DIR/vault/admin-clientprofile/admin1.json dest={{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs"
+
+ansible -i env/$ENV_DIR/inventory runners_s3[0] -m copy \
+    -a 'src=/root/replicationAudit_missing.json dest={{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/missing.json'
+
+ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
+    -a 'ctrctl exec scality-vault{{ container_name_suffix | default("")}} env NODE_PATH=/home/scality/vault/node_modules node /logs/fix-missing-replication-permissions.js \
+        /logs/missing.json localhost /logs/admin1.json /logs/replication-fix-results.json'
+
+# Retrieve fix results
+ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
+    -a 'cat {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/replication-fix-results.json' \
+    | grep -v CHANGED | tee /root/replicationAudit_fix_results.json
+
+# Step 7: Re-run check to verify fixes (repeat steps 3-5)
+
+# Step 8: Clean up remote files
 ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
     -a 'rm -f {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/missing.json \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/check-replication-permissions.js \
+       {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/fix-missing-replication-permissions.js \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/buckets-with-replication.json \
+       {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/replication-fix-results.json \
+       {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/admin1.json \
        /root/list-buckets-with-replication.sh'
-
-# Step 7 (optional): Fix missing permissions
-# Run from your local machine (requires vaultclient and @aws-sdk/client-iam)
-node replicationAudit/fix-missing-replication-permissions.js \
-    /root/replicationAudit_missing.json <supervisor-ip> admin1.json
-
-# Step 8: Re-run check to verify fixes (repeat steps 3-5)
 ```
 
 # Scripts Documentation
@@ -497,8 +517,7 @@ if the policy already exists, its document is guaranteed to be identical.
   ```
   /srv/scality/s3/s3-offline/federation/env/<ENV_DIR>/vault/admin-clientprofile/admin1.json
   ```
-- Network access to Vault admin/IAM API (port 8600) from the machine running the script
-- `vaultclient` and `@aws-sdk/client-iam` installed (both in s3utils dependencies)
+- The script runs inside the vault container (`scality-vault`), which has `vaultclient` and `aws-sdk` pre-installed
 
 ### Usage
 
@@ -509,7 +528,7 @@ node fix-missing-replication-permissions.js <input-file> <vault-host> <admin-con
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `input-file` | (required) | Path to missing.json from check script |
-| `vault-host` | (required) | Vault admin host (e.g., 13.50.166.21) |
+| `vault-host` | (required) | Vault admin host (use `localhost` when running inside the vault container) |
 | `admin-config` | (required) | Path to admin credentials JSON |
 | `output-file` | replication-fix-results.json | Output file path |
 | `--iam-port <port>` | 8600 | Vault admin and IAM API port |

--- a/replicationAudit/README.md
+++ b/replicationAudit/README.md
@@ -50,12 +50,19 @@ ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
     -a 'cat {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/missing.json' \
     | grep -v CHANGED | tee /root/replicationAudit_missing.json
 
-# Step 6: Clean up
+# Step 6: Clean up remote files
 ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
     -a 'rm -f {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/missing.json \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/check-replication-permissions.js \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/buckets-with-replication.json \
        /root/list-buckets-with-replication.sh'
+
+# Step 7 (optional): Fix missing permissions
+# Run from your local machine (requires vaultclient and @aws-sdk/client-iam)
+node replicationAudit/fix-missing-replication-permissions.js \
+    /root/replicationAudit_missing.json <supervisor-ip> admin1.json
+
+# Step 8: Re-run check to verify fixes (repeat steps 3-5)
 ```
 
 # Scripts Documentation
@@ -285,6 +292,13 @@ node check-replication-permissions.js [input-file] [leader-ip] [output-file] [--
 
 ### Output Format
 
+> **Breaking change (since 1.17.5):** The output now includes `ownerDisplayName`
+> in each result entry. This field is required by
+> `fix-missing-replication-permissions.js` to identify accounts without an
+> extra API call. If you ran `check-replication-permissions.js` on version
+> 1.17.4 or earlier, **re-run it** to produce an output that
+> `fix-missing-replication-permissions.js` can consume.
+
 The script produces a JSON file with metadata and results. The `results` array
 contains **only buckets missing the `s3:ReplicateObject` permission**.
 
@@ -310,6 +324,7 @@ contains **only buckets missing the `s3:ReplicateObject` permission**.
   "results": [
     {
       "bucket": "bucket-old-1",
+      "ownerDisplayName": "testaccount",
       "sourceRole": "arn:aws:iam::267390090509:role/crr-role-outdated",
       "policies": [
         {
@@ -461,3 +476,181 @@ Output saved to: /tmp/missing.json
 **Script timeout**
 
 - For many buckets, run directly on the S3 connector node via interactive SSH
+
+---
+
+## fix-missing-replication-permissions.js
+
+Reads the output of `check-replication-permissions.js` and creates IAM policies
+with `s3:ReplicateObject` for roles that are missing it.
+
+The script applies **minimal changes**: one policy per bucket, with an explicit
+Statement ID (`AllowReplicateObjectAuditFix`) so the policies are easily
+identifiable later. Using one policy per bucket makes re-runs truly idempotent:
+if the policy already exists, its document is guaranteed to be identical.
+
+### Prerequisites
+
+- Output from `check-replication-permissions.js` (missing.json)
+- Vault admin credentials (`admin1.json` with `accessKey` and `secretKeyValue`).
+  Found on the supervisor at:
+  ```
+  /srv/scality/s3/s3-offline/federation/env/<ENV_DIR>/vault/admin-clientprofile/admin1.json
+  ```
+- Network access to Vault admin/IAM API (port 8600) from the machine running the script
+- `vaultclient` and `@aws-sdk/client-iam` installed (both in s3utils dependencies)
+
+### Usage
+
+```bash
+node fix-missing-replication-permissions.js <input-file> <vault-host> <admin-config> [output-file] [options]
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `input-file` | (required) | Path to missing.json from check script |
+| `vault-host` | (required) | Vault admin host (e.g., 13.50.166.21) |
+| `admin-config` | (required) | Path to admin credentials JSON |
+| `output-file` | replication-fix-results.json | Output file path |
+| `--iam-port <port>` | 8600 | Vault admin and IAM API port |
+| `--https` | (not set) | Use HTTPS to connect to Vault |
+| `--dry-run` | (not set) | Show what would be done without making changes |
+
+### How It Works
+
+1. **Reads** the missing permissions file and enriches each entry with parsed role fields
+2. **Maps** account IDs to names using `ownerDisplayName` from the input (no API call)
+3. For each bucket entry (grouped by account for credential reuse):
+   - **Generates** a temporary access key via vault admin API (15-minute auto-expiry)
+   - **Creates** one IAM policy per bucket with `s3:ReplicateObject`
+   - **Attaches** the policy to the role
+   - **Deletes** the temporary access key (falls back to auto-expiry on failure)
+4. **Writes** results to the output file
+
+### Policy Created
+
+For each bucket, the script creates a policy named
+`s3-replication-audit-fix-<bucketName>`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowReplicateObjectAuditFix",
+    "Effect": "Allow",
+    "Action": "s3:ReplicateObject",
+    "Resource": "arn:aws:s3:::bucket-old-1/*"
+  }]
+}
+```
+
+### Output Format
+
+```json
+{
+  "metadata": {
+    "timestamp": "2026-02-23T20:35:00.000Z",
+    "durationMs": 65,
+    "inputFile": "missing.json",
+    "dryRun": false,
+    "counts": {
+      "totalBucketsProcessed": 3,
+      "totalBucketsFixed": 3,
+      "policiesCreated": 3,
+      "policiesAttached": 3,
+      "keysCreated": 1,
+      "keysDeleted": 1,
+      "errors": 0
+    }
+  },
+  "fixes": [
+    {
+      "accountId": "267390090509",
+      "accountName": "testaccount",
+      "roleName": "crr-role-outdated",
+      "roleArn": "arn:aws:iam::267390090509:role/crr-role-outdated",
+      "policyName": "s3-replication-audit-fix-bucket-old-1",
+      "policyArn": "arn:aws:iam::267390090509:policy/s3-replication-audit-fix-bucket-old-1",
+      "bucket": "bucket-old-1",
+      "status": "success"
+    },
+    {
+      "accountId": "267390090509",
+      "accountName": "testaccount",
+      "roleName": "crr-role-outdated",
+      "roleArn": "arn:aws:iam::267390090509:role/crr-role-outdated",
+      "policyName": "s3-replication-audit-fix-bucket-old-2",
+      "policyArn": "arn:aws:iam::267390090509:policy/s3-replication-audit-fix-bucket-old-2",
+      "bucket": "bucket-old-2",
+      "status": "success"
+    }
+  ],
+  "errors": []
+}
+```
+
+### Example Run
+
+```
+=== Fix Missing Replication Permissions ===
+Input:  missing.json
+Output: replication-fix-results.json
+Vault/IAM: 13.50.166.21:8600
+
+Processing 3 bucket(s)
+
+[1/3] Bucket "bucket-old-1" — role "crr-role-outdated" — account "testaccount"
+  Created policy "s3-replication-audit-fix-bucket-old-1"
+  Attached policy to role "crr-role-outdated"
+[2/3] Bucket "bucket-old-2" — role "crr-role-outdated" — account "testaccount"
+  Created policy "s3-replication-audit-fix-bucket-old-2"
+  Attached policy to role "crr-role-outdated"
+[3/3] Bucket "bucket-old-3" — role "crr-role-outdated" — account "testaccount"
+  Created policy "s3-replication-audit-fix-bucket-old-3"
+  Attached policy to role "crr-role-outdated"
+Deleted temp key for account "testaccount" (267390090509)
+
+=== Summary ===
+Buckets processed:     3
+Buckets fixed:         3
+Policies created:      3
+Policies attached:     3
+Keys created:          1
+Keys deleted:          1
+Errors:                0
+Duration:              0.7s
+Output saved to: replication-fix-results.json
+
+Done.
+```
+
+### Idempotency
+
+The script is safe to run multiple times:
+
+- Each bucket has its own policy, so if it already exists the document is
+  guaranteed to be identical — `EntityAlreadyExists` is a true no-op
+- Attaching an already-attached policy is a no-op in IAM
+- Temporary access keys auto-expire after 15 minutes even if deletion fails
+
+### Troubleshooting
+
+**"No ownerDisplayName found for account"**
+
+- The input file is missing `ownerDisplayName`. Re-run `check-replication-permissions.js`
+  to generate a fresh output that includes this field.
+
+**"Failed to generate temp key"**
+
+- Verify admin credentials in the config file
+- Ensure vault admin API is reachable on the specified host and port
+
+**IAM operation errors**
+
+- Check that the IAM port is correct (default 8600, may differ per deployment)
+- Verify the role still exists in vault
+
+**"Failed to delete temp key"**
+
+- Non-critical: the key auto-expires after 15 minutes
+- The error is logged but does not prevent other operations

--- a/replicationAudit/README.md
+++ b/replicationAudit/README.md
@@ -46,7 +46,7 @@ ansible -i env/$ENV_DIR/inventory md1-cluster1 -m shell \
 LEADER_IP=<leader-ip-from-step-3>
 
 ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
-    -a "mv /root/buckets-with-replication.json {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs && \
+    -a "cp /root/buckets-with-replication.json {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs && \
         ctrctl exec scality-vault{{ container_name_suffix | default("")}} node /logs/check-replication-permissions.js \
         /logs/buckets-with-replication.json $LEADER_IP /logs/missing.json"
 
@@ -82,7 +82,8 @@ ansible -i env/$ENV_DIR/inventory runners_s3[0] -m shell \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/buckets-with-replication.json \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/replication-fix-results.json \
        {{ env_host_logs}}/scality-vault{{ container_name_suffix | default("")}}/logs/admin1.json \
-       /root/list-buckets-with-replication.sh'
+       /root/list-buckets-with-replication.sh \
+       /root/buckets-with-replication.json'
 ```
 
 # Scripts Documentation

--- a/replicationAudit/check-replication-permissions.js
+++ b/replicationAudit/check-replication-permissions.js
@@ -421,7 +421,7 @@ async function main() {
 
     // Process each bucket
     for (let i = 0; i < buckets.length; i++) {
-        const { bucket, sourceRole } = buckets[i];
+        const { bucket, sourceRole, ownerDisplayName } = buckets[i];
 
         if (!sourceRole) {
             logProgress(i + 1, buckets.length, bucket, 'SKIP (no role)');
@@ -440,12 +440,12 @@ async function main() {
             } else {
                 const reason = result.error || 's3:ReplicateObject';
                 logProgress(i + 1, buckets.length, bucket, `MISSING: ${reason}`);
-                results.push(result);
+                results.push({ ...result, ownerDisplayName });
                 stats.missing++;
             }
         } catch (e) {
             logProgress(i + 1, buckets.length, bucket, `ERROR: ${e.message}`);
-            results.push({ bucket, sourceRole, error: e.message, policies: [] });
+            results.push({ bucket, sourceRole, ownerDisplayName, error: e.message, policies: [] });
             stats.errors++;
         }
     }

--- a/replicationAudit/fix-missing-replication-permissions.js
+++ b/replicationAudit/fix-missing-replication-permissions.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * fix-missing-replication-permissions.js
+ *
+ * Reads the output of check-replication-permissions.js and creates IAM policies
+ * with s3:ReplicateObject for roles that are missing it, then attaches them.
+ *
+ * TBD: This script does not re-check whether the permission is still missing
+ * before applying the fix. It only checks that a policy named
+ * s3-replication-audit-fix-<bucketName> exists (EntityAlreadyExists) to make
+ * the script idempotent — re-running it won't create extra policies. But:
+ *   - If someone manually added s3:ReplicateObject between check and fix,
+ *     a redundant (but harmless) policy is created.
+ *   - If the fix policy is later modified externally, re-running won't
+ *     detect or correct it (EntityAlreadyExists skips the policy).
+ * We keep it simple today: the intended workflow is check → fix → re-check.
+ * Re-run check-replication-permissions.js after fixing to verify the result.
+ *
+ * Usage: node fix-missing-replication-permissions.js <input-file> <vault-host> <admin-config> [output-file] [--iam-port <port>] [--https] [--dry-run]
+ *
+ * Requires: vaultclient, @aws-sdk/client-iam (both in s3utils dependencies)
+ */
+
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const { parseArgs } = require('util');
+const { Client: VaultClient } = require('vaultclient');
+const {
+    IAMClient,
+    CreatePolicyCommand,
+    AttachRolePolicyCommand,
+    DeleteAccessKeyCommand,
+} = require('@aws-sdk/client-iam');
+const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+
+// ===========================================================================
+// Constants
+// ===========================================================================
+const POLICY_PREFIX = 's3-replication-audit-fix';
+const STATEMENT_ID = 'AllowReplicateObjectAuditFix';
+const KEY_DURATION_SECONDS = '900'; // 15-minute auto-expiry safety net
+
+// ===========================================================================
+// Logging (stderr for progress, stdout reserved for JSON result)
+// ===========================================================================
+function log(message) {
+    console.error(message);
+}
+
+// ===========================================================================
+// Argument parsing (Node.js 22+ built-in util.parseArgs)
+// ===========================================================================
+function getConfig() {
+    const { values, positionals } = parseArgs({
+        allowPositionals: true,
+        options: {
+            'iam-port': { type: 'string', default: '8600' },
+            'https': { type: 'boolean', default: false },
+            'dry-run': { type: 'boolean', default: false },
+        },
+    });
+
+    if (positionals.length < 3) {
+        log('Usage: node fix-missing-replication-permissions.js'
+            + ' <input-file> <vault-host> <admin-config>'
+            + ' [output-file] [--iam-port <port>] [--https] [--dry-run]');
+        process.exit(1);
+    }
+
+    const [inputFile, vaultHost, adminConfig, outputFile] = positionals;
+    return {
+        inputFile,
+        vaultHost,
+        iamPort: parseInt(values['iam-port'], 10),
+        adminConfig,
+        useHttps: values.https,
+        outputFile: outputFile || 'replication-fix-results.json',
+        dryRun: values['dry-run'],
+    };
+}
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+/** Parse role ARN to extract account ID and role name */
+function parseRoleArn(arn) {
+    const match = arn.match(/^arn:aws:iam::(\d+):role\/(.+)$/);
+    if (!match) {
+        throw new Error(`Invalid role ARN: ${arn}`);
+    }
+    return { accountId: match[1], roleName: match[2] };
+}
+
+/** Build the IAM policy document for a single bucket */
+function buildPolicyDocument(bucket) {
+    return {
+        Version: '2012-10-17',
+        Statement: [{
+            Sid: STATEMENT_ID,
+            Effect: 'Allow',
+            Action: 's3:ReplicateObject',
+            Resource: `arn:aws:s3:::${bucket}/*`,
+        }],
+    };
+}
+
+function generateAccountAccessKeyAsync(client, accountName, options) {
+    return new Promise((resolve, reject) => {
+        client.generateAccountAccessKey(accountName, (err, res) => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(res);
+        }, options);
+    });
+}
+
+/** Create an IAM client for a given account */
+function createIAMClient(config, accessKeyId, secretKey) {
+    const protocol = config.useHttps ? 'https' : 'http';
+    return new IAMClient({
+        region: 'us-east-1',
+        endpoint: `${protocol}://${config.vaultHost}:${config.iamPort}`,
+        credentials: { accessKeyId, secretAccessKey: secretKey },
+        requestHandler: new NodeHttpHandler({
+            httpAgent: new http.Agent({ keepAlive: true }),
+            // TBD: rejectUnauthorized: false disables certificate validation.
+            // Consider accepting a CA cert path via CLI option instead.
+            httpsAgent: new https.Agent({
+                keepAlive: true,
+                rejectUnauthorized: false,
+            }),
+        }),
+    });
+}
+
+
+// ===========================================================================
+// Main
+// ===========================================================================
+async function main() {
+    const startTime = Date.now();
+    const config = getConfig();
+
+    log('=== Fix Missing Replication Permissions ===');
+    log(`Input:  ${config.inputFile}`);
+    log(`Output: ${config.outputFile}`);
+    log(`Vault/IAM: ${config.vaultHost}:${config.iamPort}`);
+    if (config.dryRun) {
+        log('Mode:   DRY-RUN (no changes will be made)');
+    }
+    log('');
+
+    // Read input
+    const input = JSON.parse(fs.readFileSync(config.inputFile, 'utf8'));
+    const entries = input.results || [];
+    if (entries.length === 0) {
+        log('No buckets with missing permissions. Nothing to fix.');
+        process.exit(0);
+    }
+
+    // Validate input format: ownerDisplayName is required (added in 1.17.5)
+    const missingOwner = entries.filter(e => !e.ownerDisplayName);
+    if (missingOwner.length > 0) {
+        log('ERROR: Input file is missing "ownerDisplayName" field in result entries.');
+        log('This field was added in s3utils 1.17.5. If your input was generated');
+        log('with version 1.17.4 or earlier, re-run check-replication-permissions.js');
+        log('to produce an updated output.');
+        process.exit(1);
+    }
+
+    // Sort by sourceRole so entries in the same account are processed
+    // consecutively, maximising credential cache hits.
+    entries.sort((a, b) => (a.sourceRole < b.sourceRole ? -1 : 1));
+
+    log(`Processing ${entries.length} bucket(s)`);
+    log('');
+
+    // Read admin credentials
+    const adminCreds = JSON.parse(fs.readFileSync(config.adminConfig, 'utf8'));
+
+    // Create vault admin client
+    const vaultAdmin = new VaultClient(
+        config.vaultHost,
+        config.iamPort,
+        config.useHttps,   // useHttps
+        undefined,         // key
+        undefined,         // cert
+        undefined,         // ca
+        config.useHttps,   // ignoreCa (skip cert verification when using HTTPS)
+        adminCreds.accessKey,
+        adminCreds.secretKeyValue,
+    );
+
+    // Results tracking
+    const outcome = {
+        metadata: {
+            timestamp: new Date().toISOString(),
+            durationMs: 0,
+            inputFile: config.inputFile,
+            dryRun: config.dryRun,
+            counts: {
+                totalBucketsProcessed: entries.length,
+                totalBucketsFixed: 0,
+                policiesCreated: 0,
+                policiesAttached: 0,
+                keysCreated: 0,
+                keysDeleted: 0,
+                errors: 0,
+            },
+        },
+        fixes: [],
+        errors: [],
+    };
+
+    // Cache IAM client per account to reuse connections across buckets
+    // and for cleanup (key deletion).
+    // Map<accountId, { accountName, accessKeyId, iamClient }>
+    const accountCache = new Map();
+
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const { accountId, roleName } = parseRoleArn(entry.sourceRole);
+        const { bucket, ownerDisplayName: accountName } = entry;
+        const policyName = `${POLICY_PREFIX}-${bucket}`;
+        const policyDocument = buildPolicyDocument(bucket);
+
+        log(`[${i + 1}/${entries.length}] Bucket "${bucket}" — role "${roleName}" — account "${accountName}"`);
+
+        const fix = {
+            accountId,
+            accountName,
+            roleName,
+            roleArn: entry.sourceRole,
+            policyName,
+            bucket,
+            status: 'pending',
+        };
+
+        if (config.dryRun) {
+            fix.status = 'dry-run';
+            log(`  [DRY-RUN] Would create policy "${policyName}"`);
+            log(`  [DRY-RUN] Would attach to role "${roleName}"`);
+            outcome.fixes.push(fix);
+            continue;
+        }
+
+        try {
+            // Get or create temporary credentials and IAM client for this account
+            if (!accountCache.has(accountId)) {
+                const keyResult = await generateAccountAccessKeyAsync(
+                    vaultAdmin, accountName,
+                    { durationSeconds: KEY_DURATION_SECONDS },
+                );
+                accountCache.set(accountId, {
+                    accountName,
+                    accessKeyId: keyResult.id,
+                    iamClient: createIAMClient(config, keyResult.id, keyResult.value),
+                });
+                outcome.metadata.counts.keysCreated++;
+            }
+
+            const { iamClient } = accountCache.get(accountId);
+
+            // Idempotent/safe to re-run: each bucket has its own policy,
+            // so EntityAlreadyExists means the exact same policy document
+            // already exists — a true no-op. AttachRolePolicy is also
+            // a no-op if the policy is already attached to the role.
+            let policyArn;
+            try {
+                const resp = await iamClient.send(new CreatePolicyCommand({
+                    PolicyName: policyName,
+                    PolicyDocument: JSON.stringify(policyDocument),
+                }));
+                policyArn = resp.Policy.Arn;
+                outcome.metadata.counts.policiesCreated++;
+                log(`  Created policy "${policyName}"`);
+            } catch (err) {
+                if (err.name === 'EntityAlreadyExistsException'
+                    || err.Code === 'EntityAlreadyExists') {
+                    policyArn = `arn:aws:iam::${accountId}:policy/${policyName}`;
+                    log(`  Policy "${policyName}" already exists, skipping`);
+                } else {
+                    throw err;
+                }
+            }
+
+            fix.policyArn = policyArn;
+
+            await iamClient.send(new AttachRolePolicyCommand({
+                RoleName: roleName,
+                PolicyArn: policyArn,
+            }));
+            outcome.metadata.counts.policiesAttached++;
+            log(`  Attached policy to role "${roleName}"`);
+
+            fix.status = 'success';
+            outcome.metadata.counts.totalBucketsFixed++;
+        } catch (err) {
+            fix.status = 'error';
+            fix.error = err.message;
+            outcome.metadata.counts.errors++;
+            outcome.errors.push({
+                accountId,
+                accountName,
+                roleName,
+                bucket,
+                policyName,
+                message: err.message,
+            });
+            log(`  ERROR: ${err.message}`);
+        }
+
+        outcome.fixes.push(fix);
+    }
+
+    // Cleanup: delete all temporary keys via IAM DeleteAccessKey
+    for (const [accountId, { accountName, accessKeyId, iamClient }] of accountCache) {
+        try {
+            await iamClient.send(new DeleteAccessKeyCommand({
+                AccessKeyId: accessKeyId,
+            }));
+            outcome.metadata.counts.keysDeleted++;
+            log(`Deleted temp key for account "${accountName}" (${accountId})`);
+        } catch (err) {
+            log(`WARNING: Failed to delete temp key for account "${accountName}" (auto-expires in ${KEY_DURATION_SECONDS}s): ${err.message}`);
+        }
+    }
+
+    // Finalize timing
+    const durationMs = Date.now() - startTime;
+    outcome.metadata.durationMs = durationMs;
+
+    // Write output file
+    fs.writeFileSync(config.outputFile, JSON.stringify(outcome, null, 2));
+
+    // Print summary
+    log('\n=== Summary ===');
+    log(`Buckets processed:     ${outcome.metadata.counts.totalBucketsProcessed}`);
+    log(`Buckets fixed:         ${outcome.metadata.counts.totalBucketsFixed}`);
+    log(`Policies created:      ${outcome.metadata.counts.policiesCreated}`);
+    log(`Policies attached:     ${outcome.metadata.counts.policiesAttached}`);
+    log(`Keys created:          ${outcome.metadata.counts.keysCreated}`);
+    log(`Keys deleted:          ${outcome.metadata.counts.keysDeleted}`);
+    log(`Errors:                ${outcome.metadata.counts.errors}`);
+    log(`Duration:              ${(durationMs / 1000).toFixed(1)}s`);
+    log(`Output saved to: ${config.outputFile}`);
+    log('');
+    log('Done.');
+
+    // JSON result to stdout
+    console.log(JSON.stringify(outcome, null, 2));
+
+    process.exit(0);
+}
+
+main().catch(e => {
+    console.error('Fatal error:', e.message);
+    process.exit(1);
+});

--- a/replicationAudit/fix-missing-replication-permissions.js
+++ b/replicationAudit/fix-missing-replication-permissions.js
@@ -19,7 +19,12 @@
  *
  * Usage: node fix-missing-replication-permissions.js <input-file> <vault-host> <admin-config> [output-file] [--iam-port <port>] [--https] [--dry-run]
  *
- * Requires: vaultclient, @aws-sdk/client-iam (both in s3utils dependencies)
+ * Requires: vaultclient, aws-sdk (both available in vault container)
+ *
+ * Note: This script uses aws-sdk v2 (not @aws-sdk/client-iam v3) because it
+ * is meant to be copied into the vault container of older S3C versions
+ * (before S3C 9.5.2 / Vault 7.84.0) where aws-sdk v2 is available but
+ * @aws-sdk/client-iam v3 is not.
  */
 
 const fs = require('fs');
@@ -27,13 +32,7 @@ const http = require('http');
 const https = require('https');
 const { parseArgs } = require('util');
 const { Client: VaultClient } = require('vaultclient');
-const {
-    IAMClient,
-    CreatePolicyCommand,
-    AttachRolePolicyCommand,
-    DeleteAccessKeyCommand,
-} = require('@aws-sdk/client-iam');
-const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+const AWS = require('aws-sdk');
 
 // ===========================================================================
 // Constants
@@ -121,19 +120,17 @@ function generateAccountAccessKeyAsync(client, accountName, options) {
 /** Create an IAM client for a given account */
 function createIAMClient(config, accessKeyId, secretKey) {
     const protocol = config.useHttps ? 'https' : 'http';
-    return new IAMClient({
-        region: 'us-east-1',
+    return new AWS.IAM({
         endpoint: `${protocol}://${config.vaultHost}:${config.iamPort}`,
-        credentials: { accessKeyId, secretAccessKey: secretKey },
-        requestHandler: new NodeHttpHandler({
-            httpAgent: new http.Agent({ keepAlive: true }),
-            // TBD: rejectUnauthorized: false disables certificate validation.
-            // Consider accepting a CA cert path via CLI option instead.
-            httpsAgent: new https.Agent({
-                keepAlive: true,
-                rejectUnauthorized: false,
-            }),
-        }),
+        region: 'us-east-1',
+        accessKeyId,
+        secretAccessKey: secretKey,
+        sslEnabled: config.useHttps,
+        httpOptions: {
+            agent: config.useHttps
+                ? new https.Agent({ keepAlive: true, rejectUnauthorized: false })
+                : new http.Agent({ keepAlive: true }),
+        },
     });
 }
 
@@ -271,16 +268,15 @@ async function main() {
             // a no-op if the policy is already attached to the role.
             let policyArn;
             try {
-                const resp = await iamClient.send(new CreatePolicyCommand({
+                const resp = await iamClient.createPolicy({
                     PolicyName: policyName,
                     PolicyDocument: JSON.stringify(policyDocument),
-                }));
+                }).promise();
                 policyArn = resp.Policy.Arn;
                 outcome.metadata.counts.policiesCreated++;
                 log(`  Created policy "${policyName}"`);
             } catch (err) {
-                if (err.name === 'EntityAlreadyExistsException'
-                    || err.Code === 'EntityAlreadyExists') {
+                if (err.code === 'EntityAlreadyExists') {
                     policyArn = `arn:aws:iam::${accountId}:policy/${policyName}`;
                     log(`  Policy "${policyName}" already exists, skipping`);
                 } else {
@@ -290,10 +286,10 @@ async function main() {
 
             fix.policyArn = policyArn;
 
-            await iamClient.send(new AttachRolePolicyCommand({
+            await iamClient.attachRolePolicy({
                 RoleName: roleName,
                 PolicyArn: policyArn,
-            }));
+            }).promise();
             outcome.metadata.counts.policiesAttached++;
             log(`  Attached policy to role "${roleName}"`);
 
@@ -320,9 +316,9 @@ async function main() {
     // Cleanup: delete all temporary keys via IAM DeleteAccessKey
     for (const [accountId, { accountName, accessKeyId, iamClient }] of accountCache) {
         try {
-            await iamClient.send(new DeleteAccessKeyCommand({
+            await iamClient.deleteAccessKey({
                 AccessKeyId: accessKeyId,
-            }));
+            }).promise();
             outcome.metadata.counts.keysDeleted++;
             log(`Deleted temp key for account "${accountName}" (${accountId})`);
         } catch (err) {

--- a/tests/functional/replicationAudit/fixMissingReplicationPermissions.js
+++ b/tests/functional/replicationAudit/fixMissingReplicationPermissions.js
@@ -1,0 +1,662 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vaultclient = require('vaultclient');
+const { Logger } = require('werelogs');
+const {
+    CreateBucketCommand,
+    PutBucketVersioningCommand,
+    PutBucketReplicationCommand,
+} = require('@aws-sdk/client-s3');
+const {
+    CreatePolicyCommand,
+    CreateRoleCommand,
+    AttachRolePolicyCommand,
+    ListAttachedRolePoliciesCommand,
+    ListAccessKeysCommand,
+    GetPolicyCommand,
+    GetPolicyVersionCommand,
+} = require('@aws-sdk/client-iam');
+
+const {
+    iamHost,
+    iamPort,
+    adminAccessKeyId,
+    adminSecretAccessKey,
+    createTestAccount,
+    deleteTestAccount,
+} = require('../../utils/S3Setup');
+
+const execFileAsync = promisify(execFile);
+
+const log = new Logger('fixMissingReplicationPermissions:test');
+
+const SCRIPT_PATH = path.resolve(__dirname, '../../../replicationAudit/fix-missing-replication-permissions.js');
+const ROLE_NAME = 'crr-role-test';
+const POLICY_PREFIX = 's3-replication-audit-fix';
+
+/**
+ * Set up CRR on the source account with a role that deliberately
+ * omits s3:ReplicateObject, so the fix script has something to fix.
+ */
+async function configureCrrWithMissingPermission(accountSource, accountDest) {
+    // Enable versioning on both buckets
+    await accountSource.s3Client.send(new PutBucketVersioningCommand({
+        Bucket: accountSource.bucketName,
+        VersioningConfiguration: { Status: 'Enabled' },
+    }));
+    await accountDest.s3Client.send(new PutBucketVersioningCommand({
+        Bucket: accountDest.bucketName,
+        VersioningConfiguration: { Status: 'Enabled' },
+    }));
+
+    // Create a CRR policy that deliberately OMITS s3:ReplicateObject
+    const incompletePolicyDoc = {
+        Version: '2012-10-17',
+        Statement: [
+            {
+                Effect: 'Allow',
+                Action: [
+                    's3:GetObjectVersion',
+                    's3:GetObjectVersionAcl',
+                ],
+                Resource: [`arn:aws:s3:::${accountSource.bucketName}/*`],
+            },
+            {
+                Effect: 'Allow',
+                Action: [
+                    's3:ListBucket',
+                    's3:GetReplicationConfiguration',
+                ],
+                Resource: [`arn:aws:s3:::${accountSource.bucketName}`],
+            },
+        ],
+    };
+
+    await accountSource.iamClient.send(new CreatePolicyCommand({
+        PolicyName: 'crr-policy-incomplete',
+        PolicyDocument: JSON.stringify(incompletePolicyDoc),
+    }));
+
+    // Create trust policy for backbeat
+    const trustDoc = {
+        Version: '2012-10-17',
+        Statement: [{
+            Effect: 'Allow',
+            Principal: { Service: 'backbeat' },
+            Action: 'sts:AssumeRole',
+        }],
+    };
+
+    await accountSource.iamClient.send(new CreateRoleCommand({
+        RoleName: ROLE_NAME,
+        AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+    }));
+
+    await accountSource.iamClient.send(new AttachRolePolicyCommand({
+        RoleName: ROLE_NAME,
+        PolicyArn: `arn:aws:iam::${accountSource.accountId}:policy/crr-policy-incomplete`,
+    }));
+
+    // Also set up destination account role (needed for replication config)
+    const destPolicyDoc = {
+        Version: '2012-10-17',
+        Statement: [{
+            Effect: 'Allow',
+            Action: ['s3:ReplicateObject', 's3:ReplicateDelete'],
+            Resource: `arn:aws:s3:::${accountDest.bucketName}/*`,
+        }],
+    };
+    await accountDest.iamClient.send(new CreatePolicyCommand({
+        PolicyName: 'crr-policy-dest',
+        PolicyDocument: JSON.stringify(destPolicyDoc),
+    }));
+    await accountDest.iamClient.send(new CreateRoleCommand({
+        RoleName: ROLE_NAME,
+        AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+    }));
+    await accountDest.iamClient.send(new AttachRolePolicyCommand({
+        RoleName: ROLE_NAME,
+        PolicyArn: `arn:aws:iam::${accountDest.accountId}:policy/crr-policy-dest`,
+    }));
+
+    // Configure bucket replication on source
+    await accountSource.s3Client.send(new PutBucketReplicationCommand({
+        Bucket: accountSource.bucketName,
+        ReplicationConfiguration: {
+            Role: `arn:aws:iam::${accountSource.accountId}:role/${ROLE_NAME},`
+                + `arn:aws:iam::${accountDest.accountId}:role/${ROLE_NAME}`,
+            Rules: [{
+                Prefix: '',
+                Status: 'Enabled',
+                Destination: {
+                    Bucket: `arn:aws:s3:::${accountDest.bucketName}`,
+                },
+            }],
+        },
+    }));
+}
+
+/**
+ * Build the missing.json input file matching check script output format.
+ */
+function buildInputFile(accountSource) {
+    return {
+        results: [{
+            bucket: accountSource.bucketName,
+            ownerDisplayName: accountSource.accountName,
+            sourceRole: `arn:aws:iam::${accountSource.accountId}:role/${ROLE_NAME}`,
+            policies: [{
+                name: 'crr-policy-incomplete',
+                path: '/',
+                allowsReplicateObject: false,
+            }],
+        }],
+    };
+}
+
+/**
+ * Run the fix script as a child process and return { stdout, stderr, exitCode }.
+ */
+async function runFixScript(args) {
+    try {
+        const { stdout, stderr } = await execFileAsync('node', [SCRIPT_PATH, ...args], {
+            timeout: 30000,
+        });
+        return { stdout, stderr, exitCode: 0 };
+    } catch (err) {
+        return {
+            stdout: err.stdout || '',
+            stderr: err.stderr || '',
+            exitCode: err.code || 1,
+        };
+    }
+}
+
+describe('fix-missing-replication-permissions', () => {
+    let vaultClient;
+    let accountSource;
+    let accountDest;
+    let tmpDir;
+    let adminConfigPath;
+    let inputFilePath;
+    let outputFilePath;
+
+    beforeEach(async () => {
+        vaultClient = new vaultclient.Client(
+            iamHost, iamPort,
+            false, undefined, undefined, undefined, undefined,
+            adminAccessKeyId, adminSecretAccessKey,
+        );
+
+        log.info('Creating test accounts');
+        accountSource = await createTestAccount(vaultClient);
+        accountDest = await createTestAccount(vaultClient);
+        log.info('Test accounts created', {
+            source: accountSource.accountName,
+            dest: accountDest.accountName,
+        });
+
+        await configureCrrWithMissingPermission(accountSource, accountDest);
+
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-repl-test-'));
+
+        adminConfigPath = path.join(tmpDir, 'admin-config.json');
+        fs.writeFileSync(adminConfigPath, JSON.stringify({
+            accessKey: adminAccessKeyId,
+            secretKeyValue: adminSecretAccessKey,
+        }));
+
+        inputFilePath = path.join(tmpDir, 'missing.json');
+        fs.writeFileSync(inputFilePath, JSON.stringify(buildInputFile(accountSource)));
+
+        outputFilePath = path.join(tmpDir, 'output.json');
+    }, 60000);
+
+    afterEach(async () => {
+        await deleteTestAccount(vaultClient, accountSource);
+        await deleteTestAccount(vaultClient, accountDest);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }, 60000);
+
+    it('--dry-run does not modify IAM state', async () => {
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+            '--dry-run',
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        expect(result.fixes[0].status).toBe('dry-run');
+
+        // Verify no policy was attached
+        const attached = await accountSource.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        const auditFixPolicy = (attached.AttachedPolicies || [])
+            .find(p => p.PolicyName === `${POLICY_PREFIX}-${accountSource.bucketName}`);
+        expect(auditFixPolicy).toBeUndefined();
+    }, 30000);
+
+    it('creates policy and attaches it to the role', async () => {
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        expect(result.fixes[0].status).toBe('success');
+        expect(result.metadata.counts.policiesCreated).toBe(1);
+        expect(result.metadata.counts.policiesAttached).toBe(1);
+
+        const bucketPolicyName = `${POLICY_PREFIX}-${accountSource.bucketName}`;
+
+        // Verify policy is attached to role
+        const attached = await accountSource.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        const auditFixPolicy = (attached.AttachedPolicies || [])
+            .find(p => p.PolicyName === bucketPolicyName);
+        expect(auditFixPolicy).toBeDefined();
+
+        // Verify policy document contains s3:ReplicateObject for this bucket
+        const policyArn = `arn:aws:iam::${accountSource.accountId}:policy/${bucketPolicyName}`;
+        const policyResp = await accountSource.iamClient.send(
+            new GetPolicyCommand({ PolicyArn: policyArn }),
+        );
+        const versionId = policyResp.Policy.DefaultVersionId;
+
+        const versionResp = await accountSource.iamClient.send(
+            new GetPolicyVersionCommand({ PolicyArn: policyArn, VersionId: versionId }),
+        );
+        const policyDoc = JSON.parse(decodeURIComponent(versionResp.PolicyVersion.Document));
+        const actions = policyDoc.Statement.flatMap(s => [].concat(s.Action));
+        expect(actions).toContain('s3:ReplicateObject');
+
+        const resources = policyDoc.Statement.flatMap(s => [].concat(s.Resource));
+        expect(resources).toContain(`arn:aws:s3:::${accountSource.bucketName}/*`);
+    }, 30000);
+
+    it('idempotent: re-run does not fail or duplicate', async () => {
+        // First run: creates the policy
+        const first = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+        expect(first.exitCode).toBe(0);
+
+        const firstResult = JSON.parse(first.stdout);
+        expect(firstResult.metadata.counts.policiesCreated).toBe(1);
+
+        // Second run: policy already exists, should reuse it
+        const second = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+        expect(second.exitCode).toBe(0);
+
+        const secondResult = JSON.parse(second.stdout);
+        expect(secondResult.fixes[0].status).toBe('success');
+        expect(secondResult.metadata.counts.policiesCreated).toBe(0);
+
+        // Verify no extra policies were attached to the role
+        const attached = await accountSource.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        const auditFixPolicies = (attached.AttachedPolicies || [])
+            .filter(p => p.PolicyName.startsWith(POLICY_PREFIX));
+        expect(auditFixPolicies).toHaveLength(1);
+    }, 30000);
+
+    it('temp key cleanup: no leftover access keys', async () => {
+        // Snapshot keys before the script runs
+        const keysBefore = await accountSource.iamClient.send(new ListAccessKeysCommand({}));
+        const keyIdsBefore = (keysBefore.AccessKeyMetadata || []).map(k => k.AccessKeyId);
+
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        expect(result.metadata.counts.keysDeleted).toBe(result.metadata.counts.keysCreated);
+
+        // Verify no new keys remain after the script
+        const keysAfter = await accountSource.iamClient.send(new ListAccessKeysCommand({}));
+        const keyIdsAfter = (keysAfter.AccessKeyMetadata || []).map(k => k.AccessKeyId);
+        expect(keyIdsAfter).toEqual(keyIdsBefore);
+    }, 30000);
+
+    it('rejects input without ownerDisplayName', async () => {
+        const badInputPath = path.join(tmpDir, 'bad-missing.json');
+        fs.writeFileSync(badInputPath, JSON.stringify({
+            results: [{
+                bucket: accountSource.bucketName,
+                // ownerDisplayName deliberately omitted
+                sourceRole: `arn:aws:iam::${accountSource.accountId}:role/${ROLE_NAME}`,
+                policies: [],
+            }],
+        }));
+
+        const { exitCode } = await runFixScript([
+            badInputPath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(1);
+    }, 30000);
+});
+
+describe('fix-missing-replication-permissions (multi-bucket and multi-role)', () => {
+    let vaultClient;
+    let accounts;
+    let tmpDir;
+    let adminConfigPath;
+    let outputFilePath;
+
+    beforeEach(() => {
+        vaultClient = new vaultclient.Client(
+            iamHost, iamPort,
+            false, undefined, undefined, undefined, undefined,
+            adminAccessKeyId, adminSecretAccessKey,
+        );
+
+        accounts = [];
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-repl-test-'));
+        adminConfigPath = path.join(tmpDir, 'admin-config.json');
+        fs.writeFileSync(adminConfigPath, JSON.stringify({
+            accessKey: adminAccessKeyId,
+            secretKeyValue: adminSecretAccessKey,
+        }));
+        outputFilePath = path.join(tmpDir, 'output.json');
+    });
+
+    afterEach(async () => {
+        for (const account of accounts) {
+            await deleteTestAccount(vaultClient, account);
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }, 60000);
+
+    it('one role, multiple buckets: one policy per bucket', async () => {
+        const accountSource = await createTestAccount(vaultClient);
+        const accountDest = await createTestAccount(vaultClient);
+        accounts.push(accountSource, accountDest);
+
+        // Create a second bucket in the source account
+        const secondBucket = `${accountSource.bucketName}-second`;
+        await accountSource.s3Client.send(new CreateBucketCommand({ Bucket: secondBucket }));
+
+        // Enable versioning on all buckets
+        await accountSource.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: accountSource.bucketName,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+        await accountSource.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: secondBucket,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+        await accountDest.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: accountDest.bucketName,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+
+        // Create role in source account
+        const trustDoc = {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { Service: 'backbeat' },
+                Action: 'sts:AssumeRole',
+            }],
+        };
+        await accountSource.iamClient.send(new CreateRoleCommand({
+            RoleName: ROLE_NAME,
+            AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+        }));
+
+        // Write input: same role referenced by two buckets
+        const inputFilePath = path.join(tmpDir, 'missing.json');
+        const sourceRole = `arn:aws:iam::${accountSource.accountId}:role/${ROLE_NAME}`;
+        fs.writeFileSync(inputFilePath, JSON.stringify({
+            results: [
+                {
+                    bucket: accountSource.bucketName,
+                    ownerDisplayName: accountSource.accountName,
+                    sourceRole,
+                    policies: [],
+                },
+                {
+                    bucket: secondBucket,
+                    ownerDisplayName: accountSource.accountName,
+                    sourceRole,
+                    policies: [],
+                },
+            ],
+        }));
+
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        // One fix entry per bucket
+        expect(result.fixes).toHaveLength(2);
+        expect(result.fixes.map(f => f.bucket)).toEqual(
+            expect.arrayContaining([accountSource.bucketName, secondBucket]),
+        );
+        // One policy per bucket
+        expect(result.metadata.counts.policiesCreated).toBe(2);
+        expect(result.metadata.counts.totalBucketsFixed).toBe(2);
+
+        // Verify each bucket has its own policy with the correct ARN
+        for (const bucketName of [accountSource.bucketName, secondBucket]) {
+            const policyName = `${POLICY_PREFIX}-${bucketName}`;
+            const policyArn = `arn:aws:iam::${accountSource.accountId}:policy/${policyName}`;
+            const policyResp = await accountSource.iamClient.send(
+                new GetPolicyCommand({ PolicyArn: policyArn }),
+            );
+            const versionResp = await accountSource.iamClient.send(
+                new GetPolicyVersionCommand({
+                    PolicyArn: policyArn,
+                    VersionId: policyResp.Policy.DefaultVersionId,
+                }),
+            );
+            const policyDoc = JSON.parse(decodeURIComponent(versionResp.PolicyVersion.Document));
+            const resources = policyDoc.Statement.flatMap(s => [].concat(s.Resource));
+            expect(resources).toEqual([`arn:aws:s3:::${bucketName}/*`]);
+        }
+    }, 60000);
+
+    it('two roles in the same account: two policies, one temp key', async () => {
+        const accountSource = await createTestAccount(vaultClient);
+        const accountDest = await createTestAccount(vaultClient);
+        accounts.push(accountSource, accountDest);
+
+        const secondRoleName = 'crr-role-test-2';
+
+        // Create a second bucket
+        const secondBucket = `${accountSource.bucketName}-second`;
+        await accountSource.s3Client.send(new CreateBucketCommand({ Bucket: secondBucket }));
+
+        // Enable versioning
+        await accountSource.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: accountSource.bucketName,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+        await accountSource.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: secondBucket,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+
+        // Create two roles in the same source account
+        const trustDoc = {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { Service: 'backbeat' },
+                Action: 'sts:AssumeRole',
+            }],
+        };
+        await accountSource.iamClient.send(new CreateRoleCommand({
+            RoleName: ROLE_NAME,
+            AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+        }));
+        await accountSource.iamClient.send(new CreateRoleCommand({
+            RoleName: secondRoleName,
+            AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+        }));
+
+        // Write input: two roles in the same account
+        const inputFilePath = path.join(tmpDir, 'missing.json');
+        fs.writeFileSync(inputFilePath, JSON.stringify({
+            results: [
+                {
+                    bucket: accountSource.bucketName,
+                    ownerDisplayName: accountSource.accountName,
+                    sourceRole: `arn:aws:iam::${accountSource.accountId}:role/${ROLE_NAME}`,
+                    policies: [],
+                },
+                {
+                    bucket: secondBucket,
+                    ownerDisplayName: accountSource.accountName,
+                    sourceRole: `arn:aws:iam::${accountSource.accountId}:role/${secondRoleName}`,
+                    policies: [],
+                },
+            ],
+        }));
+
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        expect(result.fixes).toHaveLength(2);
+        expect(result.metadata.counts.policiesCreated).toBe(2);
+        expect(result.metadata.counts.policiesAttached).toBe(2);
+        // Only one temp key for the single account
+        expect(result.metadata.counts.keysCreated).toBe(1);
+        expect(result.metadata.counts.keysDeleted).toBe(1);
+
+        // Verify both policies exist (named by bucket, not role)
+        const attached1 = await accountSource.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        expect((attached1.AttachedPolicies || [])
+            .find(p => p.PolicyName === `${POLICY_PREFIX}-${accountSource.bucketName}`)).toBeDefined();
+
+        const attached2 = await accountSource.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: secondRoleName }),
+        );
+        expect((attached2.AttachedPolicies || [])
+            .find(p => p.PolicyName === `${POLICY_PREFIX}-${secondBucket}`)).toBeDefined();
+    }, 60000);
+
+    it('two roles across different accounts: separate policies and keys', async () => {
+        const accountSource1 = await createTestAccount(vaultClient);
+        const accountSource2 = await createTestAccount(vaultClient);
+        const accountDest = await createTestAccount(vaultClient);
+        accounts.push(accountSource1, accountSource2, accountDest);
+
+        // Enable versioning
+        await accountSource1.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: accountSource1.bucketName,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+        await accountSource2.s3Client.send(new PutBucketVersioningCommand({
+            Bucket: accountSource2.bucketName,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }));
+
+        // Create roles in each source account
+        const trustDoc = {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { Service: 'backbeat' },
+                Action: 'sts:AssumeRole',
+            }],
+        };
+        await accountSource1.iamClient.send(new CreateRoleCommand({
+            RoleName: ROLE_NAME,
+            AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+        }));
+        await accountSource2.iamClient.send(new CreateRoleCommand({
+            RoleName: ROLE_NAME,
+            AssumeRolePolicyDocument: JSON.stringify(trustDoc),
+        }));
+
+        // Write input: same role name but in two different accounts
+        const inputFilePath = path.join(tmpDir, 'missing.json');
+        fs.writeFileSync(inputFilePath, JSON.stringify({
+            results: [
+                {
+                    bucket: accountSource1.bucketName,
+                    ownerDisplayName: accountSource1.accountName,
+                    sourceRole: `arn:aws:iam::${accountSource1.accountId}:role/${ROLE_NAME}`,
+                    policies: [],
+                },
+                {
+                    bucket: accountSource2.bucketName,
+                    ownerDisplayName: accountSource2.accountName,
+                    sourceRole: `arn:aws:iam::${accountSource2.accountId}:role/${ROLE_NAME}`,
+                    policies: [],
+                },
+            ],
+        }));
+
+        const { stdout, exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const result = JSON.parse(stdout);
+        expect(result.fixes).toHaveLength(2);
+        expect(result.fixes.every(f => f.status === 'success')).toBe(true);
+        expect(result.metadata.counts.policiesCreated).toBe(2);
+        // Two different accounts → two temp keys
+        expect(result.metadata.counts.keysCreated).toBe(2);
+        expect(result.metadata.counts.keysDeleted).toBe(2);
+
+        // Verify each account has its own policy attached (named by bucket)
+        const attached1 = await accountSource1.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        expect((attached1.AttachedPolicies || [])
+            .find(p => p.PolicyName === `${POLICY_PREFIX}-${accountSource1.bucketName}`)).toBeDefined();
+
+        const attached2 = await accountSource2.iamClient.send(
+            new ListAttachedRolePoliciesCommand({ RoleName: ROLE_NAME }),
+        );
+        expect((attached2.AttachedPolicies || [])
+            .find(p => p.PolicyName === `${POLICY_PREFIX}-${accountSource2.bucketName}`)).toBeDefined();
+    }, 60000);
+
+    it('empty results array exits with code 0', async () => {
+        const inputFilePath = path.join(tmpDir, 'empty.json');
+        fs.writeFileSync(inputFilePath, JSON.stringify({ results: [] }));
+
+        const { exitCode } = await runFixScript([
+            inputFilePath, iamHost, adminConfigPath, outputFilePath,
+            '--iam-port', String(iamPort),
+        ]);
+
+        expect(exitCode).toBe(0);
+    }, 30000);
+});

--- a/tests/utils/S3Setup.js
+++ b/tests/utils/S3Setup.js
@@ -1,4 +1,4 @@
-const { S3Client, CreateBucketCommand, ListObjectVersionsCommand, DeleteObjectsCommand, DeleteBucketCommand, PutBucketVersioningCommand, PutBucketReplicationCommand, DeleteBucketReplicationCommand, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const { S3Client, CreateBucketCommand, ListBucketsCommand, ListObjectVersionsCommand, DeleteObjectsCommand, DeleteBucketCommand, PutBucketVersioningCommand, PutBucketReplicationCommand, DeleteBucketReplicationCommand, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const { IAMClient, CreateUserCommand, CreatePolicyCommand, CreateRoleCommand, AttachRolePolicyCommand, DetachRolePolicyCommand, DeleteRoleCommand, DeletePolicyCommand, DeleteUserCommand, ListRolesCommand, ListAttachedRolePoliciesCommand, ListUsersCommand, ListAttachedUserPoliciesCommand, DetachUserPolicyCommand } = require('@aws-sdk/client-iam');
 const { promisify } = require('util');
 const { Logger } = require('werelogs');
@@ -73,40 +73,38 @@ async function createTestAccount(vaultClient) {
 
 
 async function deleteTestAccount(vaultClient, account) {
-    // Delete bucket
-    log.info('Deleting bucket', { bucket: account.bucketName });
-    // empty bucket - need to delete all versions and delete markers for versioned buckets
-    const listedObjects = await account.s3Client.send(new ListObjectVersionsCommand({ Bucket: account.bucketName }));
+    // Delete all buckets in the account
+    const bucketsResp = await account.s3Client.send(new ListBucketsCommand({}));
+    for (const bucket of (bucketsResp.Buckets || [])) {
+        log.info('Deleting bucket', { bucket: bucket.Name });
+        // empty bucket - need to delete all versions and delete markers for versioned buckets
+        // Note: no pagination — silently misses objects beyond 1000. Fine for test cleanup.
+        const listedObjects = await account.s3Client.send(new ListObjectVersionsCommand({ Bucket: bucket.Name }));
 
-    const objectsToDelete = [];
+        const objectsToDelete = [];
 
-    // Add all object versions
-    if (listedObjects.Versions && listedObjects.Versions.length > 0) {
-        listedObjects.Versions.forEach(({ Key, VersionId }) => {
-            log.info('Scheduling object version for deletion', { key: Key, versionId: VersionId });
-            objectsToDelete.push({ Key, VersionId });
-        });
+        if (listedObjects.Versions && listedObjects.Versions.length > 0) {
+            listedObjects.Versions.forEach(({ Key, VersionId }) => {
+                objectsToDelete.push({ Key, VersionId });
+            });
+        }
+
+        if (listedObjects.DeleteMarkers && listedObjects.DeleteMarkers.length > 0) {
+            listedObjects.DeleteMarkers.forEach(({ Key, VersionId }) => {
+                objectsToDelete.push({ Key, VersionId });
+            });
+        }
+
+        if (objectsToDelete.length > 0) {
+            await account.s3Client.send(new DeleteObjectsCommand({
+                Bucket: bucket.Name,
+                Delete: { Objects: objectsToDelete },
+            }));
+        }
+
+        await account.s3Client.send(new DeleteBucketCommand({ Bucket: bucket.Name }));
+        log.info('Deleted bucket', { bucket: bucket.Name });
     }
-
-    // Add all delete markers
-    if (listedObjects.DeleteMarkers && listedObjects.DeleteMarkers.length > 0) {
-        listedObjects.DeleteMarkers.forEach(({ Key, VersionId }) => {
-            log.info('Scheduling delete marker for deletion', { key: Key, versionId: VersionId });
-            objectsToDelete.push({ Key, VersionId });
-        });
-    }
-
-    // Delete all versions and markers
-    if (objectsToDelete.length > 0) {
-        const deleteParams = {
-            Bucket: account.bucketName,
-            Delete: { Objects: objectsToDelete }
-        };
-        await account.s3Client.send(new DeleteObjectsCommand(deleteParams));
-    }
-
-    await account.s3Client.send(new DeleteBucketCommand({ Bucket: account.bucketName }));
-    log.info('Deleted bucket', { bucket: account.bucketName });
 
     // List and delete all IAM users
     try {
@@ -174,6 +172,15 @@ async function deleteTestAccount(vaultClient, account) {
                                 })
                             );
                             log.info('Detached policy from role', { RoleName: role.RoleName, PolicyArn: policy.PolicyArn });
+                            try {
+                                await account.iamClient.send(
+                                    new DeletePolicyCommand({ PolicyArn: policy.PolicyArn })
+                                );
+                                log.info('Deleted policy', { PolicyArn: policy.PolicyArn });
+                            } catch (delPolErr) {
+                                // Policy may still be attached to another role
+                                log.info('Could not delete policy', { PolicyArn: policy.PolicyArn, error: delPolErr && delPolErr.message });
+                            }
                         }
                     }
                     await account.iamClient.send(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3554,6 +3554,22 @@ aws-sdk@^2.1691.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
+aws-sdk@^2.1692.0:
+  version "2.1693.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1693.0.tgz#fda38671af3dc5fa8117e9aa09cf6ce37e34010e"
+  integrity sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.6.2"
+
 b4a@^1.6.4:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.7.3.tgz#24cf7ccda28f5465b66aec2bac69e32809bf112f"


### PR DESCRIPTION
Add `fix-missing-replication-permissions.js` that reads the output of `check-replication-permissions.js` and automatically creates per-bucket IAM policies with `s3:ReplicateObject` for roles that are missing it. 

The script is 
- idempotent
- supports --dry-run,
- cleans up temporary credentials after use.