### PR TITLE
S3UTILS-236: fix summary line for errors cherry pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.17.7",
+  "version": "1.17.9",
   "engines": {
     "node": ">= 22"
   },

--- a/tests/unit/verifyBucketSproxydKeys.js
+++ b/tests/unit/verifyBucketSproxydKeys.js
@@ -168,3 +168,76 @@ describe('verifyBucketSproxydKeys', () => {
         });
     });
 });
+
+// Regression test for the bug where `logProgress` read `status.objectErrors`
+// (typo — missing the 's') instead of `status.objectsErrors`. Because
+// JSON.stringify drops undefined values, the `errors` field was silently
+// missing from the summary log line even when non-404 sproxyd errors had
+// been counted. A customer scan with ~27,000 HTTP 422s looked clean as a
+// result. The test below sets the counter, calls logProgress, and checks
+// the emitted summary contains the expected `errors` value.
+
+// The script reads these env vars at startup and exits if any are missing,
+// so we set them before the require. The hosts are fake — no real requests
+// are made because main() doesn't run when the file is required from a test.
+process.env.SPROXYD_HOSTPORT = process.env.SPROXYD_HOSTPORT || 'fake-sproxyd:9999';
+process.env.BUCKETD_HOSTPORT = process.env.BUCKETD_HOSTPORT || 'fake-bucketd:9998';
+process.env.BUCKETS = process.env.BUCKETS || 'test-bucket';
+
+// The script registers a periodic-progress timer at startup. If we leave it
+// alone the timer keeps the Jest worker alive after the tests finish and
+// Jest crashes with "child process exceptions". Swap setInterval for a
+// no-op while we require the file, then put it back so Jest's own internal
+// timers continue to work.
+const origSetInterval = global.setInterval;
+global.setInterval = () => undefined;
+const vbsk = require('../../verifyBucketSproxydKeys');
+global.setInterval = origSetInterval;
+
+describe('verifyBucketSproxydKeys — summary line emits errors count (S3UTILS-236)', () => {
+    let logSpy;
+
+    beforeEach(() => {
+        // Reset the counters so each test starts from zero.
+        Object.keys(vbsk.status).forEach(k => {
+            if (typeof vbsk.status[k] === 'number') {
+                vbsk.status[k] = 0;
+            }
+        });
+        // Spy on the logger so we can inspect what logProgress emits.
+        logSpy = jest.spyOn(vbsk.log, 'info').mockImplementation();
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+    });
+
+    test('emits errors count from status.objectsErrors when non-404 sproxyd errors have been counted', () => {
+        // Use the customer's actual numbers from the bug report: 59,011
+        // objects scanned, 27,152 sproxyd errors.
+        vbsk.status.objectsScanned = 59011;
+        vbsk.status.objectsErrors = 27152;
+
+        vbsk.logProgress('completed scan');
+
+        expect(logSpy).toHaveBeenCalledWith('completed scan', expect.objectContaining({
+            scanned: 59011,
+            errors: 27152,
+        }));
+    });
+
+    test('emits errors: 0 (key present, not undefined) when no errors have been counted', () => {
+        // A clean scan should still emit `errors: 0` in the summary. If the
+        // read were misspelled, the value would be undefined and the key
+        // would vanish from the output entirely — so we assert both the
+        // value and the presence of the key.
+        vbsk.status.objectsScanned = 100;
+        vbsk.status.objectsErrors = 0;
+
+        vbsk.logProgress('completed scan');
+
+        const emitted = logSpy.mock.calls[0][1];
+        expect(emitted.errors).toBe(0);
+        expect('errors' in emitted).toBe(true);
+    });
+});

--- a/tests/unit/verifyBucketSproxydKeys.js
+++ b/tests/unit/verifyBucketSproxydKeys.js
@@ -212,7 +212,7 @@ describe('verifyBucketSproxydKeys — summary line emits errors count (S3UTILS-2
         logSpy.mockRestore();
     });
 
-    test('emits errors count from status.objectsErrors when non-404 sproxyd errors have been counted', () => {
+    test('should emit errors count from status.objectsErrors when non-404 sproxyd errors have been counted', () => {
         // Use the customer's actual numbers from the bug report: 59,011
         // objects scanned, 27,152 sproxyd errors.
         vbsk.status.objectsScanned = 59011;
@@ -226,18 +226,18 @@ describe('verifyBucketSproxydKeys — summary line emits errors count (S3UTILS-2
         }));
     });
 
-    test('emits errors: 0 (key present, not undefined) when no errors have been counted', () => {
+    test('should emit errors: 0 (key present, not undefined) when no errors have been counted', () => {
         // A clean scan should still emit `errors: 0` in the summary. If the
         // read were misspelled, the value would be undefined and the key
-        // would vanish from the output entirely — so we assert both the
-        // value and the presence of the key.
+        // would vanish from the output entirely — so we first assert the
+        // key is present, then assert the value is 0.
         vbsk.status.objectsScanned = 100;
         vbsk.status.objectsErrors = 0;
 
         vbsk.logProgress('completed scan');
 
         const emitted = logSpy.mock.calls[0][1];
-        expect(emitted.errors).toBe(0);
         expect('errors' in emitted).toBe(true);
+        expect(emitted.errors).toBe(0);
     });
 });

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -196,7 +196,7 @@ function logProgress(message) {
         haveEmptyMetadata: status.objectsWithEmptyMetadata,
         haveDupVersionIds: status.objectsWithDupVersionIds,
         haveBrokenMetadata: status.objectsWithBrokenMetadata,
-        errors: status.objectErrors,
+        errors: status.objectsErrors,
         url: getObjectURL(status.bucketInProgress, status.KeyMarker),
     });
 }
@@ -662,7 +662,12 @@ function main() {
     });
 }
 
-main();
+// Run the scan when this file is launched as a CLI. Skip it when a test
+// requires the file as a module — the test will drive logProgress directly
+// using the exports at the bottom of the file.
+if (require.main === module) {
+    main();
+}
 
 function stop() {
     if (digestsStream) {
@@ -678,4 +683,9 @@ process.on('SIGHUP', stop);
 process.on('SIGQUIT', stop);
 process.on('SIGTERM', stop);
 
-module.exports = { httpRequest };
+module.exports = {
+    httpRequest,
+    status,
+    log,
+    logProgress,
+};

--- a/verifyBucketSproxydKeys.js
+++ b/verifyBucketSproxydKeys.js
@@ -662,11 +662,17 @@ function main() {
     });
 }
 
-// Run the scan when this file is launched as a CLI. Skip it when a test
-// requires the file as a module — the test will drive logProgress directly
-// using the exports at the bottom of the file.
+// Run the scan and wire up signal handlers only when this file is launched
+// as a CLI. Skip both when a test requires the file as a module — otherwise
+// the SIGINT / SIGTERM handlers would register against the Jest worker
+// process and `stop()` could silently exit it on signal (which would mask
+// CI timeouts as passing runs).
 if (require.main === module) {
     main();
+    process.on('SIGINT', stop);
+    process.on('SIGHUP', stop);
+    process.on('SIGQUIT', stop);
+    process.on('SIGTERM', stop);
 }
 
 function stop() {
@@ -677,11 +683,6 @@ function stop() {
     logProgress('last status');
     process.exit(0);
 }
-
-process.on('SIGINT', stop);
-process.on('SIGHUP', stop);
-process.on('SIGQUIT', stop);
-process.on('SIGTERM', stop);
 
 module.exports = {
     httpRequest,


### PR DESCRIPTION
I [opened a PR](https://github.com/scality/s3utils/pull/388) targeting the wrong branch, as I didn't check of development/1.17 existed. 
Cherry picking commits. Packge.json bump is by 2 intentionally, as when I merged original PR I released 1.17.8 from dev/1 which is clearly wrong.