### PR TITLE
S3UTILS-242: add repairedInfo metadata field on object repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,24 @@ and ignores other entries.
 cat /tmp/verifyBucketSproxydKeys.log | docker run -i zenko/s3utils:latest bash -c 'OBJECT_REPAIR_BUCKETD_HOSTPORT=127.0.0.1:9000 OBJECT_REPAIR_SPROXYD_HOSTPORT=127.0.0.1:8181 node repairDuplicateVersions.js' > /tmp/repairDuplicateVersions.log
 ```
 
+## Effect on object metadata
+
+In addition to updating the `location` field, the repair tool adds a
+`repairedInfo` field to the metadata of every repaired object version:
+
+```json
+"repairedInfo": {
+  "lastRepairedAt": "2026-06-17T10:30:00.000Z",
+  "reason": "duplicate-sproxyd-keys"
+}
+```
+
+This field serves as a forensic marker. `lastRepairedAt` is an ISO
+8601 timestamp of when the repair was performed; `reason` identifies
+the type of inconsistency that triggered the repair. If an object is
+repaired more than once, the field is overwritten with the information
+from the most recent repair.
+
 ## Caveat
 
 While the script is running, there is a possibility, although slim,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3utils",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "engines": {
     "node": ">= 22"
   },

--- a/repairDuplicateVersionsSuite.js
+++ b/repairDuplicateVersionsSuite.js
@@ -376,6 +376,12 @@ function repairObject(objInfo, cb) {
                     loc.key = copiedKeys[loc.key];
                 }
             });
+            // Add some info in the metadata to help forensics, if only to
+            // mark that the metadata has been repaired.
+            objMD.repairedInfo = {
+                lastRepairedAt: new Date().toISOString(),
+                reason: 'duplicate-sproxyd-keys',
+            };
             return putObjectMetadata(objInfo.objectUrl, objMD, err => {
                 if (err) {
                     log.error('error putting object metadata', {


### PR DESCRIPTION
## Summary

- When `repairObject` repairs a version with duplicate sproxyd keys, it now stamps a `repairedInfo` field on the metadata containing an ISO 8601 timestamp (`lastRepairedAt`) and the repair `reason` (`"duplicate-sproxyd-keys"`)
- This serves as a forensic marker to identify and correlate objects that were touched by the repair tool
- Documents the new field in the README under the "Repair duplicate sproxyd keys" section

## Test plan

- [ ] Verify existing unit tests for `repairObject` / `putObjectMetadata` still pass (`yarn test:unit`)
- [ ] Confirm the `repairedInfo` field is present in metadata after a repair by inspecting the object via the bucketd API
- [ ] Confirm a second repair overwrites (not appends) the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)