### PR TITLE
S3UTILS-235: Include logrotate in s3utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /usr/src/app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         jq \
+        logrotate \
         python3 \
         python3-pip \
         python3-venv \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "engines": {
     "node": ">= 22"
   },
@@ -56,9 +56,9 @@
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "^3.962.0",
-    "aws-sdk": "^2.1692.0",
     "@scality/eslint-config-scality": "scality/Guidelines#8.3.0",
     "@sinonjs/fake-timers": "^14.0.0",
+    "aws-sdk": "^2.1692.0",
     "eslint": "^9.14.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.11.0",


### PR DESCRIPTION
As object-repair will run through raft-dispatcher,
Log rotation will be handled by logrotate instead of supervisord