### PR TITLE
Fix count items stuck on empty bucket list

### DIFF
--- a/CountItems/CountManager.js
+++ b/CountItems/CountManager.js
@@ -214,6 +214,10 @@ class CountManager {
             }
         });
         this.q.resume();
+        if (this.q.idle()) {
+            this.log.info('no buckets to process, skipping count');
+            process.nextTick(onceCB);
+        }
     }
 }
 

--- a/tests/unit/CountItems/CountManager.js
+++ b/tests/unit/CountItems/CountManager.js
@@ -983,8 +983,8 @@ describe('CountItems::CountManager', () => {
         });
         const bucketList = {
             bucketCount: 10,
-            bucketInfos: Array(10)
-                .map(() => BucketInfo.deSerialize(testBucketMD)),
+            bucketInfos: Array(10).fill()
+                .map(() => BucketInfo.deSerialize(stringifiedBucketMD)),
         };
         m.addWork(bucketList);
         const testCB = jest.fn();

--- a/utils/S3UtilsMongoClient.js
+++ b/utils/S3UtilsMongoClient.js
@@ -280,7 +280,7 @@ class S3UtilsMongoClient extends MongoClientInterface {
                     targetCount = 'versionCount';
                     targetData = 'versionData';
 
-                    if (entry.value.replicationInfo.backends.length > 0
+                    if (entry.value.replicationInfo?.backends?.length > 0
                         && this._isReplicationEntryStalled(entry, cmpDate)) {
                         stalledCount++;
                     }
@@ -511,7 +511,7 @@ class S3UtilsMongoClient extends MongoClientInterface {
         };
 
         // only count it in current dataStore if object is not in transient or replication not completed
-        if (!isTransient || entry.value.replicationInfo.status !== 'COMPLETED') {
+        if (!isTransient || entry.value.replicationInfo?.status !== 'COMPLETED') {
             results.location[entry.value.dataStoreName] = size;
             // We do not support restores to custom location yet. If we do,
             // the destination would be present in the object metadata. For now,
@@ -523,7 +523,7 @@ class S3UtilsMongoClient extends MongoClientInterface {
                 results.location[bucketInfo.getLocationConstraint()] = size;
             }
         }
-        entry.value.replicationInfo.backends.forEach(rep => {
+        entry.value.replicationInfo?.backends?.forEach(rep => {
             // count it in the replication destination location if replication compeleted
             if (rep.status === 'COMPLETED') {
                 results.location[rep.site] = size;


### PR DESCRIPTION
ISSUE: S3UTILS-243

Fix 1 bug and 1 risk :

- Count item never finishes when the artesca has 0 buckets 
- While doing local tests, I found the scripts was crashing on non existent replicationInfo metadata : added defensive code