### PR TITLE
Adopt timestamp-ordered microVersionId in CRR resync tool

### DIFF
--- a/CRR/ReplicationStatusUpdater.js
+++ b/CRR/ReplicationStatusUpdater.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const {
     doWhilst, eachSeries, eachLimit, waterfall,
 } = require('async');
@@ -71,6 +72,14 @@ class ReplicationStatusUpdater {
         this.currentVersionOnly = currentVersionOnly;
         this.forceUsingConfiguration = forceUsingConfiguration;
         this.log = log;
+
+        // Random replicationGroupId (7 chars) and instanceId (6 chars) for
+        // microVersionId generation: this tool bypasses CloudServer's
+        // configured values, so per-instance random tokens prevent
+        // collisions with concurrent writers. Sizes match LENGTH_RG and
+        // LENGTH_ID in arsenal's VersionID module.
+        this.replicationGroupId = crypto.randomBytes(4).toString('hex').slice(0, 7);
+        this.instanceId = crypto.randomBytes(3).toString('hex').slice(0, 6);
 
         this._setupClients();
 
@@ -193,7 +202,7 @@ class ReplicationStatusUpdater {
                     return process.nextTick(next);
                 }
 
-                objMD.updateMicroVersionId();
+                objMD.updateMicroVersionId(this.instanceId, this.replicationGroupId);
                 const md = objMD.getSerialized();
                 return this.cloudserverclient.putMetadata({
                     Bucket: bucket,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "engines": {
     "node": ">= 22"
   },


### PR DESCRIPTION
Bump arsenal to pick up the new microVersionId format (ts + seq + repGroupId), required by cascaded CRR for loop detection and stale event handling. The resync tool bypasses CloudServer's S3 API, so it generates a random per-instance repGroupId and passes it to updateMicroVersionId() to avoid colliding with concurrent writers.

Issue: S3UTILS-234

Related PRs :
Arsenal : https://github.com/scality/Arsenal/pull/2628
Cloudserver : https://github.com/scality/cloudserver/pull/6179
CloudserverClient : https://github.com/scality/cloudserverclient/pull/24
Backbeat : https://github.com/scality/backbeat/pull/2747