### PR TITLE
S3UTILS-227: replace util.parseArgs with manual argv parsing

### DIFF
--- a/replicationAudit/fix-missing-replication-permissions.js
+++ b/replicationAudit/fix-missing-replication-permissions.js
@@ -60,6 +60,9 @@ function getConfig() {
 
     for (let i = 0; i < args.length; i++) {
         if (args[i] === '--iam-port') {
+            if (i + 1 >= args.length) {
+                throw new Error('Missing value for --iam-port');
+            }
             iamPort = parseInt(args[++i], 10);
         } else if (args[i] === '--https') {
             useHttps = true;

--- a/replicationAudit/fix-missing-replication-permissions.js
+++ b/replicationAudit/fix-missing-replication-permissions.js
@@ -30,7 +30,6 @@
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
-const { parseArgs } = require('util');
 const { Client: VaultClient } = require('vaultclient');
 const AWS = require('aws-sdk');
 
@@ -49,17 +48,27 @@ function log(message) {
 }
 
 // ===========================================================================
-// Argument parsing (Node.js 22+ built-in util.parseArgs)
+// Argument parsing (manual process.argv for Node 16+ compatibility)
 // ===========================================================================
 function getConfig() {
-    const { values, positionals } = parseArgs({
-        allowPositionals: true,
-        options: {
-            'iam-port': { type: 'string', default: '8600' },
-            'https': { type: 'boolean', default: false },
-            'dry-run': { type: 'boolean', default: false },
-        },
-    });
+    const args = process.argv.slice(2);
+
+    const positionals = [];
+    let iamPort = 8600;
+    let useHttps = false;
+    let dryRun = false;
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--iam-port') {
+            iamPort = parseInt(args[++i], 10);
+        } else if (args[i] === '--https') {
+            useHttps = true;
+        } else if (args[i] === '--dry-run') {
+            dryRun = true;
+        } else {
+            positionals.push(args[i]);
+        }
+    }
 
     if (positionals.length < 3) {
         log('Usage: node fix-missing-replication-permissions.js'
@@ -72,11 +81,11 @@ function getConfig() {
     return {
         inputFile,
         vaultHost,
-        iamPort: parseInt(values['iam-port'], 10),
+        iamPort,
         adminConfig,
-        useHttps: values.https,
+        useHttps,
         outputFile: outputFile || 'replication-fix-results.json',
-        dryRun: values['dry-run'],
+        dryRun,
     };
 }
 


### PR DESCRIPTION
**Design note:**
`fix-missing-replication-permissions.js` is a standalone script meant to be copied into the vault container of older S3C versions. It does not run inside the s3utils container. It has to be compatible with the Node and npm packages available in the target vault container.

This "copy a self-contained script into an older container" approach is not easy to implement, test, or maintain, and is not a good practice in general.

We accepted this trade-off after discussing with Product and CS to allow fast integration on customer environments.
 
This tool should not be needed once we update replication permissions for all clients using CRR.

**Problem:**
`fix-missing-replication-permissions.js` uses `util.parseArgs` which requires Node 16.17+. The vault container ships Node 16.13.2 on all S3C versions up to 9.5.0.x, causing "parseArgs is not a function" at runtime.

**Fix:**
Replace `util.parseArgs` with manual `process.argv` parsing. No other dependency changes. There is no risk with other dependencies: vaultclient, aws-sdk v2, and process.argv all work on Node 16.13.2+.

**Testing:**
Existing functional tests in `fixMissingReplicationPermissions.js` run the script as a child process through its CLI interface (positionals, --iam-port, --https, --dry-run). Since the CLI contract is unchanged, passing tests confirm the new parsing logic is equivalent.