### PR TITLE
S3UTILS-237 [bf] object repair: increase socket timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.17.9",
+  "version": "1.17.10",
   "engines": {
     "node": ">= 22"
   },

--- a/repairDuplicateVersionsSuite.js
+++ b/repairDuplicateVersionsSuite.js
@@ -17,6 +17,7 @@ const {
     OBJECT_REPAIR_TLS_KEY_PATH,
     OBJECT_REPAIR_TLS_CERT_PATH,
     OBJECT_REPAIR_TLS_CA_PATH,
+    OBJECT_REPAIR_SOCKET_TIMEOUT_SECONDS,
 } = process.env;
 
 const useHttps = (OBJECT_REPAIR_TLS_KEY_PATH !== undefined
@@ -38,9 +39,11 @@ const bucketdAgent = useHttps
             ? [fs.readFileSync(OBJECT_REPAIR_TLS_CA_PATH)]
             : undefined,
         keepAlive: true,
+        timeout: (Number(OBJECT_REPAIR_SOCKET_TIMEOUT_SECONDS) || 300) * 1000,
     })
     : new httpArsn.Agent({
         keepAlive: true,
+        timeout: (Number(OBJECT_REPAIR_SOCKET_TIMEOUT_SECONDS) || 300) * 1000,
     });
 
 let sproxydAlias;


### PR DESCRIPTION
Increase the default idle socket timeout from 10 seconds to 300 seconds, to avoid issues in particular when fetching a range of oplog from a large backup, causing the socket to not send any data for more than 10 seconds.

Make the socket timeout configurable as well in case we need to change it on some platforms, via `OBJECT_REPAIR_SOCKET_TIMEOUT_SECONDS` environment variable.
