### PR TITLE
Bump werelogs to 8.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node-schedule": "^2.1.1",
     "uuid": "^11.0.3",
     "vaultclient": "scality/vaultclient#8.5.1",
-    "werelogs": "scality/werelogs#8.2.1",
+    "werelogs": "scality/werelogs#semver:^8.2.4",
     "xml2js": "^0.6.2",
     "zenkoclient": "scality/zenkoclient#1.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8481,9 +8481,9 @@ werelogs@scality/werelogs#8.2.0:
     fast-safe-stringify "^2.1.1"
     safe-json-stringify "^1.2.0"
 
-werelogs@scality/werelogs#8.2.1:
-  version "8.2.1"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/1d58d2b1fc0c9d1360db8b2a310e8dfdd29ff7ad"
+"werelogs@scality/werelogs#semver:^8.2.4":
+  version "8.2.4"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/a7bbb5917a08b035d3763b24b070d517483d6982"
   dependencies:
     fast-safe-stringify "^2.1.1"
     safe-json-stringify "^1.2.0"


### PR DESCRIPTION
Bump werelogs to 8.2.4 to make error logging work everywhere in s3utils.

Issue: S3UTILS-244