### PR TITLE
Bugfix/s3 utils 239 fix count items bucket logging

### DIFF
--- a/CountItems/CountWorker.js
+++ b/CountItems/CountWorker.js
@@ -5,6 +5,7 @@ const monitoring = require('../utils/monitoring');
 const { deserializeBigInts, serializeBigInts } = require('./utils/utils');
 
 const PENSIEVE = 'PENSIEVE';
+
 class CountWorker {
     constructor(params) {
         this.log = params.log;
@@ -66,12 +67,16 @@ class CountWorker {
         if (!this.client.client) {
             return callback(new Error('NotConnected'));
         }
-        // 'fromObj' expects that the website configuration is an instance of
-        // WebsiteConfiguration as it is not used in CountItems, we nullify it.
-        if (bucketInfoObj._websiteConfiguration) {
-            Object.assign(bucketInfoObj, { _websiteConfiguration: null });
+        const bucketInfoData = bucketInfoObj.bucketInfo || bucketInfoObj;
+        // 'fromObj' expects class-backed fields to already be instances.
+        // They are not used in CountItems, so we nullify unsupported serialized fields.
+        if (bucketInfoData._websiteConfiguration) {
+            bucketInfoData._websiteConfiguration = null;
         }
-        const bucketInfo = BucketInfo.fromObj(bucketInfoObj.bucketInfo || bucketInfoObj);
+        if (bucketInfoData._bucketLoggingStatus) {
+            bucketInfoData._bucketLoggingStatus = null;
+        }
+        const bucketInfo = BucketInfo.fromObj(bucketInfoData);
         const bucketName = bucketInfo.getName();
         this.log.info(`${process.pid} handling ${bucketName}`);
         return async.waterfall([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "engines": {
     "node": ">= 22"
   },

--- a/tests/unit/CountItems/CountWorker.js
+++ b/tests/unit/CountItems/CountWorker.js
@@ -223,6 +223,42 @@ describe('CountItems::CountWorker', () => {
         });
     });
 
+    test('should nullify unsupported serialized bucket info fields', done => {
+        const testSendFn = jest.fn();
+        const w = new CountWorker({
+            log: new DummyLogger(),
+            sendFn: testSendFn,
+            client: mongoMock,
+        });
+        const bucketInfo = {
+            _name: 'test-bucket',
+            _owner: 'any',
+            _ownerDisplayName: 'any',
+            _creationDate: Date.now().toString(),
+            _websiteConfiguration: {
+                _indexDocument: 'index.html',
+            },
+            _bucketLoggingStatus: {
+                _loggingEnabled: {
+                    TargetBucket: 'target-bucket',
+                    TargetPrefix: 'logs/',
+                },
+            },
+        };
+        w.getIsTransient = jest.fn((bucketInfo, cb) => cb(null, true));
+        mongoMock.setup.mockImplementationOnce(cb => cb());
+        mongoMock.close.mockImplementationOnce(cb => cb());
+        mongoMock.client.isConnected.mockImplementationOnce(() => false);
+        mongoMock.getObjectMDStats.mockImplementationOnce((_a, _b, _c, _d, cb) => cb(null, { value: 42 }));
+        w.countItems(bucketInfo, (err, results) => {
+            expect(err).toBeNull();
+            expect(results).toEqual({ value: 42 });
+            expect(bucketInfo._websiteConfiguration).toBeNull();
+            expect(bucketInfo._bucketLoggingStatus).toBeNull();
+            done();
+        });
+    });
+
     describe('CountWorker.getIsTransient method', () => {
         let worker;
         let mockBucketInfo;


### PR DESCRIPTION
In the PR we are nullifying _bucketLoggingStatus which is safe for count-items specifically: that this metadata is unrelated to object count / storage usage computation and  only exists on the BucketInfo object because it is part of the full bucket metadata model.
The implementation we now have is cleaner and makes this explicit by naming the fields as unsupported serialized BucketInfo fields for count-items. 
The rationale being that : class-backed fields that count-items does not consume should not be rehydrated in the worker path just to count object metadata.

Issue: S3UTILS-239